### PR TITLE
Instant update narrow line color

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -200,12 +200,12 @@ export const app = (window.app = createApp({
         preview.sceneManager.boundingBoxColor = drawBoundingBox.value
           ? (settings.value.boundingBoxColor ?? 'magenta')
           : undefined;
+        preview.sceneManager.travelColor = settings.value.travelColor;
       });
 
       watchEffect(() => {
         if (!preview) return;
         preview.sceneManager.renderTravel = settings.value.renderTravel;
-        preview.sceneManager.travelColor = settings.value.travelColor;
         preview.sceneManager.lineWidth = +settings.value.lineWidth;
 
         preview.sceneManager.renderExtrusion = settings.value.renderExtrusion;

--- a/src/extensions/object3d.ts
+++ b/src/extensions/object3d.ts
@@ -3,20 +3,19 @@ import { Object3D } from "three";
 declare module 'three' {
   interface Object3D {
     // eslint-disable-next-line no-unused-vars
-    getObjectByUserDataProperty(name: string, value: unknown): Array<Object3D>;
+    getByUserData(name: string, value: unknown): Array<Object3D>;
   }
 }
 
-Object3D.prototype.getObjectByUserDataProperty = function (this: Object3D, name: string, value: unknown) {
-  const result: Array<Object3D> = [];
+// from https://discourse.threejs.org/t/getobject-by-any-custom-property-present-in-userdata-of-object/3378/3
+Object3D.prototype.getByUserData = function (this: Object3D, name: string, value: unknown) {
+  const meshes: Array<Object3D> = [];
 
-  if (this.userData[name] === value)
-    result.push(this);
+  this.traverse((node) => {
+    if (node.userData[name] === value) {
+      meshes.push(node);
+    }
+  });
 
-  for (const child of this.children) {
-    const objects = child.getObjectByUserDataProperty(name, value);
-    result.push(...objects);
-  }
-
-  return result;
+  return meshes;
 }

--- a/src/extensions/object3d.ts
+++ b/src/extensions/object3d.ts
@@ -1,0 +1,22 @@
+import { Object3D } from "three";
+
+declare module 'three' {
+  interface Object3D {
+    // eslint-disable-next-line no-unused-vars
+    getObjectByUserDataProperty(name: string, value: unknown): Array<Object3D>;
+  }
+}
+
+Object3D.prototype.getObjectByUserDataProperty = function (this: Object3D, name: string, value: unknown) {
+  const result: Array<Object3D> = [];
+
+  if (this.userData[name] === value)
+    result.push(this);
+
+  for (const child of this.children) {
+    const objects = child.getObjectByUserDataProperty(name, value);
+    result.push(...objects);
+  }
+
+  return result;
+}

--- a/src/extensions/object3d.ts
+++ b/src/extensions/object3d.ts
@@ -1,4 +1,4 @@
-import { Object3D } from "three";
+import { Object3D } from 'three';
 
 declare module 'three' {
   interface Object3D {
@@ -18,4 +18,4 @@ Object3D.prototype.getByUserData = function (this: Object3D, name: string, value
   });
 
   return meshes;
-}
+};

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -5,6 +5,7 @@ import { Job } from './job';
 import { DevGUI, type DevModeOptions } from './dev-gui';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { makeDroppable } from './extra/dom-utils';
+import "./extensions/object3d"; // import extensions 
 
 /**
  * Options for configuring the G-code preview

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -5,7 +5,7 @@ import { Job } from './job';
 import { DevGUI, type DevModeOptions } from './dev-gui';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { makeDroppable } from './extra/dom-utils';
-import "./extensions/object3d"; // import extensions 
+import './extensions/object3d'; // import extensions
 
 /**
  * Options for configuring the G-code preview

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -364,6 +364,10 @@ export class SceneManager {
    */
   set travelColor(value: number | string | Color) {
     this._travelColor = new Color(value);
+
+    if (this.travelLineMaterial) {
+      this.travelLineMaterial.color.set(this._travelColor);
+    }
   }
 
   /**
@@ -843,6 +847,7 @@ export class SceneManager {
     }
   }
 
+  private travelLineMaterial: LineMaterial;
   /**
    * Renders paths as 2D lines
    * @param paths - Array of paths to render
@@ -855,7 +860,7 @@ export class SceneManager {
     let clippingPlanes: Plane[] = [];
     clippingPlanes = this.createClippingPlanes(minZ, maxZ);
 
-    const material = new LineMaterial({
+    this.travelLineMaterial = new LineMaterial({
       color: Number(color.getHex()),
       linewidth: this.lineWidth,
       clippingPlanes
@@ -877,9 +882,9 @@ export class SceneManager {
     });
 
     const geometry = new LineSegmentsGeometry().setPositions(lineVertices);
-    const line = new LineSegments2(geometry, material);
+    const line = new LineSegments2(geometry, this.travelLineMaterial);
 
-    this.disposables.push(material);
+    this.disposables.push(this.travelLineMaterial);
     this.disposables.push(geometry);
     this.currentChunk?.add(line);
   }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -27,7 +27,8 @@ import {
   Vector3,
   WebGLRenderer,
   MathUtils,
-  LineBasicMaterial
+  LineBasicMaterial,
+  Object3D
 } from 'three';
 
 export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
@@ -331,6 +332,12 @@ export class SceneManager {
     }
 
     this.materials[0].uniforms.uColor.value = this._extrusionColor;
+
+    if (!this.renderTubes) {
+      for (const line of this._extrusionLines) {
+        line.material.color.set(this._extrusionColor);
+      }
+    }
   }
 
   /**
@@ -365,8 +372,8 @@ export class SceneManager {
   set travelColor(value: number | string | Color) {
     this._travelColor = new Color(value);
 
-    if (this.travelLineMaterial) {
-      this.travelLineMaterial.color.set(this._travelColor);
+    for (const line of this._travelLines) {
+      line.material.color.set(this._travelColor);
     }
   }
 
@@ -832,7 +839,10 @@ export class SceneManager {
    */
   private renderPaths(endPathNumber: number = Infinity): void {
     if (this.renderTravel) {
-      this.renderPathsAsLines(this.job.travels.slice(this.renderPathIndex, endPathNumber), this._travelColor);
+      const travelLine = this.renderPathsAsLines(this.job.travels.slice(this.renderPathIndex, endPathNumber), this._travelColor);
+      travelLine.userData = {
+        lineType: 'travel'
+      }
     }
 
     if (this.renderExtrusion) {
@@ -841,26 +851,28 @@ export class SceneManager {
         if (this.renderTubes) {
           this.renderPathsAsTubes(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
         } else {
-          this.renderPathsAsLines(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
+          const extrusionLine = this.renderPathsAsLines(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
+          extrusionLine.userData = {
+            lineType: 'extrusion'
+          }
         }
       });
     }
   }
 
-  private travelLineMaterial: LineMaterial;
   /**
    * Renders paths as 2D lines
    * @param paths - Array of paths to render
    * @param color - Color to use for the lines
    */
-  private renderPathsAsLines(paths: Path[], color: Color): void {
+  private renderPathsAsLines(paths: Path[], color: Color): Object3D {
     const minZ = this.job.layers[this._startLayer - 1]?.z;
     const maxZ = this.job.layers[this._endLayer - 1]?.z;
 
     let clippingPlanes: Plane[] = [];
     clippingPlanes = this.createClippingPlanes(minZ, maxZ);
 
-    this.travelLineMaterial = new LineMaterial({
+    const material = new LineMaterial({
       color: Number(color.getHex()),
       linewidth: this.lineWidth,
       clippingPlanes
@@ -882,11 +894,12 @@ export class SceneManager {
     });
 
     const geometry = new LineSegmentsGeometry().setPositions(lineVertices);
-    const line = new LineSegments2(geometry, this.travelLineMaterial);
+    const line = new LineSegments2(geometry, material);
 
-    this.disposables.push(this.travelLineMaterial);
+    this.disposables.push(material);
     this.disposables.push(geometry);
     this.currentChunk?.add(line);
+    return line;
   }
 
   /**
@@ -975,4 +988,37 @@ export class SceneManager {
     localStorage.removeItem('cameraZoom');
     localStorage.removeItem('cameraTarget');
   }
+
+  get _travelLines() {
+    const lines = this.scene.getObjectByUserDataProperty('lineType', 'travel');
+    return lines as unknown as [LineSegments2];
+  }
+
+  get _extrusionLines() {
+    const lines = this.scene.getObjectByUserDataProperty('lineType', 'extrusion');
+    return lines as unknown as [LineSegments2];
+  }
+}
+
+import * as THREE from "three";
+
+declare module 'three' {
+  interface Object3D {
+    // eslint-disable-next-line no-unused-vars
+    getObjectByUserDataProperty(name: string, value: unknown): Array<Object3D>;
+  }
+}
+
+THREE.Object3D.prototype.getObjectByUserDataProperty = function (this: Object3D, name: string, value: unknown) {
+  const result: Array<Object3D> = [];
+
+  if (this.userData[name] === value)
+    result.push(this);
+
+  for (const child of this.children) {
+    const objects = child.getObjectByUserDataProperty(name, value);
+    result.push(...objects);
+  }
+
+  return result;
 }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -1000,25 +1000,3 @@ export class SceneManager {
   }
 }
 
-import * as THREE from "three";
-
-declare module 'three' {
-  interface Object3D {
-    // eslint-disable-next-line no-unused-vars
-    getObjectByUserDataProperty(name: string, value: unknown): Array<Object3D>;
-  }
-}
-
-THREE.Object3D.prototype.getObjectByUserDataProperty = function (this: Object3D, name: string, value: unknown) {
-  const result: Array<Object3D> = [];
-
-  if (this.userData[name] === value)
-    result.push(this);
-
-  for (const child of this.children) {
-    const objects = child.getObjectByUserDataProperty(name, value);
-    result.push(...objects);
-  }
-
-  return result;
-}

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -615,6 +615,16 @@ export class SceneManager {
     });
   }
 
+  private get travelLines() {
+    const lines = this.scene.getByUserData('lineType', 'travel');
+    return lines as unknown as [LineSegments2];
+  }
+
+  private get extrusionLines() {
+    const lines = this.scene.getByUserData('lineType', 'extrusion');
+    return lines as unknown as [LineSegments2];
+  }
+
   /** @internal */
   /**
    * Animation loop that continuously renders the scene
@@ -839,10 +849,13 @@ export class SceneManager {
    */
   private renderPaths(endPathNumber: number = Infinity): void {
     if (this.renderTravel) {
-      const travelLine = this.renderPathsAsLines(this.job.travels.slice(this.renderPathIndex, endPathNumber), this._travelColor);
+      const travelLine = this.renderPathsAsLines(
+        this.job.travels.slice(this.renderPathIndex, endPathNumber),
+        this._travelColor
+      );
       travelLine.userData = {
         lineType: 'travel'
-      }
+      };
     }
 
     if (this.renderExtrusion) {
@@ -854,7 +867,7 @@ export class SceneManager {
           const extrusionLine = this.renderPathsAsLines(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
           extrusionLine.userData = {
             lineType: 'extrusion'
-          }
+          };
         }
       });
     }
@@ -987,15 +1000,5 @@ export class SceneManager {
     localStorage.removeItem('cameraRotation');
     localStorage.removeItem('cameraZoom');
     localStorage.removeItem('cameraTarget');
-  }
-
-  private get travelLines() {
-    const lines = this.scene.getByUserData('lineType', 'travel');
-    return lines as unknown as [LineSegments2];
-  }
-
-  private get extrusionLines() {
-    const lines = this.scene.getByUserData('lineType', 'extrusion');
-    return lines as unknown as [LineSegments2];
   }
 }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -334,7 +334,7 @@ export class SceneManager {
     this.materials[0].uniforms.uColor.value = this._extrusionColor;
 
     if (!this.renderTubes) {
-      for (const line of this._extrusionLines) {
+      for (const line of this.extrusionLines) {
         line.material.color.set(this._extrusionColor);
       }
     }
@@ -372,7 +372,7 @@ export class SceneManager {
   set travelColor(value: number | string | Color) {
     this._travelColor = new Color(value);
 
-    for (const line of this._travelLines) {
+    for (const line of this.travelLines) {
       line.material.color.set(this._travelColor);
     }
   }
@@ -989,14 +989,13 @@ export class SceneManager {
     localStorage.removeItem('cameraTarget');
   }
 
-  get _travelLines() {
-    const lines = this.scene.getObjectByUserDataProperty('lineType', 'travel');
+  private get travelLines() {
+    const lines = this.scene.getByUserData('lineType', 'travel');
     return lines as unknown as [LineSegments2];
   }
 
-  get _extrusionLines() {
-    const lines = this.scene.getObjectByUserDataProperty('lineType', 'extrusion');
+  private get extrusionLines() {
+    const lines = this.scene.getByUserData('lineType', 'extrusion');
     return lines as unknown as [LineSegments2];
   }
 }
-


### PR DESCRIPTION
Color of narrow extrusion/travel lines is updated instantly. 

The way I access the travel lines and extrusion lines in the scene:
- .userData a reserved object on 3d objects (meshes, groups) with a custom prop for 'lineType'.
- a function to 'query' the scene by traversing the scene graph and filtering on that lineType

