### PR TITLE
fix: update test mocks for vitest v4 constructor compatibility

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -65,20 +65,26 @@ describe('GCodePreview', () => {
     };
 
     // Setup mocks
-    vi.mocked(Job).mockImplementation(() => mockJob);
-    vi.mocked(Interpreter).mockImplementation(() => mockInterpreter);
-    vi.mocked(SceneManager).mockImplementation(() => mockSceneManager);
-    vi.mocked(Parser).mockImplementation(() => ({
-      parseGCode: vi.fn().mockReturnValue({
-        commands: ['G0 X0 Y0', 'G1 X10 Y10']
-      }),
-      metadata: { thumbnails: {} }
-    }));
-    vi.mocked(DevGUI).mockImplementation(() => mockDevGui);
-    vi.mocked(Stats).mockImplementation(() => ({
-      update: vi.fn(),
-      dom: document.createElement('div')
-    }));
+    // vitest v4 requires function keyword (not arrow functions) in mockImplementation
+    // for mocked constructors — arrow functions cannot be called with `new`.
+    vi.mocked(Job).mockImplementation(function () { return mockJob; } as never);
+    vi.mocked(Interpreter).mockImplementation(function () { return mockInterpreter; } as never);
+    vi.mocked(SceneManager).mockImplementation(function () { return mockSceneManager; } as never);
+    vi.mocked(Parser).mockImplementation(function () {
+      return {
+        parseGCode: vi.fn().mockReturnValue({
+          commands: ['G0 X0 Y0', 'G1 X10 Y10']
+        }),
+        metadata: { thumbnails: {} }
+      };
+    } as never);
+    vi.mocked(DevGUI).mockImplementation(function () { return mockDevGui; } as never);
+    vi.mocked(Stats).mockImplementation(function () {
+      return {
+        update: vi.fn(),
+        dom: document.createElement('div')
+      };
+    } as never);
   });
 
   afterEach(() => {
@@ -283,7 +289,7 @@ describe('GCodePreview', () => {
 
       // Create new mock for second DevGUI instance
       const newMockDevGui = { reset: vi.fn(), destroy: vi.fn() };
-      vi.mocked(DevGUI).mockImplementationOnce(() => newMockDevGui);
+      vi.mocked(DevGUI).mockImplementationOnce(function () { return newMockDevGui; } as never);
 
       preview.devMode = false;
 


### PR DESCRIPTION
## Summary

Fixes the 34 pre-existing test failures introduced by the vitest 3→4 bump in #329.

**Root cause:** vitest v4 enforces that `mockImplementation` callbacks used as class constructors must use the `function` keyword — arrow functions cannot be called with `new`. All `vi.mocked(SomeClass).mockImplementation(() => mockObj)` calls were affected.

**Fix:** Replace arrow functions with `function () { return mock; } as never` in all `mockImplementation`/`mockImplementationOnce` calls for mocked constructors. No production code is changed.

## Test results

Before: 34 failed, 121 passed  
After: 0 failed, 155 passed ✅

## Why a separate PR

As requested in the review of #342 — this fix is purely a test infrastructure correction independent of the orthographic camera feature. Once this merges to `develop`, PR #342 can be rebased onto it.