### PR TITLE
Support three.js r166-r185 with matrix CI coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,52 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # test against the min and max supported three.js versions (see #308)
+        include:
+          - three-version: 0.166.1
+            types-version: 0.166.0
+          - three-version: 0.167.1
+            types-version: 0.167.2
+          - three-version: 0.168.0
+            types-version: 0.168.0
+          - three-version: 0.169.0
+            types-version: 0.169.0
+          - three-version: 0.170.0
+            types-version: 0.170.0
+          - three-version: 0.171.0
+            types-version: 0.171.0
+          - three-version: 0.172.0
+            types-version: 0.172.0
+          - three-version: 0.173.0
+            types-version: 0.173.0
+          - three-version: 0.174.0
+            types-version: 0.174.0
+          - three-version: 0.175.0
+            types-version: 0.175.0
+          - three-version: 0.176.0
+            types-version: 0.176.0
+          - three-version: 0.177.0
+            types-version: 0.177.0
+          - three-version: 0.178.0
+            types-version: 0.178.1
+          - three-version: 0.179.1
+            types-version: 0.179.0
+          - three-version: 0.180.0
+            types-version: 0.180.0
+          - three-version: 0.181.2
+            types-version: 0.181.0
+          - three-version: 0.182.0
+            types-version: 0.182.0
+          - three-version: 0.183.2
+            types-version: 0.183.1
+          - three-version: 0.184.0
+            types-version: 0.184.1
+          - three-version: 0.185.1
+            types-version: 0.185.4
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -27,6 +73,8 @@ jobs:
           node-version: '22.x'
           cache: "npm"
       - run: npm ci
+      - name: Install three.js ${{ matrix.three-version }}
+        run: npm install three@${{ matrix.three-version }} @types/three@${{ matrix.types-version }} --no-save
       - run: npm run build
       - run: npm run test
       - run: npm run typeCheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "lil-gui": "^0.20.0",
-        "three": "0.178.0"
+        "three": ">=0.166.0 <0.186.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",
@@ -18,6 +18,7 @@
         "@types/three": "0.178.0",
         "@typescript-eslint/eslint-plugin": "^8.36.0",
         "@typescript-eslint/parser": "^8.36.0",
+        "@webgpu/types": "^0.1.64",
         "concurrently": "^9.2.0",
         "copyfiles": "^2.4.1",
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@types/node": "^24.0.10",
     "@types/three": "0.178.0",
+    "@webgpu/types": "^0.1.64",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
     "concurrently": "^9.2.0",
@@ -61,6 +62,6 @@
   },
   "dependencies": {
     "lil-gui": "^0.20.0",
-    "three": "0.178.0"
+    "three": ">=0.166.0 <0.186.0"
   }
 }

--- a/src/__tests__/renderer-smoke.ts
+++ b/src/__tests__/renderer-smoke.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { BatchedMesh } from 'three';
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
+
+import { GCodePreview } from '../gcode-preview';
+
+const SAMPLE_GCODE = [
+  'G28',
+  'G1 X0 Y0 Z0.2 F1200',
+  'G1 X10 Y0 E1',
+  'G1 X10 Y10 E2',
+  'G1 X0 Y10 E3',
+  'G1 X0 Y0 E4'
+].join('\n');
+
+const { MockWebGLRenderer, mockRenderers } = vi.hoisted(() => {
+  const mockRenderers: MockWebGLRenderer[] = [];
+
+  class MockWebGLRenderer {
+    domElement: HTMLElement;
+    info = {
+      render: { triangles: 0, calls: 0, lines: 0, points: 0 },
+      memory: { geometries: 0, textures: 0 }
+    };
+    localClippingEnabled = false;
+    setPixelRatio = vi.fn();
+    setSize = vi.fn();
+    render = vi.fn();
+    dispose = vi.fn();
+
+    constructor(opts: { canvas?: HTMLElement } = {}) {
+      this.domElement = opts.canvas ?? document.createElement('canvas');
+      mockRenderers.push(this);
+    }
+  }
+
+  return { MockWebGLRenderer, mockRenderers };
+});
+
+// Only the WebGLRenderer is replaced so the tests can run without a GPU.
+// Every other three.js class stays real, meaning the actual BatchedMesh,
+// LineSegments2, LineMaterial and OrbitControls get constructed at runtime.
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('three')>();
+  return { ...actual, WebGLRenderer: MockWebGLRenderer };
+});
+
+async function nextFrame(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+function createPreview(opts: Record<string, unknown> = {}) {
+  const canvas = document.createElement('canvas');
+  Object.defineProperty(canvas, 'offsetWidth', { value: 800, configurable: true });
+  Object.defineProperty(canvas, 'offsetHeight', { value: 600, configurable: true });
+  return new GCodePreview({ canvas, buildVolume: { x: 200, y: 200, z: 200 }, ...opts });
+}
+
+describe('SceneManager runtime smoke test', () => {
+  afterEach(() => {
+    mockRenderers.forEach((renderer) => {
+      renderer.render.mockClear();
+      renderer.dispose.mockClear();
+    });
+    mockRenderers.length = 0;
+  });
+
+  it('constructs real three.js objects when rendering lines', async () => {
+    const preview = createPreview({ renderExtrusion: true, renderTravel: true });
+    preview.processGCode(SAMPLE_GCODE);
+    await nextFrame();
+
+    const group = preview.sceneManager.scene.getObjectByName('allLayers');
+    expect(group).toBeDefined();
+    expect(group?.children.length).toBeGreaterThan(0);
+
+    let lineCount = 0;
+    preview.sceneManager.scene.traverse((obj) => {
+      if (obj instanceof LineSegments2) lineCount++;
+    });
+    expect(lineCount).toBeGreaterThan(0);
+
+    // the render loop ran against the mocked renderer
+    expect(mockRenderers[0].render).toHaveBeenCalled();
+
+    expect(() => preview.dispose()).not.toThrow();
+    expect(mockRenderers[0].dispose).toHaveBeenCalled();
+  });
+
+  it('constructs a real BatchedMesh when rendering tubes', async () => {
+    const preview = createPreview({ renderExtrusion: true, renderTravel: false, renderTubes: true });
+    preview.processGCode(SAMPLE_GCODE);
+    await nextFrame();
+
+    let batchedMeshCount = 0;
+    preview.sceneManager.scene.traverse((obj) => {
+      if (obj instanceof BatchedMesh) batchedMeshCount++;
+    });
+    expect(batchedMeshCount).toBeGreaterThan(0);
+
+    expect(() => preview.dispose()).not.toThrow();
+    expect(mockRenderers[0].dispose).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/three-version.ts
+++ b/src/__tests__/three-version.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'fs';
+import { test, expect } from 'vitest';
+
+import pkg from '../../package.json';
+
+const MIN_VERSION = '0.166.0';
+const MAX_EXCLUSIVE_VERSION = '0.186.0';
+const SUPPORTED_RANGE = `>=${MIN_VERSION} <${MAX_EXCLUSIVE_VERSION}`;
+
+function parseVersion(version: string): number {
+  const match = version.match(/^0\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`unexpected three.js version: ${version}`);
+  }
+  return Number(match[1]);
+}
+
+const minMinor = Number(MIN_VERSION.split('.')[1]);
+const maxMinorExclusive = Number(MAX_EXCLUSIVE_VERSION.split('.')[1]);
+
+test('three.js dependency is declared as the supported range', () => {
+  expect(pkg.dependencies.three).toBe(SUPPORTED_RANGE);
+});
+
+test('installed three.js version is within the supported range', () => {
+  const threePkg = JSON.parse(readFileSync(`${process.cwd()}/node_modules/three/package.json`, 'utf8'));
+  const version = parseVersion(threePkg.version);
+  expect(version).toBeGreaterThanOrEqual(minMinor);
+  expect(version).toBeLessThan(maxMinorExclusive);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "paths": {
       "three": ["node_modules/three/src/Three"]
     },
-    "typeRoots": ["types", "node_modules/@types"]
+    "typeRoots": ["types", "node_modules/@types", "node_modules/@webgpu"]
   },
   "files": ["src/gcode-preview.ts"]
 }


### PR DESCRIPTION
Closes #308

## Summary

Relaxes the `three` dependency from a hard pin (`0.178.0`) to a supported range `>=0.166.0 <0.186.0` (r166–r185), and proves that range works by running the full CI suite (build, test, typeCheck, lint) against **every minor three.js version** in the range via a CI matrix.

## Behavior change

This is a dependency-range relaxation only. Rendered output is unchanged; the change makes the library compatible with (and tested against) three.js r166 through r185, including the current r185.

## Why a matrix

Per #308, three.js does not use semver, so each minor can introduce breaking changes. The matrix pins CI to test both the exact min (r166) and max (r185) bounds — and now every minor in between — so a regression at any version surfaces in CI instead of in consumers' projects.

## What was added/changed

- `package.json`: `three` → `>=0.166.0 <0.186.0`; adds `@webgpu/types` as a devDependency
- `.github/workflows/run-tests.yml`: matrix with all 20 minor versions (r166–r185), each paired with its matching `@types/three`
- `tsconfig.json`: added `node_modules/@webgpu` to `typeRoots`
- `src/__tests__/three-version.ts`: guards the declared dependency range and asserts the installed three version stays within it
- `src/__tests__/renderer-smoke.ts`: runtime smoke tests that mock **only** `WebGLRenderer` and construct the real `BatchedMesh`, `LineSegments2`, `LineMaterial`, and `OrbitControls` through the full parse → interpret → render pipeline, then dispose cleanly

## Verification

All 20 matrix combos verified locally: `test`, `typeCheck`, `build`, `lint` pass on each. `npm run check` passes at the lock version (0.178.0).

## Notes

- three.js r166–r185 release notes contain **no breaking changes** to the APIs this library uses (verified against the official migration guide).
- `three@0.180.0` initially failed `typeCheck` due to an upstream bug in `@types/three@0.180.0` (missing `/// <reference types="@webgpu/types" />` in `ExternalTexture.d.ts`); resolved via the `@webgpu/types` typeRoots entry.
- Future note: r186 adds `Object3D.dispose()`; `LineBox.dispose()` should call `super.dispose()` when the max bound is next bumped.