### PR TITLE
Reuse the corner vectors in ExtrusionGeometry

### DIFF
--- a/src/__tests__/extrusion-geometry.ts
+++ b/src/__tests__/extrusion-geometry.ts
@@ -126,3 +126,36 @@ test('ExtrusionGeometry produces the same ring for every point on the path', () 
 
   expect(secondRing).toEqual(firstRing);
 });
+
+test('ExtrusionGeometry orients each corner independently', () => {
+  // The corner vectors are scratch objects shared between points, so stale
+  // state from one point leaking into the next would show up as a corner
+  // oriented like its predecessor. This path turns 90 degrees, so the ring
+  // before the turn and the ring after it must not match.
+  const radialSegments = 4;
+  const ring = (radialSegments + 1) * 3;
+  const points = [new Vector3(0, 0, 0), new Vector3(2, 0, 0), new Vector3(2, 2, 0), new Vector3(2, 2, 2)];
+  const geometry = new ExtrusionGeometry(points, 0.6, 0.2, radialSegments);
+
+  const normals = geometry.attributes.normal.array;
+  const ringAt = (i: number) => Array.from(normals.slice(i * ring, (i + 1) * ring));
+
+  expect(ringAt(0)).not.toEqual(ringAt(1));
+  expect(ringAt(1)).not.toEqual(ringAt(2));
+  expect(ringAt(2)).not.toEqual(ringAt(3));
+});
+
+test('ExtrusionGeometry keeps a straight run consistent across points', () => {
+  // The mirror of the test above: with no change in direction, sharing the
+  // scratch vectors must still produce the same ring at every point.
+  const radialSegments = 4;
+  const ring = (radialSegments + 1) * 3;
+  const points = [new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(2, 0, 0), new Vector3(3, 0, 0)];
+  const geometry = new ExtrusionGeometry(points, 0.6, 0.2, radialSegments);
+
+  const normals = geometry.attributes.normal.array;
+  const ringAt = (i: number) => Array.from(normals.slice(i * ring, (i + 1) * ring));
+
+  expect(ringAt(1)).toEqual(ringAt(0));
+  expect(ringAt(2)).toEqual(ringAt(0));
+});

--- a/src/extrusion-geometry.ts
+++ b/src/extrusion-geometry.ts
@@ -56,6 +56,17 @@ class ExtrusionGeometry extends BufferGeometry {
     const normal = new Vector3();
     const uv = new Vector2();
 
+    // Scratch vectors for computeCornerAngles. It runs once per point, and
+    // allocating a fresh set each time means hundreds of thousands of short
+    // lived Vector3 on a real model. Every one is fully overwritten before use,
+    // and generateSegment consumes the result before the next call, so they are
+    // safe to share.
+    const tangent = new Vector3();
+    const cornerNormal = new Vector3();
+    const cornerBinormal = new Vector3();
+    const cross = new Vector3();
+    const nextDirection = new Vector3();
+
     // buffers, sized up front from the path topology so they are filled in
     // place. Growing plain arrays and letting three.js copy them into typed
     // arrays afterwards costs both the repeated growth and the copy.
@@ -203,21 +214,28 @@ class ExtrusionGeometry extends BufferGeometry {
 
     /**
      * Computes the corner angles (position, normal, binormal) for a segment
+     *
+     * Note: the returned N/B vectors are shared scratch — consume them before
+     * the next call; do not store references.
      * @param i - Index of the segment
      * @returns Array containing position, normal and binormal vectors
      */
     function computeCornerAngles(i: number): Array<Vector3> {
       const P = points[i];
-      const tangent = new Vector3();
-      const N = new Vector3();
-      const B = new Vector3();
-      const vec = new Vector3();
+      const N = cornerNormal;
+      const B = cornerBinormal;
+      const vec = cross;
 
       tangent
         .copy(P)
         .sub(points[i - 1] || P)
         .normalize()
-        .add((points[i + 1] || P).clone().sub(P).normalize())
+        .add(
+          nextDirection
+            .copy(points[i + 1] || P)
+            .sub(P)
+            .normalize()
+        )
         .normalize();
 
       // Calculate the normal and binormal vectors for the segment


### PR DESCRIPTION
`computeCornerAngles` runs once per point on every path, and allocates five `Vector3` on each call:

```js
const tangent = new Vector3();
const N = new Vector3();
const B = new Vector3();
const vec = new Vector3();

tangent.copy(P).sub(points[i - 1] || P).normalize()
  .add((points[i + 1] || P).clone().sub(P).normalize())   // <- fifth
  .normalize();
```

None of them outlive the call. Every one is fully overwritten before it is read, and `generateSegment` consumes the returned `[P, N, B]` before the next call happens — so one shared set at constructor scope does the same work.

### Benchmark

3.5 MB 3DBenchy: 163,474 lines → 7023 paths → **104,037 points**.

| | before | after |
| --- | --- | --- |
| `Vector3` allocated per tube render | **520,185** | 5 |
| tube geometry generation | 103 ms | **94 ms** |

Chrome, median of 7 runs after warm-up, building every extrusion geometry in the model.

The wall-clock saving is the smallest of the three `ExtrusionGeometry` wins, but it removes half a million short-lived objects from every render, which is the kind of garbage that shows up as jank rather than as throughput.

### Correctness

Positions and normals compared element-by-element against a reimplementation of the previous allocating version across **500 geometries — all identical**, no tolerance. Model renders unchanged.

Sharing scratch state is exactly the kind of change that breaks quietly, so the two tests added target that failure mode directly rather than the timing:

- a path that turns 90 degrees twice must produce a **different** ring at each corner — stale state leaking from one point into the next would show up as a corner oriented like its predecessor
- a straight run must produce an **identical** ring at every point — the mirror case, catching the opposite error

`npm run check` passes: 12 test files, typecheck, lint.

### Related

Two other independent optimizations in the same file: #349 pre-sizes the geometry buffers, #350 caches the ring of sines and cosines. All three touch `ExtrusionGeometry`, so whichever merge later will need a small rebase. Together they take tube geometry generation from 103 ms to 39 ms.



Assisted by Claude Code - Opus 5
