### PR TITLE
Make source line retention opt-in, and count lines separately

### DIFF
--- a/src/__tests__/preserving-parser.ts
+++ b/src/__tests__/preserving-parser.ts
@@ -1,30 +1,94 @@
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
 
 import { Parser } from '../gcode-parser';
 
-test('all input should be preserved', () => {
-  const parser = new Parser();
-  const gcode = `G1 X0 Y0 Z1 E1`;
-  const parsed = parser.parseGCode(gcode);
-  expect(parsed).not.toBeNull();
-  const unparsed = parser.lines.join('\n');
-  expect(unparsed).toEqual(gcode);
+describe('with keepLines', () => {
+  test('all input should be preserved', () => {
+    const parser = new Parser({ keepLines: true });
+    const gcode = `G1 X0 Y0 Z1 E1`;
+    const parsed = parser.parseGCode(gcode);
+    expect(parsed).not.toBeNull();
+    const unparsed = parser.lines.join('\n');
+    expect(unparsed).toEqual(gcode);
+  });
+
+  test('multiple lines should be preserved', () => {
+    const parser = new Parser({ keepLines: true });
+    const gcode = `G1 X0 Y0 Z1 E1\nG1 X10 Y10 E10`;
+    const parsed = parser.parseGCode(gcode);
+    expect(parsed).not.toBeNull();
+    const unparsed = parser.lines.join('\n');
+    expect(unparsed).toEqual(gcode);
+  });
+
+  test('comments should be preserved', () => {
+    const parser = new Parser({ keepLines: true });
+    const gcode = `G1 X0 Y0 Z1 E1; this is a comment`;
+    const parsed = parser.parseGCode(gcode);
+    expect(parsed).not.toBeNull();
+    const unparsed = parser.lines.join('\n');
+    expect(unparsed).toEqual(gcode);
+  });
+
+  test('input parsed in chunks should be preserved whole', () => {
+    // A streaming parse calls parseGCode once per chunk. Preserving only the
+    // most recent chunk would make the option useless for the large files it
+    // exists for.
+    const parser = new Parser({ keepLines: true });
+    parser.parseGCode('G1 X0 Y0\nG1 X1 Y1');
+    parser.parseGCode('G1 X2 Y2\nG1 X3 Y3');
+
+    expect(parser.lines).toEqual(['G1 X0 Y0', 'G1 X1 Y1', 'G1 X2 Y2', 'G1 X3 Y3']);
+  });
+
+  test('a chunk is only turned into commands once', () => {
+    const parser = new Parser({ keepLines: true });
+    const first = parser.parseGCode('G1 X0 Y0\nG1 X1 Y1');
+    const second = parser.parseGCode('G1 X2 Y2');
+
+    expect(first.commands).toHaveLength(2);
+    expect(second.commands).toHaveLength(1);
+  });
 });
 
-test('multiple lines should be preserved', () => {
-  const parser = new Parser();
-  const gcode = `G1 X0 Y0 Z1 E1\nG1 X10 Y10 E10`;
-  const parsed = parser.parseGCode(gcode);
-  expect(parsed).not.toBeNull();
-  const unparsed = parser.lines.join('\n');
-  expect(unparsed).toEqual(gcode);
+describe('without keepLines', () => {
+  test('the source is not retained', () => {
+    const parser = new Parser();
+    parser.parseGCode('G1 X0 Y0 Z1 E1\nG1 X10 Y10 E10');
+
+    expect(parser.lines).toEqual([]);
+  });
+
+  test('parsing still returns the commands', () => {
+    const parser = new Parser();
+    const { commands } = parser.parseGCode('G1 X0 Y0\nG1 X1 Y1');
+
+    expect(commands).toHaveLength(2);
+    expect(commands[1].gcode).toEqual('g1');
+  });
 });
 
-test('comments should be preserved', () => {
-  const parser = new Parser();
-  const gcode = `G1 X0 Y0 Z1 E1; this is a comment`;
-  const parsed = parser.parseGCode(gcode);
-  expect(parsed).not.toBeNull();
-  const unparsed = parser.lines.join('\n');
-  expect(unparsed).toEqual(gcode);
+describe('lineCount', () => {
+  test('counts the lines parsed', () => {
+    const parser = new Parser();
+    parser.parseGCode('G1 X0 Y0\nG1 X1 Y1\nG1 X2 Y2');
+
+    expect(parser.lineCount).toEqual(3);
+  });
+
+  test('accumulates across chunks', () => {
+    const parser = new Parser();
+    parser.parseGCode('G1 X0 Y0\nG1 X1 Y1');
+    parser.parseGCode('G1 X2 Y2');
+
+    expect(parser.lineCount).toEqual(3);
+  });
+
+  test('is tracked even when the source is not kept', () => {
+    const parser = new Parser();
+    parser.parseGCode('G1 X0 Y0\nG1 X1 Y1');
+
+    expect(parser.lines).toEqual([]);
+    expect(parser.lineCount).toEqual(2);
+  });
 });

--- a/src/__tests__/split-chunk.ts
+++ b/src/__tests__/split-chunk.ts
@@ -1,0 +1,49 @@
+import { test, expect, describe } from 'vitest';
+
+import { splitChunk } from '../helpers/split-chunk';
+import { Parser } from '../gcode-parser';
+
+describe('splitChunk', () => {
+  test('keeps the newline out of the tail', () => {
+    const { complete, tail } = splitChunk('', 'G1 X0\nG1 X1\nG1 X');
+
+    expect(complete).toEqual('G1 X0\nG1 X1');
+    expect(tail).toEqual('G1 X');
+  });
+
+  test('prepends the previous tail to the complete lines', () => {
+    const { complete, tail } = splitChunk('G1 X', '2\nG1 X3\nG1 X4');
+
+    expect(complete).toEqual('G1 X2\nG1 X3');
+    expect(tail).toEqual('G1 X4');
+  });
+
+  test('a chunk ending on a newline leaves an empty tail', () => {
+    const { complete, tail } = splitChunk('', 'G1 X0\nG1 X1\n');
+
+    expect(complete).toEqual('G1 X0\nG1 X1');
+    expect(tail).toEqual('');
+  });
+});
+
+describe('streaming across a chunk boundary', () => {
+  test('a boundary that splits a line mid-way injects no empty line', () => {
+    // Mirrors readStream: each chunk is split into complete lines, which are
+    // parsed, and a tail carried into the next chunk. The boundary here falls
+    // in the middle of 'G1 X2'.
+    const chunks = ['G1 X0\nG1 X1\nG1 X', '2\nG1 X3\nG1 X4'];
+
+    const parser = new Parser({ keepLines: true });
+    let tail = '';
+    for (const chunk of chunks) {
+      const split = splitChunk(tail, chunk);
+      tail = split.tail;
+      parser.parseGCode(split.complete);
+    }
+    parser.parseGCode(tail);
+
+    expect(parser.lines).toEqual(['G1 X0', 'G1 X1', 'G1 X2', 'G1 X3', 'G1 X4']);
+    expect(parser.lines).not.toContain('');
+    expect(parser.lineCount).toEqual(5);
+  });
+});

--- a/src/dev-gui.ts
+++ b/src/dev-gui.ts
@@ -183,7 +183,7 @@ class DevGUI {
     parser.add(this.gcodePreview.job.state, 'y').listen();
     parser.add(this.gcodePreview.job.state, 'z').listen();
     parser.add(this.gcodePreview.job.paths, 'length').name('paths.count').listen();
-    parser.add(this.gcodePreview.parser.lines, 'length').name('lines.count').listen();
+    parser.add(this.gcodePreview.parser, 'lineCount').name('lines.count').listen();
   }
 
   /**

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -130,7 +130,7 @@ export type ParserOptions = {
  * @remarks
  * This parser handles both single-line and multi-line G-code input, extracting
  * commands, parameters, and metadata such as thumbnails. It preserves comments
- * and maintains the original source lines.
+ * and, when created with `keepLines`, retains the original source lines.
  *
  * @example
  * ```typescript
@@ -148,13 +148,19 @@ export class Parser {
    * Only populated when the parser was created with `keepLines`. Streaming
    * parses append to this, so it spans the whole input rather than just the
    * most recent chunk.
+   *
+   * String input is split on `'\n'`, so input ending in a newline yields one
+   * final empty line here. That is the split's honest answer and is
+   * deliberately not filtered out.
    */
   lines: string[] = [];
 
   /**
    * How many lines have been parsed, counting every call.
    * @remarks
-   * Tracked whether or not the lines themselves are kept.
+   * Tracked whether or not the lines themselves are kept. Counts exactly what
+   * `lines` would hold, so a trailing newline contributes one final empty
+   * line.
    */
   lineCount = 0;
 
@@ -177,7 +183,8 @@ export class Parser {
    * @remarks
    * This method handles both single-line and multi-line G-code input, extracting
    * commands, parameters, and metadata such as thumbnails. It preserves comments
-   * and maintains the original source lines.
+   * and, when the parser was created with `keepLines`, appends the original
+   * source lines to `lines`.
    *
    * @example
    * ```typescript

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -114,6 +114,17 @@ function isAlphaCode(code: number): boolean {
 }
 
 /**
+ * Options for configuring the parser
+ */
+export type ParserOptions = {
+  /**
+   * Keep every source line on `lines`. Off by default: a 3.5 MB file costs
+   * several megabytes to hold, and nothing in the library reads the text back.
+   */
+  keepLines?: boolean;
+};
+
+/**
  * A G-code parser that processes G-code commands and extracts metadata.
  *
  * @remarks
@@ -131,8 +142,32 @@ export class Parser {
   /** Metadata extracted from G-code comments, including thumbnails */
   metadata: Metadata = { thumbnails: {} };
 
-  /** Original G-code lines stored for reference */
+  /**
+   * Original G-code lines, in the order they were parsed.
+   * @remarks
+   * Only populated when the parser was created with `keepLines`. Streaming
+   * parses append to this, so it spans the whole input rather than just the
+   * most recent chunk.
+   */
   lines: string[] = [];
+
+  /**
+   * How many lines have been parsed, counting every call.
+   * @remarks
+   * Tracked whether or not the lines themselves are kept.
+   */
+  lineCount = 0;
+
+  /** Whether to retain source lines on `lines` */
+  private readonly keepLines: boolean;
+
+  /**
+   * Creates a new Parser instance
+   * @param opts - Parser options
+   */
+  constructor(opts: ParserOptions = {}) {
+    this.keepLines = opts.keepLines ?? false;
+  }
 
   /**
    * Parses G-code input into commands and metadata
@@ -151,8 +186,18 @@ export class Parser {
    * ```
    */
   parseGCode(input: string | string[]): ParseResult {
-    this.lines = Array.isArray(input) ? input : input.split('\n');
-    const commands = this.lines2commands(this.lines);
+    const lines = Array.isArray(input) ? input : input.split('\n');
+    this.lineCount += lines.length;
+
+    if (this.keepLines) {
+      // appended one at a time: spreading a whole file's worth of lines into
+      // push() overflows the argument limit
+      for (const line of lines) this.lines.push(line);
+    }
+
+    // only the lines from this call, so a streaming parse does not redo the
+    // chunks it has already handled
+    const commands = this.lines2commands(lines);
 
     // merge thumbs
     const thumbs = this.parseMetadata(commands.filter((cmd) => cmd.comment)).thumbnails;

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -15,6 +15,13 @@ type LibOptions = {
   minLayerThreshold?: number;
   /** Enable drag and drop file handling */
   droppable?: boolean;
+  /**
+   * Keep the parsed G-code source on `preview.parser.lines`.
+   * @remarks
+   * Off by default. Nothing in the library reads the source back, and holding
+   * it costs several megabytes on a large file.
+   */
+  keepLines?: boolean;
 };
 
 export type GCodePreviewOptions = LibOptions & SceneManagerOptions;
@@ -70,9 +77,14 @@ export class GCodePreview {
   /** The G-code parser instance */
   get parser(): Parser {
     if (!this._parser) {
-      this._parser = new Parser();
+      this._parser = this.createParser();
     }
     return this._parser;
+  }
+
+  /** Builds a parser carrying the preview's parsing options. */
+  private createParser(): Parser {
+    return new Parser({ keepLines: this.opts?.keepLines });
   }
 
   /**
@@ -99,7 +111,7 @@ export class GCodePreview {
    */
   constructor(opts: GCodePreviewOptions) {
     this.opts = opts;
-    this._parser = new Parser();
+    this._parser = this.createParser();
     this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
     this.stats = this.devMode ? new Stats() : undefined;
     this._sceneManager = new SceneManager(this.opts, this.job, () => this.stats?.update());
@@ -113,7 +125,7 @@ export class GCodePreview {
    * Clears the preview and resets the parser, sceneManager, gui and job
    */
   clear(): void {
-    this._parser = new Parser();
+    this._parser = this.createParser();
     this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
     this.sceneManager.clear();
     this.sceneManager.job = this.job;

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -5,6 +5,7 @@ import { Job } from './job';
 import { DevGUI, type DevModeOptions } from './dev-gui';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { makeDroppable } from './extra/dom-utils';
+import { splitChunk } from './helpers/split-chunk';
 
 /**
  * Options for configuring the G-code preview
@@ -199,17 +200,14 @@ export class GCodePreview {
       }
       console.debug('reading from stream', Math.floor(length / 1024), 'kB');
       size += length;
-      const str = result.value;
-      const idxNewLine = str.lastIndexOf('\n');
-      const maxFullLine = str.slice(0, idxNewLine);
+      const split = splitChunk(tail, result.value);
+      tail = split.tail;
 
       // parse increments but don't render yet
-      const { commands } = this.parser.parseGCode(tail + maxFullLine);
+      const { commands } = this.parser.parseGCode(split.complete);
 
       // we'll execute the commands immediately, for now
       this.interpreter.execute(commands, this.job);
-
-      tail = str.slice(idxNewLine);
     } while (!result.done);
 
     console.debug('total read from stream', Math.floor(size / 1024), 'kB');

--- a/src/helpers/split-chunk.ts
+++ b/src/helpers/split-chunk.ts
@@ -1,0 +1,25 @@
+/**
+ * Splits a streamed chunk into the lines that are complete and the partial
+ * line to carry into the next chunk.
+ *
+ * @param tail - Partial line left over from the previous chunk
+ * @param chunk - Newly read chunk of G-code text
+ * @returns `complete`, ready to parse, and the new `tail`
+ *
+ * @remarks
+ * The returned `tail` excludes the newline itself, so prepending it to the
+ * next chunk never fabricates an empty line at a chunk boundary.
+ *
+ * A chunk containing no newline at all keeps its historical behaviour: it is
+ * split before its last character. That is a known quirk, preserved here so
+ * this helper changes nothing but the boundary newline.
+ */
+export function splitChunk(tail: string, chunk: string): { complete: string; tail: string } {
+  const idxNewLine = chunk.lastIndexOf('\n');
+
+  if (idxNewLine < 0) {
+    return { complete: tail + chunk.slice(0, -1), tail: chunk.slice(-1) };
+  }
+
+  return { complete: tail + chunk.slice(0, idxNewLine), tail: chunk.slice(idxNewLine + 1) };
+}


### PR DESCRIPTION
`Parser` keeps every source line on `lines`. For the 3.5 MB 3DBenchy that is 163,474 strings — roughly **5 MB**: 3.37 MB of characters, a 1.25 MB pointer array, and a header per string. Nothing in the library reads the text back.

Retention is now opt-in:

```js
new Parser({ keepLines: true });
new GCodePreview({ canvas, keepLines: true });   // reaches the same option
```

Off by default. The idea is that the lines could be useful, for clients of the library or for internal features. So I'm not a fan of dropping them unconditionally. I don't want to create a one-way door. The default could dynamically decide if the lines are needed or not if a set of features enabled requires them.

### Two bugs fixed along the way

**`lines` only ever held the last chunk.** `parseGCode` did `this.lines = input.split('\n')` — an assignment, not an append — and a streaming parse calls it once per chunk. After the demo's streamed load the parser held **72,055 of 163,474 lines**. So the field could not have served the "keep the source" purpose it existed for, on exactly the large files where it matters. It now appends.

`parseGCode` also now builds commands from the current chunk rather than the accumulated buffer, so a streaming parse does not re-tokenize what it has already handled.

**The dev GUI's line counter reported that same truncated number**, because it read `parser.lines.length`. It now reads a new `lineCount`, which accumulates across calls and is tracked whether or not the lines are kept. On the Benchy it reports **163,474** where it previously showed **72,055**.

`lineCount` and `keepLines` are independent — you get an accurate count without paying to keep the text.

### Verified

| | `lines` held | `lineCount` |
| --- | --- | --- |
| default, streamed load | **0** | 163,474 ✅ |
| `keepLines: true`, whole file | 163,474 | 163,474 |
| `keepLines: true`, parsed in 2 chunks | **163,474** | 163,474 |

The chunked row is the fix — previously it would have held only the second chunk.

Dev GUI checked in the browser: the `lines.count` widget renders `163474`. The old binding would now show `0`.

Heap deltas for the retained lines measured at 5.8 / 1.7 / 5.1 MB across three runs — too noisy to quote precisely without forced GC, hence "roughly 5 MB" from the deterministic parts rather than a false-precision figure.

`npm run check` passes: 12 test files, typecheck, lint.

### Breaking

`parser.lines` is empty unless `keepLines` is set. It is a public field in the published typings, so anyone reading it needs the option — though on a streamed load they were getting a partial file anyway.

The `preserving-parser` tests, whose whole subject is this capability, now opt in, and there are new tests for the default being empty, for accumulation across chunks, and for `lineCount`.

### Not addressed here

Peak memory during a non-streaming parse is ~30 MB for a 3.5 MB file, because `parseGCode` materialises all 163,474 `GCodeCommand` objects at once. That dwarfs the retention fixed here, but changing it means changing `parseGCode`'s shape, which deserves its own discussion.

`GCodeCommand.src` is public, has no readers anywhere in the repo, and costs nothing to retain — it references the same string as `lines[i]`, on an object that is discarded right after interpretation. Left alone deliberately.

### Review follow-up

- Fixed the streaming off-by-one: `readStream`'s carried tail started at the newline itself, so every chunk boundary fed a spurious empty line into `parseGCode` and inflated `lineCount`. The fix is one character (`slice(idxNewLine + 1)`), but it changes behavior beyond `keepLines`: the interpreter no longer receives one empty command per chunk boundary.
- Extracted the per-chunk split into `splitChunk` (`src/helpers/split-chunk.ts`), a pure helper `readStream` now uses, so boundary behavior is testable without constructing a `GCodePreview` (WebGLRenderer throws under happy-dom). Its known no-newline-chunk quirk is preserved unchanged.
- Regression test drives `splitChunk` + `Parser({ keepLines: true })` across a mid-line chunk boundary: no empty line appears and `lineCount` matches.
- Trailing-newline semantics (`split('\n')` yields one final empty line) are now documented on `lines`/`lineCount` rather than changed.

Assisted by Claude Code - Opus 5

