### PR TITLE
chore: bump @types/three to ^0.185.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@types/node": "^24.0.10",
-        "@types/three": "0.178.0",
+        "@types/three": "^0.185.4",
         "@typescript-eslint/eslint-plugin": "^8.36.0",
         "@typescript-eslint/parser": "^8.36.0",
         "@webgpu/types": "^0.1.64",
@@ -1612,19 +1612,18 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.178.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.0.tgz",
-      "integrity": "sha512-1IpVbMKbEAAWjyn0VTdVcNvI1h1NlTv3CcnwMr3NNBv/gi3PL0/EsWROnXUEkXBxl94MH5bZvS8h0WnBRmR/pQ==",
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "@webgpu/types": "*",
+        "@types/webxr": ">=0.5.17",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/unist": {
@@ -4864,9 +4863,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "dev": true,
       "license": "MIT"
     },
@@ -6828,9 +6827,9 @@
       "license": "MIT"
     },
     "node_modules/three": {
-      "version": "0.178.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
-      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "license": "MIT"
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@types/node": "^24.0.10",
-    "@types/three": "0.178.0",
-    "@webgpu/types": "^0.1.64",
+    "@types/three": "^0.185.4",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
+    "@webgpu/types": "^0.1.64",
     "concurrently": "^9.2.0",
     "copyfiles": "^2.4.1",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- Bump `@types/three` from pinned `0.178.0` to `^0.185.4` to match the latest published `three@0.185.x`.
- The runtime `three` dependency range (`>=0.166.0 <0.186.0`) already covers `three@0.185.1`, so no change was needed there.

## Testing
- `npm run check` — 159 tests passed, typecheck clean, lint clean.