### PR TITLE
WIP: Rainbow filament coloring by extrusion distance

### DIFF
--- a/src/__tests__/path.ts
+++ b/src/__tests__/path.ts
@@ -70,12 +70,13 @@ describe('.geometry', () => {
     path.addPoint(0, 0, 0);
     path.addPoint(1, 2, 3);
 
-    const result = path.geometry() as ExtrusionGeometry;
+    const result = path.geometry();
 
     expect(result).not.toBeNull();
-    expect(result).toBeInstanceOf(ExtrusionGeometry);
-    expect(result.parameters.points.length).toEqual(2);
-    expect(result.parameters.closed).toEqual(false);
+    const geometry = result.geometry as ExtrusionGeometry;
+    expect(geometry).toBeInstanceOf(ExtrusionGeometry);
+    expect(geometry.parameters.points.length).toEqual(2);
+    expect(geometry.parameters.closed).toEqual(false);
   });
 
   test('returns an ExtrusionGeometry with the path extrusion width', () => {
@@ -84,9 +85,10 @@ describe('.geometry', () => {
     path.addPoint(0, 0, 0);
     path.addPoint(1, 2, 3);
 
-    const result = path.geometry() as ExtrusionGeometry;
+    const result = path.geometry();
+    const geometry = result.geometry as ExtrusionGeometry;
 
-    expect(result.parameters.lineWidth).toEqual(9);
+    expect(geometry.parameters.lineWidth).toEqual(9);
   });
 
   test('returns an ExtrusionGeometry with the path line height', () => {
@@ -95,9 +97,10 @@ describe('.geometry', () => {
     path.addPoint(0, 0, 0);
     path.addPoint(1, 2, 3);
 
-    const result = path.geometry() as ExtrusionGeometry;
+    const result = path.geometry();
+    const geometry = result.geometry as ExtrusionGeometry;
 
-    expect(result.parameters.lineHeight).toEqual(5);
+    expect(geometry.parameters.lineHeight).toEqual(5);
   });
 
   test('returns an ExtrusionGeometry with the extrusionWidthOverride when passed', () => {
@@ -106,9 +109,10 @@ describe('.geometry', () => {
     path.addPoint(0, 0, 0);
     path.addPoint(1, 2, 3);
 
-    const result = path.geometry({ extrusionWidthOverride: 2 }) as ExtrusionGeometry;
+    const result = path.geometry({ extrusionWidthOverride: 2 });
+    const geometry = result.geometry as ExtrusionGeometry;
 
-    expect(result.parameters.lineWidth).toEqual(2);
+    expect(geometry.parameters.lineWidth).toEqual(2);
   });
 
   test('returns an ExtrusionGeometry with the lineHeightOverride when passed', () => {
@@ -117,9 +121,10 @@ describe('.geometry', () => {
     path.addPoint(0, 0, 0);
     path.addPoint(1, 2, 3);
 
-    const result = path.geometry({ lineHeightOverride: 7 }) as ExtrusionGeometry;
+    const result = path.geometry({ lineHeightOverride: 7 });
+    const geometry = result.geometry as ExtrusionGeometry;
 
-    expect(result.parameters.lineHeight).toEqual(7);
+    expect(geometry.parameters.lineHeight).toEqual(7);
   });
 
   test('returns null if there are 0 vertices', () => {

--- a/src/helpers/colorMaterial.ts
+++ b/src/helpers/colorMaterial.ts
@@ -10,50 +10,78 @@ import { Color } from 'three/src/math/Color.js';
 const vertexShader = `
 uniform float clipMinY;
 uniform float clipMaxY;
+attribute float extrusionDistance;
 varying vec3 vNormal;
 varying vec3 vPosition;
 varying float vWorldY;
+varying float vExtrusion;
 
 void main() {
   vNormal = normalize(normalMatrix * normal);
   vPosition = position;
   vWorldY = (modelMatrix * vec4(position, 1.0)).y;
+  vExtrusion = extrusionDistance;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }
+
 `;
 
 // Fragment Shader
 const fragmentShader = `
-uniform vec3 uColor;
 uniform float ambient;
 uniform float directional;
 uniform float brightness;
 uniform float clipMinY;
 uniform float clipMaxY;
+
 varying vec3 vNormal;
 varying vec3 vPosition;
 varying float vWorldY;
+varying float vExtrusion;
+
+// Rainbow mapping function
+vec3 hsv2rgb(float h, float s, float v) {
+  float c = v * s;
+  float x = c * (1.0 - abs(mod(h * 6.0, 2.0) - 1.0));
+  float m = v - c;
+
+  vec3 rgb;
+  if (h < 1.0 / 6.0)      rgb = vec3(c, x, 0.0);
+  else if (h < 2.0 / 6.0) rgb = vec3(x, c, 0.0);
+  else if (h < 3.0 / 6.0) rgb = vec3(0.0, c, x);
+  else if (h < 4.0 / 6.0) rgb = vec3(0.0, x, c);
+  else if (h < 5.0 / 6.0) rgb = vec3(x, 0.0, c);
+  else                   rgb = vec3(c, 0.0, x);
+
+  return rgb + vec3(m);
+}
+
+vec3 rainbow(float t) {
+  // return hsv2rgb(t, 1.0, 1.0); // Full saturation and brightness
+  if (t > 0.0 && t < 1.0) {
+    return vec3(1.0, 0.0, 0.0);
+  }
+  return vec3(1.0, 1.0, 1.0); 
+}
+
 
 void main() {
-  // Apply clipping
-  if (vWorldY < clipMinY || vWorldY > clipMaxY) {
-    discard;
-  }
-  
-  // Fixed light direction (pointing from front-left)
+  // Clipping
+  if (vWorldY < clipMinY || vWorldY > clipMaxY) discard;
+
   vec3 lightDir = normalize(vec3(-0.8, -0.2, -0.8));
-  
-  // Calculate diffuse lighting with increased intensity
   float diff = max(dot(vNormal, -lightDir), 0.0) * directional;
-  
-  // Combine lighting with color
-  vec3 finalColor = uColor * (diff + ambient);
-  
-  // Add a bit of extra brightness
+
+  // Map extrusion to [0,1] with optional wrapping every 300 mm
+  float t = mod(vExtrusion, 100.0) / 100.0;
+  vec3 baseColor = rainbow(t);
+
+  vec3 finalColor = baseColor * (diff + ambient);
   finalColor = min(finalColor * brightness, 1.0);
-  
+
   gl_FragColor = vec4(finalColor, 1.0);
 }
+
 `;
 
 // cachedMaterial is used to store the material so that it is only created once for every color
@@ -83,7 +111,9 @@ export function createColorMaterial(
       brightness: { value: brightness },
       clipMinY: { value: -Infinity },
       clipMaxY: { value: Infinity }
-    }
+    },
+    wireframe: false,
+    side: 2, // Double-sided for debugging
   });
 
   // Cache the material

--- a/src/helpers/colorMaterial.ts
+++ b/src/helpers/colorMaterial.ts
@@ -113,7 +113,7 @@ export function createColorMaterial(
       clipMaxY: { value: Infinity }
     },
     wireframe: false,
-    side: 2, // Double-sided for debugging
+    side: 2 // Double-sided for debugging
   });
 
   // Cache the material

--- a/src/path.ts
+++ b/src/path.ts
@@ -107,11 +107,13 @@ export class Path {
    * @param opts.lineHeightOverride - Optional override for line height
    * @returns BufferGeometry representing the path
    */
-  geometry(opts: { 
-    extrusionWidthOverride?: number; 
-    lineHeightOverride?: number
-  },
-  extrusionDistance: number): { geometry: BufferGeometry, extrusionDistance: number } {
+  geometry(
+    opts: {
+      extrusionWidthOverride?: number;
+      lineHeightOverride?: number;
+    } = {},
+    extrusionDistance = 0
+  ): { geometry: BufferGeometry; extrusionDistance: number } {
     if (this._vertices.length < 6) {
       // a path needs at least 2 points to be valid
       console.warn('Path has less than 6 points, returning empty geometry');
@@ -128,27 +130,23 @@ export class Path {
       radialSegments
     );
 
-    
     // // Assuming you have a path and know the extrusion per segment
     // for (let i = 0; i < extrusionDistances.length; i++) {
-      //   const ringIndex = Math.floor(i / radialSegments);
-      //   extrusionDistances[i] = cumulative[ringIndex];
-      // }
-      
-      // create an array with length equal to the number of vertices
-      // and fill it with a constant value
-      const extrusionDistances = new Float32Array(geometry.attributes.position.count);
-      for (let i = 0; i < path.length; i++) {
-        extrusionDistances[i] = cumulative[i];
-      }
-      
-    geometry.setAttribute(
-      'extrusionDistance',
-      new BufferAttribute(extrusionDistances, 1)
-    );
+    //   const ringIndex = Math.floor(i / radialSegments);
+    //   extrusionDistances[i] = cumulative[ringIndex];
+    // }
+
+    // create an array with length equal to the number of vertices
+    // and fill it with a constant value
+    const extrusionDistances = new Float32Array(geometry.attributes.position.count);
+    for (let i = 0; i < path.length; i++) {
+      extrusionDistances[i] = cumulative[i];
+    }
+
+    geometry.setAttribute('extrusionDistance', new BufferAttribute(extrusionDistances, 1));
 
     return {
-      geometry : geometry,
+      geometry: geometry,
       extrusionDistance: extrusionDistance
     };
   }
@@ -175,7 +173,6 @@ export class Path {
     return this.vertices.some((_, i, arr) => i % 3 === 2 && arr[i] !== arr[2]);
   }
 }
-
 
 function computeCumulativeExtrusion(startingDistance: number, path: Vector3[]): Float32Array {
   const distances = new Float32Array(path.length + 1);

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { BufferGeometry, Vector3 } from 'three';
+import { BufferAttribute, BufferGeometry, Vector3 } from 'three';
 import { ExtrusionGeometry } from './extrusion-geometry';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 
@@ -107,19 +107,50 @@ export class Path {
    * @param opts.lineHeightOverride - Optional override for line height
    * @returns BufferGeometry representing the path
    */
-  geometry(opts: { extrusionWidthOverride?: number; lineHeightOverride?: number } = {}): BufferGeometry {
+  geometry(opts: { 
+    extrusionWidthOverride?: number; 
+    lineHeightOverride?: number
+  },
+  extrusionDistance: number): { geometry: BufferGeometry, extrusionDistance: number } {
     if (this._vertices.length < 6) {
       // a path needs at least 2 points to be valid
       console.warn('Path has less than 6 points, returning empty geometry');
       return null;
     }
+    const path = this.path();
+    const cumulative = computeCumulativeExtrusion(extrusionDistance, path);
 
-    return new ExtrusionGeometry(
-      this.path(),
+    const radialSegments = 4;
+    const geometry = new ExtrusionGeometry(
+      path,
       opts.extrusionWidthOverride ?? this.extrusionWidth,
       opts.lineHeightOverride ?? this.lineHeight,
-      4
+      radialSegments
     );
+
+    
+    // // Assuming you have a path and know the extrusion per segment
+    // for (let i = 0; i < extrusionDistances.length; i++) {
+      //   const ringIndex = Math.floor(i / radialSegments);
+      //   extrusionDistances[i] = cumulative[ringIndex];
+      // }
+      
+      // create an array with length equal to the number of vertices
+      // and fill it with a constant value
+      const extrusionDistances = new Float32Array(geometry.attributes.position.count);
+      for (let i = 0; i < path.length; i++) {
+        extrusionDistances[i] = cumulative[i];
+      }
+      
+    geometry.setAttribute(
+      'extrusionDistance',
+      new BufferAttribute(extrusionDistances, 1)
+    );
+
+    return {
+      geometry : geometry,
+      extrusionDistance: extrusionDistance
+    };
   }
 
   /**
@@ -143,4 +174,19 @@ export class Path {
   hasVerticalMoves(): boolean {
     return this.vertices.some((_, i, arr) => i % 3 === 2 && arr[i] !== arr[2]);
   }
+}
+
+
+function computeCumulativeExtrusion(startingDistance: number, path: Vector3[]): Float32Array {
+  const distances = new Float32Array(path.length + 1);
+  let total = startingDistance;
+
+  distances[0] = total; // Start with the initial extrusion distance
+  for (let i = 1; i < path.length; i++) {
+    const dist = path[i].distanceTo(path[i - 1]);
+    total += dist;
+    distances[i] = total;
+  }
+
+  return distances;
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -105,7 +105,8 @@ export class Path {
    * @param opts - Geometry options
    * @param opts.extrusionWidthOverride - Optional override for extrusion width
    * @param opts.lineHeightOverride - Optional override for line height
-   * @returns BufferGeometry representing the path
+   * @param extrusionDistance - Cumulative extrusion distance before this path
+   * @returns The geometry and the cumulative extrusion distance, or null if the path is invalid
    */
   geometry(
     opts: {
@@ -113,7 +114,7 @@ export class Path {
       lineHeightOverride?: number;
     } = {},
     extrusionDistance = 0
-  ): { geometry: BufferGeometry; extrusionDistance: number } {
+  ): { geometry: BufferGeometry; extrusionDistance: number } | null {
     if (this._vertices.length < 6) {
       // a path needs at least 2 points to be valid
       console.warn('Path has less than 6 points, returning empty geometry');

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -143,8 +143,11 @@ export class SceneManager {
   private _boundingBoxColor?: Color;
 
   // rendering
-  /** Group containing all rendered paths */
+  /** Group containing all extruded paths */
   private group?: Group;
+  /** Group containing all travel paths */
+  private travelGroup?: Group;
+
   /** Disposable resources */
   private disposables: Disposable[] = [];
   /** Default extrusion color */
@@ -717,7 +720,7 @@ export class SceneManager {
    * Sets up the group's orientation and position based on build volume dimensions.
    * If no build volume is defined, uses a default position.
    */
-  private createGroup(name: string): Group {
+  private createGroup(name: string) : Group {
     const group = new Group();
     group.name = name;
     group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
@@ -904,10 +907,14 @@ export class SceneManager {
     if (this.renderExtrusion) {
       this.job.toolPaths.forEach((toolPaths, index) => {
         const color = Array.isArray(this._extrusionColor) ? this._extrusionColor[index] : this._extrusionColor;
+        const slicedToolPaths = toolPaths.slice(this.renderPathIndex, endPathNumber);
+        if (slicedToolPaths.length === 0) {
+          return;
+        }
         if (this.renderTubes) {
-          this.renderPathsAsTubes(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
+          this.renderPathsAsTubes(slicedToolPaths, color);
         } else {
-          this.renderPathsAsLines(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
+          this.renderPathsAsLines(slicedToolPaths, color);
         }
       });
     }
@@ -960,20 +967,29 @@ export class SceneManager {
    * @param color - Color to use for the tubes
    */
   private renderPathsAsTubes(paths: Path[], color: Color): void {
+    console.log('rendering '+paths.length+' paths as tubes');
+
+    // use a random color instead of the default extrusion color
+    // const randomColor = Math.floor(Math.random() * 16777215); // 0xFFFFFF
+    // this._extrusionColor = new Color(randomColor);
     const colorNumber = Number(color.getHex());
     const geometries: BufferGeometry[] = [];
 
     const material = createColorMaterial(colorNumber, this.ambientLight, this.directionalLight, this.brightness);
 
     this.materials.push(material);
+    let totalExtrusionDistance = 0;
 
     paths.forEach((path) => {
-      const geometry = path.geometry({
+      const { geometry, extrusionDistance } = path.geometry({
         extrusionWidthOverride: this.extrusionWidth,
         lineHeightOverride: this.lineHeight
-      });
+      }, totalExtrusionDistance);
 
       if (!geometry) return;
+
+      console.debug(extrusionDistance, 'mm extrusion distance for path');
+      totalExtrusionDistance = extrusionDistance;
 
       this.disposables.push(geometry);
       geometries.push(geometry);
@@ -992,11 +1008,12 @@ export class SceneManager {
    * @returns Batched mesh instance
    */
   private createBatchMesh(geometries: BufferGeometry[], material: Material): BatchedMesh {
+    console.debug('creating batched mesh with', geometries.length, 'geometries');
     const maxVertexCount = geometries.reduce((acc, geometry) => geometry.attributes.position.count * 3 + acc, 0);
 
     const batchedMesh = new BatchedMesh(geometries.length, maxVertexCount, undefined, material);
     this.disposables.push(batchedMesh);
-
+    
     geometries.forEach((geometry) => {
       const geometryId = batchedMesh.addGeometry(geometry);
       // NOTE: for older versions of three.js, addInstance is not available

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -720,7 +720,7 @@ export class SceneManager {
    * Sets up the group's orientation and position based on build volume dimensions.
    * If no build volume is defined, uses a default position.
    */
-  private createGroup(name: string) : Group {
+  private createGroup(name: string): Group {
     const group = new Group();
     group.name = name;
     group.quaternion.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
@@ -967,7 +967,7 @@ export class SceneManager {
    * @param color - Color to use for the tubes
    */
   private renderPathsAsTubes(paths: Path[], color: Color): void {
-    console.log('rendering '+paths.length+' paths as tubes');
+    console.log('rendering ' + paths.length + ' paths as tubes');
 
     // use a random color instead of the default extrusion color
     // const randomColor = Math.floor(Math.random() * 16777215); // 0xFFFFFF
@@ -981,12 +981,17 @@ export class SceneManager {
     let totalExtrusionDistance = 0;
 
     paths.forEach((path) => {
-      const { geometry, extrusionDistance } = path.geometry({
-        extrusionWidthOverride: this.extrusionWidth,
-        lineHeightOverride: this.lineHeight
-      }, totalExtrusionDistance);
+      const result = path.geometry(
+        {
+          extrusionWidthOverride: this.extrusionWidth,
+          lineHeightOverride: this.lineHeight
+        },
+        totalExtrusionDistance
+      );
 
-      if (!geometry) return;
+      if (!result) return;
+
+      const { geometry, extrusionDistance } = result;
 
       console.debug(extrusionDistance, 'mm extrusion distance for path');
       totalExtrusionDistance = extrusionDistance;
@@ -1013,7 +1018,7 @@ export class SceneManager {
 
     const batchedMesh = new BatchedMesh(geometries.length, maxVertexCount, undefined, material);
     this.disposables.push(batchedMesh);
-    
+
     geometries.forEach((geometry) => {
       const geometryId = batchedMesh.addGeometry(geometry);
       // NOTE: for older versions of three.js, addInstance is not available


### PR DESCRIPTION
## Intent

Color filament by cumulative extrusion distance, computed per path and passed to the shader as a vertex attribute (`extrusionDistance`). Each geometry gets a per-vertex extrusion-distance attribute, and the material's fragment shader maps that value onto a rainbow hue.

## Current state (WIP)

- `Path.geometry()` now accepts an `extrusionDistance` parameter and returns `{ geometry, extrusionDistance }`, setting a per-vertex `extrusionDistance` attribute.
- `createColorMaterial` shader receives `vExtrusion` and maps it via `mod(vExtrusion, 100.0) / 100.0` into a rainbow. The actual `rainbow()` mapping is stubbed — it returns red for `t in (0,1)` and white otherwise, so no real color gradient yet.
- `renderPathsAsTubes` threads a running `totalExtrusionDistance` through each path and uses the returned geometry.
- Uses a debug double-sided material (`side: 2`).

## Fixes applied to make it compile

- `src/path.ts`: gave `geometry()` a default value for the new `extrusionDistance` param and default `opts` so existing callers still type-check.
- `src/scene-manager.ts`: guarded against the `null` result from `path.geometry()` before destructuring.
- Prettier formatting on the WIP files so `npm run lint` passes.

`npm run typeCheck` and `npm run lint` both pass.