### PR TITLE
Reject non-finite coordinates in the bounding box

### DIFF
--- a/src/__tests__/bounding-box.ts
+++ b/src/__tests__/bounding-box.ts
@@ -57,6 +57,51 @@ describe('BoundingBox', () => {
     });
   });
 
+  describe('non-finite coordinates', () => {
+    it('a NaN coordinate does not make the box valid', () => {
+      const bbox = new BoundingBox();
+      bbox.update(NaN, 5, 5);
+      expect(bbox.isValid).toBe(false);
+      expect(bbox.size).toBeNull();
+      expect(bbox.center).toBeNull();
+      expect(bbox.corners).toBeNull();
+    });
+
+    it('a NaN coordinate does not poison an already-valid box', () => {
+      const bbox = new BoundingBox();
+      bbox.update(1, 2, 3);
+      bbox.update(NaN, 10, 10);
+      expect(bbox.isValid).toBe(true);
+      expect(bbox.size).toMatchObject({ x: 0, y: 0, z: 0 });
+      expect(bbox.center).toMatchObject({ x: 1, y: 2, z: 3 });
+    });
+
+    it('rejects a point with a NaN y or z coordinate', () => {
+      const yBox = new BoundingBox();
+      yBox.update(1, NaN, 2);
+      expect(yBox.isValid).toBe(false);
+
+      const zBox = new BoundingBox();
+      zBox.update(1, 2, NaN);
+      expect(zBox.isValid).toBe(false);
+    });
+
+    it('an Infinity coordinate is rejected too', () => {
+      const xBox = new BoundingBox();
+      xBox.update(Infinity, 0, 0);
+      expect(xBox.isValid).toBe(false);
+
+      const yBox = new BoundingBox();
+      yBox.update(0, Infinity, 0);
+      expect(yBox.isValid).toBe(false);
+      expect(yBox.size).toBeNull();
+
+      const zBox = new BoundingBox();
+      zBox.update(0, 0, -Infinity);
+      expect(zBox.isValid).toBe(false);
+    });
+  });
+
   describe('corners', () => {
     it('returns null before any point has been added', () => {
       const bbox = new BoundingBox();

--- a/src/bounding-box.ts
+++ b/src/bounding-box.ts
@@ -13,6 +13,7 @@ export class BoundingBox {
   public update(x: number, y: number, z: number): void {
     // Malformed gcode can yield NaN params; a partial point would corrupt the extremes, so reject the whole point.
     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      console.error(`BoundingBox.update: ignoring non-finite point (${x}, ${y}, ${z})`);
       return;
     }
     this.min.x = Math.min(this.min.x, x);

--- a/src/bounding-box.ts
+++ b/src/bounding-box.ts
@@ -5,11 +5,16 @@ export class BoundingBox {
 
   /**
    * Updates the bounding box with the given coordinates.
+   * Points with any non-finite coordinate (NaN or Infinity) are ignored.
    * @param x - The X coordinate.
    * @param y - The Y coordinate.
    * @param z - The Z coordinate.
    */
   public update(x: number, y: number, z: number): void {
+    // Malformed gcode can yield NaN params; a partial point would corrupt the extremes, so reject the whole point.
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      return;
+    }
     this.min.x = Math.min(this.min.x, x);
     this.max.x = Math.max(this.max.x, x);
     this.min.y = Math.min(this.min.y, y);
@@ -19,11 +24,11 @@ export class BoundingBox {
   }
 
   /**
-   * Checks if the bounding box has been updated with any points.
-   * @returns True if at least one point has been added, false otherwise.
+   * Checks if the bounding box has been updated with at least one finite point.
+   * @returns True if at least one finite point has been added, false otherwise.
    */
   public get isValid(): boolean {
-    return this.min.x !== Infinity;
+    return Number.isFinite(this.min.x);
   }
 
   /**


### PR DESCRIPTION
## The bug

`BoundingBox.update()` fed coordinates straight into `Math.min`/`Math.max` with no finiteness check, and `isValid` was `this.min.x !== Infinity`. A single NaN coordinate turns `Math.min(Infinity, NaN)` into NaN, which then sticks forever (`Math.min(NaN, anything)` is NaN) — yet `isValid` reports **true** (`NaN !== Infinity`), so `size`/`center`/`corners` hand out all-NaN vectors as if they were real.

Reachable from real gcode: `G1 Xabc` → parser `parseFloat` → `params.x = NaN` → interpreter `state.x = x ?? state.x` keeps NaN (`??` only catches null/undefined) → `boundingBox.update(NaN, ...)`. Downstream that poisons the ortho camera frustum and the LineBox with NaN geometry. Infinity coordinates on y/z leaked through the same way (`update(0, Infinity, 0)` reported valid with an Infinity-sized box).

## Red

```
 ❯ src/__tests__/bounding-box.ts (15 tests | 4 failed)
       × a NaN coordinate does not make the box valid
       × a NaN coordinate does not poison an already-valid box
       × rejects a point with a NaN y or z coordinate
       × an Infinity coordinate is rejected too

AssertionError: expected true to be false // Object.is equality
AssertionError: expected GCodeVector3{ x: NaN, y: 8, z: 7 } to match object { x: +0, y: +0, z: +0 }

      Tests  4 failed | 11 passed (15)
```

## The fix

`update()` rejects the whole point when any coordinate is non-finite — a point with NaN x but valid y/z is meaningless, and letting the finite axes through would corrupt the extremes with half a point. `isValid` is hardened to `Number.isFinite(this.min.x)` as belt-and-suspenders (the empty-box Infinity sentinel reads as invalid through the same lens). `src/bounding-box.ts` stays at the 100/100/100/100 coverage threshold, and both mutations (guard removed; guard checking x only) are killed by the new tests.

## Notes

- Deliberately stacked on #363 (same test file and the coverage threshold gate live there). If #363 merges first, retarget this to `develop`.
- Related to #361: this is a self-defense instance of the invalid-input story — the box now protects itself even before parser/interpreter-level validation lands.

Assisted by Claude Code - Fable 5
