### PR TITLE
Validate coordinates at the parser boundary, and fix the arc edge cases

### DIFF
--- a/src/__tests__/gcode-parser.ts
+++ b/src/__tests__/gcode-parser.ts
@@ -222,6 +222,19 @@ describe('parseCommand tokenizing', () => {
       expect(cmd.params.z).toEqual(2);
     });
 
+    test('takes the leading number and drops trailing letters', () => {
+      // The tokenizer splits at the first letter, so X's value slice is '123' and the
+      // trailing letters become valueless words that are now dropped rather than stored
+      // as NaN. Lenient like the firmware: Marlin's strtod also ignores the tail.
+      const cmd = parse('G1 X123abc Y5');
+      expect(cmd.params).toEqual({ x: 123, y: 5 });
+    });
+
+    test('takes the leading number of a malformed decimal', () => {
+      const cmd = parse('G1 X1.2.3 Y5');
+      expect(cmd.params).toEqual({ x: 1.2, y: 5 });
+    });
+
     test('keeps finite values of every shape', () => {
       const cmd = parse('G1 X-0.5 Y0 Z100 E-.27245');
       expect(cmd.params).toEqual({ x: -0.5, y: 0, z: 100, e: -0.27245 });

--- a/src/__tests__/gcode-parser.ts
+++ b/src/__tests__/gcode-parser.ts
@@ -195,6 +195,39 @@ describe('parseCommand tokenizing', () => {
     });
   });
 
+  describe('non-finite parameter values', () => {
+    test('drops a param whose value is not a number', () => {
+      // G1 Xabc used to yield params.x === NaN, which propagated all the way into
+      // the bounding box and the camera frustum.
+      const cmd = parse('G1 Xabc Y5 Z1');
+      expect(cmd.gcode).toEqual('g1');
+      expect(cmd.params.x).toBeUndefined();
+      expect(cmd.params.y).toEqual(5);
+      expect(cmd.params.z).toEqual(1);
+    });
+
+    test('drops a param with no value at all', () => {
+      const cmd = parse('G1 X Y5');
+      expect(cmd.params.x).toBeUndefined();
+      expect(cmd.params.y).toEqual(5);
+    });
+
+    test('drops a param whose value overflows to Infinity', () => {
+      // The tokenizer splits on letters, so exponent notation is not a route to
+      // Infinity here; an absurdly long digit run is.
+      const huge = '1' + '0'.repeat(400);
+      const cmd = parse(`G1 X${huge} Y-${huge} Z2`);
+      expect(cmd.params.x).toBeUndefined();
+      expect(cmd.params.y).toBeUndefined();
+      expect(cmd.params.z).toEqual(2);
+    });
+
+    test('keeps finite values of every shape', () => {
+      const cmd = parse('G1 X-0.5 Y0 Z100 E-.27245');
+      expect(cmd.params).toEqual({ x: -0.5, y: 0, z: 100, e: -0.27245 });
+    });
+  });
+
   test('produces an empty command for a blank line', () => {
     const cmd = parse('   ');
     expect(cmd.gcode).toEqual('');
@@ -216,13 +249,12 @@ describe('parseCommand tokenizing', () => {
     expect(cmd.params).toEqual({});
   });
 
-  test('treats letters in free text as parameters, as it always has', () => {
-    // M117 style messages have no value after each letter, so each becomes NaN.
-    // Preserved deliberately: the previous regex split behaved the same way.
+  test('drops valueless letters in free text instead of storing NaN params', () => {
+    // M117 style messages have no value after each letter, so each parses to NaN.
+    // Those are no longer stored: params only ever hold finite numbers now.
     const cmd = parse('M117 Hi');
     expect(cmd.gcode).toEqual('m117');
-    expect(Object.keys(cmd.params)).toEqual(['h', 'i']);
-    expect(cmd.params.h).toBeNaN();
+    expect(cmd.params).toEqual({});
   });
 });
 

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'vitest';
-import { GCodeCommand } from '../gcode-parser';
+import { GCodeCommand, Parser } from '../gcode-parser';
 import { Interpreter } from '../interpreter';
 import { Job } from '../job';
 import { PathType } from '../path';
@@ -317,4 +317,109 @@ test('.t7 sets the tool to 7', () => {
   interpreter.t7(command, job);
 
   expect(job.state.tool).toEqual(7);
+});
+
+describe('malformed coordinates through the whole pipeline', () => {
+  const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
+  const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);
+  // The vertices the final command contributed, without the lead-in move or the
+  // implicit start point at the origin.
+  const tailVertices = (setup: string[], last: string) => {
+    const before = allVertices(run(setup.join('\n'))).length;
+    return allVertices(run([...setup, last].join('\n'))).slice(before);
+  };
+
+  test('a malformed coordinate leaves the job state finite', () => {
+    // Before validation at the parser boundary, Xabc parsed to NaN and `x ?? state.x`
+    // kept it (?? only catches null/undefined), poisoning the state from there on.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G1 Xabc Y20 E1'].join('\n'));
+
+    expect(job.state.x).toEqual(10);
+    expect(job.state.y).toEqual(20);
+    expect(Number.isFinite(job.state.x)).toBe(true);
+  });
+
+  test('a malformed coordinate does not poison the bounding box', () => {
+    const job = run(['G1 X10 Y10 Z1 E1', 'G1 Xabc Y20 E1', 'G1 X30 Y30 E1'].join('\n'));
+
+    expect(job.boundingBox.isValid).toBe(true);
+    expect(job.boundingBox.corners).toEqual({
+      min: expect.objectContaining({ x: 10, y: 10, z: 1 }),
+      max: expect.objectContaining({ x: 30, y: 30, z: 1 })
+    });
+  });
+
+  test('an overflowing coordinate does not stretch the bounding box to Infinity', () => {
+    const huge = '1' + '0'.repeat(400);
+    const job = run(['G1 X10 Y10 Z1 E1', `G1 X${huge} E1`, 'G1 X30 Y30 E1'].join('\n'));
+
+    expect(job.boundingBox.size).toEqual(expect.objectContaining({ x: 20, y: 20, z: 0 }));
+  });
+
+  test('an arc emits only finite segment points', () => {
+    // A half circle of radius 5 -- enough arc length to go through the segment loop.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1'].join('\n'));
+
+    const points = job.paths.flatMap((path) => path.vertices);
+    expect(points.length).toBeGreaterThan(3 * 3);
+    expect(points.every((value) => Number.isFinite(value))).toBe(true);
+    expect(job.boundingBox.isValid).toBe(true);
+  });
+
+  test('an arc ending on X0 or Y0 moves there instead of keeping the previous position', () => {
+    // g2 used `x || state.x`, so a legitimate 0 endpoint was falsy and silently
+    // discarded. This is ordinary valid gcode, not a malformed-input case.
+    const job = run(['G1 X10 Y10 Z5 E1', 'G2 X0 Y0 I-5 J-5 E1'].join('\n'));
+
+    expect(job.state.x).toEqual(0);
+    expect(job.state.y).toEqual(0);
+  });
+
+  test('an arc ending on Z0 moves there instead of keeping the previous height', () => {
+    const job = run(['G1 X10 Y10 Z5 E1', 'G2 X20 Y10 Z0 I5 J0 E1'].join('\n'));
+
+    expect(job.state.z).toEqual(0);
+  });
+
+  test('a degenerate R-mode whole circle emits the endpoint and no arc', () => {
+    // start === end in R mode leaves dSquared === 0, so the centre is undefined.
+    // The arc is skipped deliberately rather than rendered from NaN centres.
+    const arcVertices = tailVertices(['G1 X10 Y10 Z1 E1'], 'G2 X10 Y10 R5 E1');
+
+    expect(arcVertices).toEqual([10, 10, 1]); // the endpoint only, no intermediate points
+  });
+
+  test('a degenerate R-mode whole circle terminates and emits only finite points', () => {
+    // Every param here is finite, but deltaX/deltaY are 0 so the R block divides by
+    // dSquared === 0: hDivD is Infinity and i/j come out NaN.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X10 Y10 R5 E1'].join('\n'));
+
+    const points = job.paths.flatMap((path) => path.vertices);
+    expect(points.every((value) => Number.isFinite(value))).toBe(true);
+    expect(job.boundingBox.isValid).toBe(true);
+  });
+
+  test('arc offsets that overflow the radius do not blow up the vertex buffer', () => {
+    // I/J near Number.MAX_VALUE make arcRadius Infinity. On a whole circle totalArc is
+    // 2*PI rather than 0, so totalSegments is Infinity instead of NaN and
+    // `moveIdx < totalSegments - 1` never becomes false. Without the guard the loop
+    // pushes vertices until the array hits its length limit and throws
+    // `RangeError: Invalid array length`, aborting execute() and losing the whole job.
+    const huge = '1' + '0'.repeat(308);
+    const job = run(['G1 X10 Y10 Z1 E1', `G2 X10 Y10 I${huge} J${huge} E1`].join('\n'));
+
+    const points = job.paths.flatMap((path) => path.vertices);
+    expect(points.every((value) => Number.isFinite(value))).toBe(true);
+    expect(job.boundingBox.isValid).toBe(true);
+  });
+
+  test('an arc with a malformed endpoint still produces only finite points', () => {
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 Xabc Y20 I5 J0 E1'].join('\n'));
+
+    const points = job.paths.flatMap((path) => path.vertices);
+    expect(points.length).toBeGreaterThan(0);
+    expect(points.every((value) => Number.isFinite(value))).toBe(true);
+    expect(job.boundingBox.isValid).toBe(true);
+    expect(job.boundingBox.corners?.min.x).not.toBeNaN();
+  });
 });

--- a/src/gcode-parser.ts
+++ b/src/gcode-parser.ts
@@ -279,7 +279,14 @@ export class Parser {
         gcode = letter.toLowerCase() + Number(value);
         isFirstWord = false;
       } else {
-        params[letter.toLowerCase()] = parseFloat(value);
+        // Validate at the boundary: `X`, `Xabc` and overflowing digit runs parse to
+        // NaN/Infinity. Drop the param instead of storing a poisoned value -- an absent
+        // param is handled everywhere downstream (`x ?? state.x`), a NaN is not: it would
+        // latch into the job state and from there into every later vertex.
+        const parsed = parseFloat(value);
+        if (Number.isFinite(parsed)) {
+          params[letter.toLowerCase()] = parsed;
+        }
       }
 
       i = end;

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -133,6 +133,8 @@ export class Interpreter {
   g2(command: GCodeCommand, job: Job): void {
     const { x, y, z, e } = command.params;
     let { i, j, r } = command.params;
+    // Set when the arc cannot be described at all, so only the endpoint is emitted.
+    let arcIsDegenerate = false;
     const { state } = job;
 
     const cw = command.gcode === 'g2';
@@ -158,23 +160,24 @@ export class Interpreter {
 
       const dSquared = Math.pow(deltaX, 2) + Math.pow(deltaY, 2);
       const hSquared = Math.pow(r, 2) - dSquared / 4;
-      // if (dSquared == 0 || hSquared < 0) {
-      //   return { position: { x: x, y: z, z: y }, points: [] }; //we'll abort the render and move te position to the new position.
-      // }
-      let hDivD = Math.sqrt(hSquared / dSquared);
 
-      // Ref RRF DoArcMove for details
-      if ((cw && r < 0.0) || (!cw && r > 0.0)) {
-        hDivD = -hDivD;
+      // R mode cannot describe a whole circle: with start == end the centre is
+      // undefined, and hSquared / dSquared divides by zero, which used to make i/j NaN
+      // and poison every derived value. Skip the arc and move straight to the endpoint.
+      // (hSquared < 0 needs no guard: r was just clamped to minR, so it cannot go
+      // negative.) This replaces the guard that was commented out here.
+      if (dSquared === 0) {
+        arcIsDegenerate = true;
+      } else {
+        let hDivD = Math.sqrt(hSquared / dSquared);
+
+        // Ref RRF DoArcMove for details
+        if ((cw && r < 0.0) || (!cw && r > 0.0)) {
+          hDivD = -hDivD;
+        }
+        i = deltaX / 2 + deltaY * hDivD;
+        j = deltaY / 2 - deltaX * hDivD;
       }
-      i = deltaX / 2 + deltaY * hDivD;
-      j = deltaY / 2 - deltaX * hDivD;
-      // } else {
-      //     //the radial point is an offset from the current position
-      //     ///Need at least on point
-      //     if (i == 0 && j == 0) {
-      //         return { position: { x: x, y: y, z: z }, points: [] }; //we'll abort the render and move te position to the new position.
-      //     }
     }
 
     const wholeCircle = state.x == x && state.y == y;
@@ -214,20 +217,31 @@ export class Interpreter {
     // calculate segments
     let currentAngle = arcCurrentAngle;
 
-    for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
-      currentAngle += arcAngleIncrement;
-      px = centerX + arcRadius * Math.cos(currentAngle);
-      py = centerY + arcRadius * Math.sin(currentAngle);
-      pz += zStep;
-      currentPath.addPoint(px, py, pz);
-      if (pathType === PathType.Extrusion) {
-        job.boundingBox.update(px, py, pz);
+    // A degenerate arc leaves totalSegments non-finite even though every param was
+    // finite: an R-mode whole circle divides by dSquared === 0, and offsets near
+    // Number.MAX_VALUE overflow arcRadius. NaN already skipped the loop (NaN - 1
+    // fails the condition), but Infinity ran until the vertex array hit its length
+    // limit and threw, aborting the whole job. Emit no intermediate points in either
+    // case and fall through to the endpoint below.
+    if (!arcIsDegenerate && Number.isFinite(totalSegments)) {
+      for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
+        currentAngle += arcAngleIncrement;
+        px = centerX + arcRadius * Math.cos(currentAngle);
+        py = centerY + arcRadius * Math.sin(currentAngle);
+        pz += zStep;
+        currentPath.addPoint(px, py, pz);
+        if (pathType === PathType.Extrusion) {
+          job.boundingBox.update(px, py, pz);
+        }
       }
     }
 
-    state.x = x || state.x;
-    state.y = y || state.y;
-    state.z = z || state.z;
+    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
+    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
+    // rejecting NaN here by accident, which `??` does not do.
+    state.x = x ?? state.x;
+    state.y = y ?? state.y;
+    state.z = z ?? state.z;
 
     currentPath.addPoint(state.x, state.y, state.z);
     if (pathType === PathType.Extrusion) {


### PR DESCRIPTION
Supersedes the branded-`FiniteNumber` version of this PR. Stacked on #364 — the two approaches are layered, not alternatives, as @sophiedeziel pointed out.

## Why the parser is the right boundary

`parseFloat('abc')` yields `NaN`, and NaN is *absorbing*, not diluting:

```
after NaN,           min = NaN
after 2 good points, min = NaN     ← never recovers
isValid?             true          ← min.x !== Infinity, and NaN !== Infinity
NaN ?? 5 = NaN                     ← state.x = x ?? state.x keeps it
```

So one malformed word permanently broke the bounding box no matter how many valid extrusions followed, `isValid` still reported `true`, and because `??` doesn't catch NaN the job state stayed poisoned — every later vertex was NaN too. User-visible result: a blank viewport with no error.

Severity order is geometry > state > bounding box. Guarding `BoundingBox.update` alone (#364) could never be enough, because `Path.addPoint` is an unguarded sink one line above it. One check at the parser covers state, vertex buffer and bounding box together.

## Why not the branded type

The earlier version of this PR added a branded `FiniteNumber` across `GCodeParameters`, `State` and `BoundingBox` — 236 lines and a new module. It's been dropped:

- It fixed nothing the runtime check doesn't, and the guarantee was partial anyway: arithmetic strips the brand, so the arc path re-validated at runtime regardless.
- It changed the public API. Reads were fine (`FiniteNumber` is assignable to `number`), but anyone *constructing* commands for `Interpreter.execute` — a custom parser, a non-Marlin dialect, downstream test fixtures — would have needed `finiteNumber()` and an `undefined` check. `Parser` and `GCodeCommand` are both public exports.

Smuggling an API change in behind a bug fix isn't worth it. If we later grow more numeric surface (CNC dialects, laser, more arc math), the brand is worth revisiting on its own merits.

## What's here

**`gcode-parser.ts`** — drop params that don't parse to a finite number. `G1 Xabc Y20` now leaves `params.x` undefined, so `x ?? state.x` keeps the last good X.

**`interpreter.ts`** — three arc bugs the parser can't reach:

1. **`x || state.x` → `x ?? state.x`** for the arc endpoint. An arc ending on X0, Y0 or Z0 silently kept the previous coordinate. **This one fires on ordinary valid gcode** and is arguably the most impactful fix in the PR. It is only safe *because* of the parser change: `||` was rejecting NaN here by accident, and `??` does not. The two changes look independent but aren't.
2. **`dSquared === 0`** — an R-mode whole circle divides by zero, making `i`/`j` NaN. Now guarded explicitly, replacing the guard that had been sitting commented out at that exact spot. `hSquared < 0` needs no guard: `r` is clamped to `minR` just above.
3. **Non-finite `totalSegments`** — I/J offsets near `Number.MAX_VALUE` overflow `arcRadius`, and on a whole circle `totalArc` is 2π rather than 0, so `totalSegments` came out `Infinity`. The loop then pushed vertices until the array hit its length limit and threw `RangeError: Invalid array length` after ~800ms, aborting `execute()` and losing the whole job.

## A note on the arc analysis

My first attempt guarded each arc point with a finiteness check. That was **dead code** — probing it showed why:

| arc math | `totalSegments` | loop body |
|---|---|---|
| NaN centres (R-mode whole circle) | `NaN` | never runs — `0 < NaN - 1` is false |
| huge I/J on a whole circle | `Infinity` | runs ~2³² times, then throws |
| normal | 10 | runs |

NaN kills the loop condition before it can reach `addPoint`, and when `arcRadius` is finite, `|i|`,`|j|` are bounded under ~1.3e154 so `centerX` can't overflow. The guard belongs on `totalSegments`, before the loop.

## Behaviour change (user visible)

Params that used to be stored as `NaN` are now **absent**. Consumers reading `cmd.params.<letter>` must handle `undefined` where they previously got `NaN`. Both are falsy and both fail `> 0`, so interpreter paths are unaffected. `M117 Hi` no longer stores `h`/`i` as NaN params — one characterization test was updated for this.

## Verification

- 254 tests passing; coverage thresholds green; Prettier clean; `tsc` at the same 7 pre-existing errors as the base branch.
- Reverting `gcode-parser.ts` → 5 tests red. Reverting `interpreter.ts` → 3 tests red.
- The degenerate-whole-circle test passes on baseline too, deliberately: NaN already skipped the loop by accident, so it's a characterization test locking in the now-explicit behaviour.

## Not in scope

The inverted `zDist` in the same function — helical arcs interpolate Z *away* from the target, so a Z1→Z3 arc walks its intermediate points down to Z−0.8 before snapping to Z3 — is being fixed in another PR, so line 210 is left byte-identical to the base. Whoever fixes it should switch `z || state.z` to `??` in the same change, to match the endpoint fix here.
