### PR TITLE
Failing test: exponent notation is split into a value plus a phantom E extrusion (#368)

### DIFF
--- a/src/__tests__/gcode-parser.ts
+++ b/src/__tests__/gcode-parser.ts
@@ -140,6 +140,21 @@ test('gcode commands without gcode should result in a command with empty string 
 describe('parseCommand tokenizing', () => {
   const parse = (line: string) => new Parser().parseCommand(line) as GCodeCommand;
 
+  // FAILING ON PURPOSE -- see #368.
+  // The tokenizer splits a word at every letter, so the `e` in an exponent is read as a
+  // separate E parameter. That is not merely lossy: Interpreter derives the path type
+  // from `e` (`e ? Extrusion : Travel`), so a travel move silently renders as extruded
+  // filament and inflates extrusionDistance.
+  //
+  // The expectation below is the fix in option 3 of #368 (recognize exponent notation in
+  // the tokenizer). If the team picks option 2 instead (reject a word whose value is
+  // followed by a valueless letter), change this to expect x to be absent. Either way the
+  // fabricated `e` must go.
+  test('reads exponent notation as a single value, not a value plus an E parameter', () => {
+    const cmd = parse('G1 X12e5 Y5');
+    expect(cmd.params).toEqual({ x: 1200000, y: 5 });
+  });
+
   test('reads a command and its parameters', () => {
     const cmd = parse('G1 X100.5 Y-20 E0.04 F1200');
     expect(cmd.gcode).toEqual('g1');


### PR DESCRIPTION
Adds a failing test for #368. **CI will be red on this branch by design — do not merge as is.**

The point is to pin the bug down as executable spec rather than prose, so whoever fixes the tokenizer has a target that goes green.

## The failure

```
AssertionError: expected { x: 12, e: 5, y: 5 } to deeply equal { x: 1200000, y: 5 }
```

`G1 X12e5 Y5` — the tokenizer splits a word at every letter, so the `e` of the exponent is read as a separate `E` parameter.

## Why the fabricated `e` is the damaging part

This isn't just a lossy coordinate. `Interpreter` derives the path type from `e`:

```ts
const pathType = e ? PathType.Extrusion : PathType.Travel;
```

So the line is interpreted as a move to X12 **that extrudes 5mm of filament**:

- a travel move renders as extruded filament, drawing a solid line where the print has none
- `extrusionDistance` is inflated by 5
- the segment lands in an extrusion path, so it also stretches the bounding box

All silent — no parse error, no warning.

## About the expectation

The test asserts option 3 from #368 (recognize exponent notation in the tokenizer), i.e. `x: 1200000` and no `e`. If the team prefers option 2 (reject a word whose value is followed by a valueless letter), change the expectation to `x` being absent. Either resolution has to remove the fabricated `e`, which is what the test really guards.

Option 1 in #368 is "leave it, document it" — if that wins, close this PR and land a characterization test asserting the current `{x: 12, e: 5, y: 5}` instead.

## Likelihood

Low: G-code has no exponent notation, and no slicer emits it. The realistic route is a generator doing naive float-to-string on an extreme coordinate, since `String()` reaches exponent form by itself — `String(1e21)` is `'1e+21'`, `String(1e-7)` is `'1e-7'`.

## Relationship to #367

Independent and pre-existing; this branch is off `develop`, not the #367 stack. #367 does not change this behavior. The characterization test for it was deliberately kept out of #367 so the current behavior isn't locked in before this is decided.
