### PR TITLE
Fix arc Z interpolation: inverted sign, and Z0 treated as absent

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -394,6 +394,24 @@ describe('malformed coordinates through the whole pipeline', () => {
     expect(Math.max(...zs)).toBeGreaterThan(1);
   });
 
+  test('an arc descending to Z0 spreads the drop across its segments', () => {
+    // `z || state.z` made a Z0 target fall back to the current height, so zDist was 0
+    // and every intermediate point sat flat at Z5 before the endpoint snapped to Z0.
+    const zs = zsOf(tailVertices(['G1 X10 Y10 Z5 E1'], 'G2 X20 Y10 Z0 I5 J0 E1'));
+
+    expect(zs.some((value) => value > 0 && value < 5)).toBe(true);
+    expect(zs.every((value) => Number.isFinite(value))).toBe(true);
+  });
+
+  test('a malformed Z on an arc leaves the intermediate points finite', () => {
+    // `??` propagates NaN where `||` absorbed it, so this relies on the parser
+    // dropping the param entirely. Guards the coupling between the two changes.
+    const zs = zsOf(tailVertices(['G1 X10 Y10 Z5 E1'], 'G2 X20 Y10 Zabc I5 J0 E1'));
+
+    expect(zs.every((value) => Number.isFinite(value))).toBe(true);
+    expect(zs.every((value) => value === 5)).toBe(true);
+  });
+
   test('a degenerate R-mode whole circle emits the endpoint and no arc', () => {
     // start === end in R mode leaves dSquared === 0, so the centre is undefined.
     // The arc is skipped deliberately rather than rendered from NaN centres.

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -324,6 +324,7 @@ describe('malformed coordinates through the whole pipeline', () => {
   const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);
   // The vertices the final command contributed, without the lead-in move or the
   // implicit start point at the origin.
+  const zsOf = (vertices: number[]) => vertices.filter((_, index) => index % 3 === 2);
   const tailVertices = (setup: string[], last: string) => {
     const before = allVertices(run(setup.join('\n'))).length;
     return allVertices(run([...setup, last].join('\n'))).slice(before);
@@ -379,6 +380,18 @@ describe('malformed coordinates through the whole pipeline', () => {
     const job = run(['G1 X10 Y10 Z5 E1', 'G2 X20 Y10 Z0 I5 J0 E1'].join('\n'));
 
     expect(job.state.z).toEqual(0);
+  });
+
+  test('a helical arc interpolates Z towards the target, not away from it', () => {
+    // zDist was current - target, so a climb from Z1 to Z3 descended to Z-0.97 across
+    // its 31 intermediate points and only reached Z3 at the endpoint.
+    const zs = zsOf(tailVertices(['G1 X10 Y10 Z1 E1'], 'G2 X20 Y10 Z3 I5 J0 E1'));
+
+    expect(zs.length).toBeGreaterThan(2);
+    expect(Math.min(...zs)).toBeGreaterThanOrEqual(1);
+    expect(Math.max(...zs)).toBeLessThanOrEqual(3);
+    // and it should actually climb, not sit flat at the start height
+    expect(Math.max(...zs)).toBeGreaterThan(1);
   });
 
   test('a degenerate R-mode whole circle emits the endpoint and no arc', () => {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -210,7 +210,12 @@ export class Interpreter {
     // target - current. This was the other way round, so a helical arc climbing
     // Z1 -> Z3 walked its intermediate points down to Z-0.97 and only landed on Z3 at
     // the endpoint, leaving a visible spike in the rendered path.
-    const zDist = (z || state.z) - state.z;
+    //
+    // `??` not `||`: Z0 is a legitimate target, and `|| state.z` turned a descent to
+    // Z0 into a flat arc at the old height. This matches the endpoint assignment
+    // below, and is only safe because the parser now drops non-finite params -- `||`
+    // was rejecting NaN here by accident, and `??` does not.
+    const zDist = (z ?? state.z) - state.z;
     const zStep = zDist / totalSegments;
 
     // get points for the arc

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -207,7 +207,10 @@ export class Interpreter {
     let arcAngleIncrement = totalArc / totalSegments;
     arcAngleIncrement *= cw ? -1 : 1;
 
-    const zDist = state.z - (z || state.z);
+    // target - current. This was the other way round, so a helical arc climbing
+    // Z1 -> Z3 walked its intermediate points down to Z-0.97 and only landed on Z3 at
+    // the endpoint, leaving a visible spike in the rendered path.
+    const zDist = (z || state.z) - state.z;
     const zStep = zDist / totalSegments;
 
     // get points for the arc


### PR DESCRIPTION
Two independent bugs on one line of `Interpreter.g2`, one commit each. Stacked on #367 — see *Why this stacks* below.

```ts
const zDist = state.z - (z || state.z);   // before
const zDist = (z ?? state.z) - state.z;   // after
```

## 1. The sign is inverted (82e0481)

`zDist` was computed as *current − target*, so the intermediate points of a helical arc walked **away** from the requested height. A `G2` climbing Z1 → Z3 on current `develop`:

```
0.94 0.87 0.81 ... 0.05 -0.02 -0.08 ... -0.91 -0.97 3.00
```

31 points descending to Z−0.97, then a jump to Z3 at the endpoint.

**This needs no malformed input.** Every Z-changing arc has rendered this way since #211 introduced the line, and `|| state.z` masked it only when the target happened to be 0. Slicers with arc fitting emit these routinely — vase mode, spirals, anything with `ARC_SUPPORT` enabled — so it is likely visible to users today. Of everything in this batch of PRs, this is the one that affects ordinary valid G-code.

## 2. `||` treats Z0 as absent (1459efc)

Z0 is a legitimate target, but `z || state.z` fell back to the current height, so `zDist` was 0 and a descent to Z0 sat flat at the old height until the endpoint snapped down. The endpoint assignment already uses `??`; this makes the two agree.

## Why this stacks on #367

The `??` half is **not safe on `develop` alone**. Without the parser validation in #367, a malformed Z still reaches the interpreter as `NaN`:

```
develop parses Zabc as: null   isNaN: true
  with || : 0      ← absorbed by accident
  with ?? : NaN    ← propagates
```

So `||` was doing NaN rejection by accident, and `??` doesn't. There is a test covering exactly this coupling — it feeds an arc a malformed Z and asserts the intermediate points stay finite.

The sign fix alone has no such dependency and could be cherry-picked to `develop` today if you want it out ahead of the stack. Say so and I'll split it.

## Verification

- 259 tests passing; coverage thresholds green; Prettier clean.
- Each commit is independently red-before-green: reverting the sign fails `a helical arc interpolates Z towards the target` with `expected -0.9735 to be >= 1`; reverting the `??` fails `an arc descending to Z0 spreads the drop across its segments`.

## Note on provenance

This was originally part of #367 and I backed it out, believing a merged performance PR had already fixed it. It hadn't — none of #348–#353 touch `interpreter.ts` (they cluster on `extrusion-geometry.ts` and `gcode-parser.ts`), the `zDist` line is unchanged since #211, and no remote branch carries any variant of the fix.
