### PR TITLE
Fix crash when extrusionColor array is shorter than the tools used

### DIFF
--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -596,9 +596,7 @@ test('render falls back to the default extrusion color when no colors are config
   expect(() => sm.render()).not.toThrow();
 
   const meshes = collect(sm, isBatchedMesh);
-  expect((meshes[0].material as any).uniforms.uColor.value.getHex()).toBe(
-    SceneManager.defaultExtrusionColor.getHex()
-  );
+  expect((meshes[0].material as any).uniforms.uColor.value.getHex()).toBe(SceneManager.defaultExtrusionColor.getHex());
   warn.mockRestore();
 });
 

--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -576,6 +576,32 @@ test('render falls back to a configured color when a tool has none of its own', 
   warn.mockRestore();
 });
 
+test('render only warns once per tool index missing a configured color', () => {
+  const job = jobFromGCode(['T2', ...LAYERED_GCODE.split('\n')].join('\n'));
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const sm = createSceneManager({ renderTubes: true, extrusionColor: ['#00ff00'] }, job);
+
+  sm.render();
+  sm.render();
+
+  expect(warn).toHaveBeenCalledTimes(1);
+  warn.mockRestore();
+});
+
+test('render falls back to the default extrusion color when no colors are configured at all', () => {
+  const job = jobFromGCode(['T2', ...LAYERED_GCODE.split('\n')].join('\n'));
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const sm = createSceneManager({ renderTubes: true, extrusionColor: [] }, job);
+
+  expect(() => sm.render()).not.toThrow();
+
+  const meshes = collect(sm, isBatchedMesh);
+  expect((meshes[0].material as any).uniforms.uColor.value.getHex()).toBe(
+    SceneManager.defaultExtrusionColor.getHex()
+  );
+  warn.mockRestore();
+});
+
 test('paths too short for a tube geometry are skipped', () => {
   const job = jobFromGCode(LAYERED_GCODE);
   const stub = new Path(PathType.Extrusion);

--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -560,6 +560,22 @@ test('render as tubes creates a batched mesh with the per-tool color', () => {
   expect((meshes[0].material as any).uniforms.uColor.value.getHex()).toBe(0x00ff00);
 });
 
+test('render falls back to a configured color when a tool has none of its own', () => {
+  // T2 selects a tool index one past the single color supplied, which used to
+  // read extrusionColor[2] as undefined and throw inside renderPathsAsTubes.
+  const job = jobFromGCode(['T2', ...LAYERED_GCODE.split('\n')].join('\n'));
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const sm = createSceneManager({ renderTubes: true, extrusionColor: ['#00ff00'] }, job);
+
+  expect(() => sm.render()).not.toThrow();
+
+  const meshes = collect(sm, isBatchedMesh);
+  expect(meshes).toHaveLength(1);
+  expect((meshes[0].material as any).uniforms.uColor.value.getHex()).toBe(0x00ff00);
+  expect(warn).toHaveBeenCalledWith('No extrusionColor configured for tool index 2, falling back to another color');
+  warn.mockRestore();
+});
+
 test('paths too short for a tube geometry are skipped', () => {
   const job = jobFromGCode(LAYERED_GCODE);
   const stub = new Path(PathType.Extrusion);

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -903,7 +903,7 @@ export class SceneManager {
     if (this.renderExtrusion) {
       this.job.toolPaths.forEach((toolPaths, index) => {
         const color = Array.isArray(this._extrusionColor)
-          ? this._extrusionColor[index] ?? this.fallbackExtrusionColor(index)
+          ? (this._extrusionColor[index] ?? this.fallbackExtrusionColor(index))
           : this._extrusionColor;
         if (this.renderTubes) {
           this.renderPathsAsTubes(toolPaths.slice(this.renderPathIndex, endPathNumber), color);

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -151,6 +151,8 @@ export class SceneManager {
   static readonly defaultExtrusionColor = new Color('hotpink');
   /** Current extrusion color(s) */
   private _extrusionColor: Color | Color[] = SceneManager.defaultExtrusionColor;
+  /** Tool indices already warned about missing an entry in the extrusionColor array */
+  private warnedMissingExtrusionColorIndices = new Set<number>();
   /** Animation frame ID */
   private animationFrameId?: number;
   /** Current path index for animated rendering */
@@ -900,7 +902,9 @@ export class SceneManager {
 
     if (this.renderExtrusion) {
       this.job.toolPaths.forEach((toolPaths, index) => {
-        const color = Array.isArray(this._extrusionColor) ? this._extrusionColor[index] : this._extrusionColor;
+        const color = Array.isArray(this._extrusionColor)
+          ? this._extrusionColor[index] ?? this.fallbackExtrusionColor(index)
+          : this._extrusionColor;
         if (this.renderTubes) {
           this.renderPathsAsTubes(toolPaths.slice(this.renderPathIndex, endPathNumber), color);
         } else {
@@ -908,6 +912,23 @@ export class SceneManager {
         }
       });
     }
+  }
+
+  /**
+   * Falls back to a usable color when extrusionColor is an array with no entry for a tool index
+   * @param toolIndex - Tool index missing a configured color
+   * @returns The array's last configured color, or the default extrusion color if the array is empty
+   * @remarks
+   * A gcode file can reference more tools than the caller supplied colors for (e.g. a color array
+   * sized for 2 tools rendering a 3-tool file). Warns once per tool index instead of throwing.
+   */
+  private fallbackExtrusionColor(toolIndex: number): Color {
+    if (!this.warnedMissingExtrusionColorIndices.has(toolIndex)) {
+      this.warnedMissingExtrusionColorIndices.add(toolIndex);
+      console.warn(`No extrusionColor configured for tool index ${toolIndex}, falling back to another color`);
+    }
+    const colors = this._extrusionColor as Color[];
+    return colors[colors.length - 1] ?? SceneManager.defaultExtrusionColor;
   }
 
   /**


### PR DESCRIPTION
## Problem

Loading a gcode file with a tool index beyond the length of a configured `extrusionColor` array threw:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'getHex')
    at renderPathsAsTubes
```

Found while investigating a report on #363 (a separate NaN bounding-box issue) — this crash reproduces on `develop` independently of that one.

## Root cause

`renderPaths()` looks up the color for a tool by array index: `this._extrusionColor[index]`. `index` comes from `job.toolPaths`, which is indexed by the gcode's actual tool number (T0, T1, T2, ...), not by how many colors the caller configured. The demo app's presets illustrate this exactly — e.g. the 3DBenchy preset sets `extrusionColor: ['#95dfa1']`, a single-color array. Any gcode that switches to `T1` or higher then indexes past the array, returns `undefined`, which is passed straight into `renderPathsAsTubes`/`renderPathsAsLines` and crashes on `.getHex()`.

## Fix

Falls back to the array's last configured color (or the library default) when a tool index has none of its own, and warns once per missing index via `console.warn` instead of throwing.

## Testing

Added a regression test that reproduces the crash with a `T2` tool change and a single-color array, asserting it no longer throws and warns exactly once. Full suite (243 tests) and typecheck pass.
