### PR TITLE
Remove the dead toolColors option

### DIFF
--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -132,7 +132,6 @@ test('constructor applies explicit options to the instance state', () => {
       travelColor: '#336699',
       topLayerColor: '#fedcba',
       lastSegmentColor: '#446688',
-      toolColors: { 0: '#aaaaaa', 1: '#bbbbbb' },
       disableGradient: true,
       startLayer: 1,
       endLayer: 2,
@@ -155,8 +154,6 @@ test('constructor applies explicit options to the instance state', () => {
   expect((sm.extrusionColor as Color[]).map((c) => c.getHex())).toEqual([0x00ff00, 0x0000ff]);
   expect((sm.lastSegmentColor as Color).getHex()).toBe(0x446688);
   expect((sm.boundingBoxColor as Color).getHex()).toBe(0xff0000);
-  expect((sm as any)._toolColors[0].getHex()).toBe(0xaaaaaa);
-  expect((sm as any)._toolColors[1].getHex()).toBe(0xbbbbbb);
 
   expect(sm.buildVolume?.x).toBe(150);
   expect(sm.buildVolume?.y).toBe(100);

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -75,8 +75,6 @@ export type SceneManagerOptions = {
   topLayerColor?: ColorRepresentation;
   /** Color for travel moves */
   travelColor?: ColorRepresentation;
-  /** Colors for different tools */
-  toolColors?: Record<number, ColorRepresentation>;
   /** Disable color gradient between layers */
   disableGradient?: boolean;
   /** Width of extruded material */
@@ -173,8 +171,6 @@ export class SceneManager {
   private _topLayerColor?: Color;
   /** Last segment color */
   private _lastSegmentColor?: Color;
-  /** Tool-specific colors */
-  private _toolColors: Record<number, Color> = {};
   /** Last render time in milliseconds */
   lastRenderTime = 0;
   /** Whether to render in wireframe mode */
@@ -238,13 +234,6 @@ export class SceneManager {
     if (opts.lastSegmentColor !== undefined) {
       this.lastSegmentColor = new Color(opts.lastSegmentColor);
     }
-    if (opts.toolColors) {
-      this._toolColors = {};
-      for (const [key, value] of Object.entries(opts.toolColors)) {
-        this._toolColors[parseInt(key)] = new Color(value);
-      }
-    }
-
     if (opts.disableGradient !== undefined) {
       this.disableGradient = opts.disableGradient;
     }


### PR DESCRIPTION
Part of #356 — the `toolColors` half.

`toolColors` was accepted by `SceneManager`, converted to `Color`s and stored on `_toolColors`, but no render path ever read it. Setting it had zero visual effect and no warning.

The render-side use was removed in 935f03e (#125 "Feature/multi color"), intentionally superseded by `extrusionColor` accepting a map of colors, which covers the same use case. Its public accessors were deleted then too; only the constructor plumbing and a storage round-trip test survived, which green-lit the dead code.

**Breaking change for v3.0:** `toolColors` is gone from `SceneManagerOptions`. Pass per-tool colors via `extrusionColor` instead.

The other three options in #356 (`topLayerColor`, `lastSegmentColor`, `disableGradient`) are untouched here. A `topLayerColor` re-implementation was briefly on this branch and has been dropped — it surfaced a live bug in how `SceneManager.materials` is indexed (splitting a tool into two draw calls breaks the tool→material mapping the `extrusionColor` setter relies on, producing wrong colors in tube mode), which wants resolving first. Related: #375.

## Verification

- `npm run typeCheck` — clean
- `npm test` — 229 passed