### PR TITLE
Extract arc tessellation into ArcTessellator with chord-tolerance segmentation

### DIFF
--- a/src/__tests__/arc-tessellator.ts
+++ b/src/__tests__/arc-tessellator.ts
@@ -1,0 +1,151 @@
+import { test, expect, describe } from 'vitest';
+import { ArcTessellator, ArcMove, ArcPoint } from '../arc-tessellator';
+
+describe('ArcTessellator', () => {
+  const tessellator = new ArcTessellator();
+
+  function tessellate(start: ArcPoint, move: ArcMove, units: 'mm' | 'in' = 'mm'): ArcPoint[] {
+    const points: ArcPoint[] = [];
+    tessellator.tessellate(start, move, (x, y, z) => points.push({ x, y, z }), units);
+    return points;
+  }
+
+  test('tessellates a counter-clockwise quarter circle onto the arc', () => {
+    // start (1,0), center (0,0), end (0,1)
+    const points = tessellate({ x: 1, y: 0, z: 0 }, { cw: false, x: 0, y: 1, i: -1, j: 0 });
+
+    expect(points.length).toBeGreaterThan(1);
+    for (const point of points) {
+      expect(Math.sqrt(point.x * point.x + point.y * point.y)).toBeCloseTo(1, 6);
+    }
+  });
+
+  test('ends exactly on the target coordinates and returns the endpoint', () => {
+    const points: ArcPoint[] = [];
+    const endPoint = tessellator.tessellate({ x: 1, y: 0, z: 0 }, { cw: false, x: 0, y: 1, i: -1, j: 0 }, (x, y, z) =>
+      points.push({ x, y, z })
+    );
+
+    expect(endPoint).toEqual({ x: 0, y: 1, z: 0 });
+    expect(points[points.length - 1]).toEqual(endPoint);
+  });
+
+  test('sweeps through opposite half-planes for cw and ccw arcs', () => {
+    const start = { x: 1, y: 0, z: 0 };
+    const move = { x: -1, y: 0, i: -1, j: 0 };
+
+    const ccw = tessellate(start, { cw: false, ...move });
+    const cw = tessellate(start, { cw: true, ...move });
+
+    // both are half circles around (0,0); ccw passes through +Y, cw through -Y
+    expect(Math.max(...ccw.map((p) => p.y))).toBeCloseTo(1, 1);
+    expect(Math.min(...cw.map((p) => p.y))).toBeCloseTo(-1, 1);
+  });
+
+  test('keeps omitted axes at their start values', () => {
+    const points = tessellate({ x: 3, y: 4, z: 5 }, { cw: true, i: 1, j: 0 });
+
+    const endPoint = points[points.length - 1];
+    expect(endPoint).toEqual({ x: 3, y: 4, z: 5 });
+  });
+
+  test('emits only the endpoint for a degenerate R-mode whole circle', () => {
+    const points = tessellate({ x: 1, y: 1, z: 0 }, { cw: true, x: 1, y: 1, r: 5 });
+
+    expect(points).toEqual([{ x: 1, y: 1, z: 0 }]);
+  });
+
+  test('emits a single straight segment for an arc shorter than one step', () => {
+    // ~0.1 rad of sweep on r=10 is below the coarsest allowed step, so the
+    // segment count clamps to 1 and only the endpoint is emitted
+    const end = { x: 10 * Math.cos(0.1), y: 10 * Math.sin(0.1) };
+    const points = tessellate({ x: 10, y: 0, z: 0 }, { cw: false, x: end.x, y: end.y, i: -10, j: 0 });
+
+    expect(points).toEqual([{ x: end.x, y: end.y, z: 0 }]);
+  });
+
+  test('converts R mode to a clockwise arc that stays on the circle', () => {
+    const points = tessellate({ x: 0, y: 0, z: 0 }, { cw: true, x: 2, y: 0, r: 1 });
+
+    for (const point of points) {
+      const dx = point.x - 1;
+      const dy = point.y;
+      expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(1, 6);
+    }
+  });
+
+  test('converts R mode to an arc that stays on a circle through start and end', () => {
+    // r equals half the start-end distance, so the center is the midpoint (1,0)
+    const points = tessellate({ x: 0, y: 0, z: 0 }, { cw: false, x: 2, y: 0, r: 1 });
+
+    for (const point of points) {
+      const dx = point.x - 1;
+      const dy = point.y;
+      expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(1, 6);
+    }
+  });
+
+  test('interpolates Z monotonically along a helical arc', () => {
+    const points = tessellate({ x: 10, y: 0, z: 1 }, { cw: false, x: -10, y: 0, z: 3, i: -10, j: 0 });
+
+    let previousZ = 1;
+    for (const point of points) {
+      expect(point.z).toBeGreaterThan(previousZ);
+      previousZ = point.z;
+    }
+    expect(points[points.length - 1].z).toEqual(3);
+  });
+
+  test('keeps every chord within the tolerance of the true arc', () => {
+    // quarter circle of radius 100 around (0,0); default tolerance is 0.05mm
+    const points = [
+      { x: 100, y: 0, z: 0 },
+      ...tessellate({ x: 100, y: 0, z: 0 }, { cw: false, x: 0, y: 100, i: -100, j: 0 })
+    ];
+
+    for (let index = 1; index < points.length; index++) {
+      const midX = (points[index - 1].x + points[index].x) / 2;
+      const midY = (points[index - 1].y + points[index].y) / 2;
+      const sagitta = 100 - Math.sqrt(midX * midX + midY * midY);
+      expect(sagitta).toBeLessThanOrEqual(0.05 + 1e-9);
+    }
+  });
+
+  test('spends far fewer segments on large arcs than fixed-length chords would', () => {
+    // 0.5mm-long chords would put ~314 points on this arc
+    const points = tessellate({ x: 100, y: 0, z: 0 }, { cw: false, x: 0, y: 100, i: -100, j: 0 });
+
+    expect(points.length).toBeLessThan(40);
+    expect(points.length).toBeGreaterThan(10);
+  });
+
+  test('a tighter chord tolerance produces more points', () => {
+    const fine = new ArcTessellator({ chordTolerance: 0.005 });
+    const start = { x: 10, y: 0, z: 0 };
+    const move = { cw: false, x: -10, y: 0, i: -10, j: 0 };
+
+    const coarsePoints = tessellate(start, move);
+    const finePoints: ArcPoint[] = [];
+    fine.tessellate(start, move, (x, y, z) => finePoints.push({ x, y, z }));
+
+    expect(finePoints.length).toBeGreaterThan(coarsePoints.length);
+  });
+
+  test('keeps tiny circles round despite the tolerance allowing coarse steps', () => {
+    // whole circle with a radius near the tolerance; the max segment angle
+    // caps the step at 22.5 degrees, so a full turn gets at least 16 points
+    const points = tessellate({ x: 0.2, y: 0, z: 0 }, { cw: true, x: 0.2, y: 0, i: -0.2, j: 0 });
+
+    expect(points.length).toBeGreaterThanOrEqual(16);
+  });
+
+  test('emits more segments for the same arc in inches', () => {
+    const start = { x: 1, y: 0, z: 0 };
+    const move = { cw: false, x: 0, y: 1, i: -1, j: 0 };
+
+    const mm = tessellate(start, move, 'mm');
+    const inches = tessellate(start, move, 'in');
+
+    expect(inches.length).toBeGreaterThan(mm.length);
+  });
+});

--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -111,6 +111,12 @@ describe('GCodePreview', () => {
       expect(preview).toBeInstanceOf(GCodePreview);
     });
 
+    it('passes arcChordTolerance to the interpreter', () => {
+      preview = new GCodePreview({ canvas: mockCanvas, arcChordTolerance: 0.01 });
+
+      expect(Interpreter).toHaveBeenCalledWith({ arcChordTolerance: 0.01 });
+    });
+
     it('should expose renderer, parser, and job as public properties', () => {
       const options = { canvas: mockCanvas };
       preview = new GCodePreview(options);

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -114,6 +114,7 @@ describe('malformed coordinates through the whole pipeline', () => {
   const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);
   // The vertices the final command contributed, without the lead-in move or the
   // implicit start point at the origin.
+  const ysOf = (vertices: number[]) => vertices.filter((_, index) => index % 3 === 1);
   const zsOf = (vertices: number[]) => vertices.filter((_, index) => index % 3 === 2);
   const tailVertices = (setup: string[], last: string) => {
     const before = allVertices(run(setup.join('\n'))).length;
@@ -155,6 +156,22 @@ describe('malformed coordinates through the whole pipeline', () => {
     expect(points.length).toBeGreaterThan(3 * 3);
     expect(points.every((value) => Number.isFinite(value))).toBe(true);
     expect(job.boundingBox.isValid).toBe(true);
+  });
+
+  test('a G3 arc sweeps counter-clockwise where G2 sweeps clockwise', () => {
+    // The same half circle around (15,10), from west to east, in both directions.
+    // Viewed from above, G2 (clockwise) passes north of the center and G3
+    // (counter-clockwise) south. Also guards the g3 registry wiring end to end:
+    // without it G3 is silently ignored and contributes no intermediate points,
+    // and the shared handler must still flip direction per gcode.
+    const g2Ys = ysOf(tailVertices(['G1 X10 Y10 Z1 E1'], 'G2 X20 Y10 I5 J0 E1'));
+    const g3Ys = ysOf(tailVertices(['G1 X10 Y10 Z1 E1'], 'G3 X20 Y10 I5 J0 E1'));
+
+    expect(g3Ys.length).toBeGreaterThan(2);
+    expect(Math.max(...g2Ys)).toBeGreaterThan(14);
+    expect(Math.min(...g2Ys)).toBeGreaterThanOrEqual(10);
+    expect(Math.min(...g3Ys)).toBeLessThan(6);
+    expect(Math.max(...g3Ys)).toBeLessThanOrEqual(10);
   });
 
   test('an arc ending on X0 or Y0 moves there instead of keeping the previous position', () => {

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -174,6 +174,17 @@ describe('malformed coordinates through the whole pipeline', () => {
     expect(Math.max(...g3Ys)).toBeLessThanOrEqual(10);
   });
 
+  test('arcChordTolerance tunes how densely arcs are tessellated', () => {
+    const gcode = ['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1'].join('\n');
+    const runWith = (tolerance?: number) =>
+      new Interpreter({ arcChordTolerance: tolerance }).execute(new Parser().parseGCode(gcode).commands);
+
+    const defaultCount = allVertices(runWith()).length;
+
+    expect(allVertices(runWith(0.005)).length).toBeGreaterThan(defaultCount);
+    expect(allVertices(runWith(0.5)).length).toBeLessThan(defaultCount);
+  });
+
   test('an arc ending on X0 or Y0 moves there instead of keeping the previous position', () => {
     // g2 used `x || state.x`, so a legitimate 0 endpoint was falsy and silently
     // discarded. This is ordinary valid gcode, not a malformed-input case.

--- a/src/__tests__/interpreter/commands/arc-move.ts
+++ b/src/__tests__/interpreter/commands/arc-move.ts
@@ -79,16 +79,18 @@ describe('arcMove (G2/G3)', () => {
     expect(segCount(inch)).toBeGreaterThan(segCount(mm));
   });
 
-  test('a tiny arc still emits at least the endpoint (segment count clamped to 1)', () => {
-    // arcRadius * totalArc / 0.5 drops below 1 for a sub-millimetre arc; the count is
-    // clamped to 1 so the endpoint is always emitted and the loop adds no interior points.
+  test('an arc shorter than one chord step still emits the endpoint (segment count clamped to 1)', () => {
+    // A ~0.05 rad sweep on r=10 is below the chord-tolerance step (~0.2 rad), so the
+    // count is clamped to 1: the endpoint is always emitted and the loop adds no
+    // interior points. (A sub-millimetre *radius* no longer exercises the clamp: the
+    // max-segment-angle cap deliberately keeps tiny circles round instead.)
     // A travel lead-in keeps the extrusion arc on its own path so we count only its points.
-    const job = run(['G0 X10 Y10 Z1', 'G2 X10.01 Y10 I0.005 J0 E1'].join('\n'));
+    const job = run(['G0 X10 Y10 Z1', 'G2 X10.0125 Y10.4998 I10 J0 E1'].join('\n'));
 
     const arcPath = job.paths[job.paths.length - 1];
     const points = arcPath.path();
     // start-of-path point + endpoint only, no interior segments
     expect(points.length).toEqual(2);
-    expect(points[points.length - 1]).toMatchObject({ x: 10.01, y: 10 });
+    expect(points[points.length - 1]).toMatchObject({ x: 10.0125, y: 10.4998 });
   });
 });

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -42,6 +42,7 @@ describe('public API types', () => {
         | 'droppable'
         | 'keepLines'
         | 'liveRenderInterval'
+        | 'arcChordTolerance'
         // SceneManagerOptions
         | 'buildVolume'
         | 'backgroundColor'

--- a/src/arc-tessellator.ts
+++ b/src/arc-tessellator.ts
@@ -1,3 +1,5 @@
+import { Units, MM_PER_INCH } from './units';
+
 /** A point along a tessellated arc, in absolute G-code coordinates */
 export interface ArcPoint {
   x: number;
@@ -44,9 +46,6 @@ const DEFAULT_CHORD_TOLERANCE = 0.05;
  */
 const MAX_SEGMENT_ANGLE = Math.PI / 8;
 
-/** Millimeters per inch, for applying the tolerance to inch-based moves */
-const MM_PER_INCH = 25.4;
-
 /**
  * Tessellates G2/G3 arc moves into straight line segments
  *
@@ -79,7 +78,7 @@ export class ArcTessellator {
    * @returns The arc's exact endpoint (also the last point emitted). Emits at
    * least the endpoint, even for degenerate arcs.
    */
-  tessellate(start: ArcPoint, move: ArcMove, emit: EmitPoint, units: 'mm' | 'in' = 'mm'): ArcPoint {
+  tessellate(start: ArcPoint, move: ArcMove, emit: EmitPoint, units: Units = 'mm'): ArcPoint {
     const { cw, x, y, z } = move;
     let { i, j, r } = move;
     // Set when the arc cannot be described at all, so only the endpoint is emitted.

--- a/src/arc-tessellator.ts
+++ b/src/arc-tessellator.ts
@@ -1,0 +1,191 @@
+/** A point along a tessellated arc, in absolute G-code coordinates */
+export interface ArcPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Describes a G2/G3 arc move relative to a known start position */
+export interface ArcMove {
+  /** true for clockwise arcs (G2), false for counter-clockwise arcs (G3) */
+  cw: boolean;
+  /** Absolute target coordinates; an omitted axis keeps its start value */
+  x?: number;
+  y?: number;
+  z?: number;
+  /** X offset from the start point to the arc center (I/J mode) */
+  i?: number;
+  /** Y offset from the start point to the arc center (I/J mode) */
+  j?: number;
+  /** Arc radius (R mode); takes precedence over i/j when non-zero */
+  r?: number;
+}
+
+/** Receives each tessellated point in order, endpoint included */
+// eslint-disable-next-line no-unused-vars
+export type EmitPoint = (x: number, y: number, z: number) => void;
+
+/** Options for {@link ArcTessellator} */
+export interface ArcTessellatorOptions {
+  /**
+   * Maximum deviation, in millimeters, between the emitted chords and the true
+   * arc (default 0.05). Smaller values produce smoother, heavier geometry.
+   */
+  chordTolerance?: number;
+}
+
+/** Max chord deviation from the true arc, in millimeters */
+const DEFAULT_CHORD_TOLERANCE = 0.05;
+
+/**
+ * Cap on the angle a single segment may span (22.5 degrees, so a full circle
+ * gets at least 16 segments). Below chordTolerance-sized radii the tolerance
+ * alone would allow steps so coarse that small circles render as squares.
+ */
+const MAX_SEGMENT_ANGLE = Math.PI / 8;
+
+/** Millimeters per inch, for applying the tolerance to inch-based moves */
+const MM_PER_INCH = 25.4;
+
+/**
+ * Tessellates G2/G3 arc moves into straight line segments
+ *
+ * @remarks
+ * Downstream geometry only handles straight segments, so arcs are approximated
+ * by a polyline. The segment count is chosen so the chords stay within
+ * chordTolerance of the true arc: for an angular step t on a circle of radius
+ * r the worst-case gap (sagitta) is r * (1 - cos(t / 2)), so the step scales
+ * with the square root of the radius instead of linearly -- large arcs get far
+ * fewer points than fixed-length segments would, at equal visual quality.
+ * Supports both I/J center-offset mode and R radius mode, including helical
+ * arcs that change Z along the way. All arc math lives here; the interpreter
+ * routes the resulting points into paths and job state.
+ */
+export class ArcTessellator {
+  private readonly chordTolerance: number;
+
+  constructor(options: ArcTessellatorOptions = {}) {
+    this.chordTolerance = options.chordTolerance ?? DEFAULT_CHORD_TOLERANCE;
+  }
+  /**
+   * Converts an arc move into the points to draw, ending on the arc's endpoint
+   * @param start - Absolute position at the start of the arc
+   * @param move - Arc parameters from the G2/G3 command
+   * @param emit - Called once per point, in order, endpoint last. A callback
+   * instead of a returned array so arc-heavy files do not allocate a throwaway
+   * point object per segment.
+   * @param units - Current units; the chord tolerance is defined in
+   * millimeters, so inch-based arcs are tessellated proportionally finer
+   * @returns The arc's exact endpoint (also the last point emitted). Emits at
+   * least the endpoint, even for degenerate arcs.
+   */
+  tessellate(start: ArcPoint, move: ArcMove, emit: EmitPoint, units: 'mm' | 'in' = 'mm'): ArcPoint {
+    const { cw, x, y, z } = move;
+    let { i, j, r } = move;
+    // Set when the arc cannot be described at all, so only the endpoint is emitted.
+    let arcIsDegenerate = false;
+
+    if (r) {
+      // in r mode a minimum radius will be applied if the distance can otherwise not be bridged
+      const deltaX = x - start.x; // assume abs mode
+      const deltaY = y - start.y;
+
+      // apply a minimal radius to bridge the distance
+      const minR = Math.sqrt(Math.pow(deltaX / 2, 2) + Math.pow(deltaY / 2, 2));
+      r = Math.max(r, minR);
+
+      const dSquared = Math.pow(deltaX, 2) + Math.pow(deltaY, 2);
+      const hSquared = Math.pow(r, 2) - dSquared / 4;
+
+      // R mode cannot describe a whole circle: with start == end the centre is
+      // undefined, and hSquared / dSquared divides by zero, which used to make i/j NaN
+      // and poison every derived value. Skip the arc and move straight to the endpoint.
+      // (hSquared < 0 needs no guard: r was just clamped to minR, so it cannot go
+      // negative.) This replaces the guard that was commented out here.
+      if (dSquared === 0) {
+        arcIsDegenerate = true;
+      } else {
+        let hDivD = Math.sqrt(hSquared / dSquared);
+
+        // Ref RRF DoArcMove. RRF also negates for cw arcs with a negative r
+        // (the long-way-round form), but r cannot be negative here: it was just
+        // clamped to minR, which is positive whenever dSquared is non-zero.
+        if (!cw) {
+          hDivD = -hDivD;
+        }
+        i = deltaX / 2 + deltaY * hDivD;
+        j = deltaY / 2 - deltaX * hDivD;
+      }
+    }
+
+    const wholeCircle = start.x == x && start.y == y;
+    const centerX = start.x + i;
+    const centerY = start.y + j;
+
+    const arcRadius = Math.sqrt(i * i + j * j);
+    const arcCurrentAngle = Math.atan2(-j, -i);
+    const finalTheta = Math.atan2(y - centerY, x - centerX);
+
+    let totalArc;
+    if (wholeCircle) {
+      totalArc = 2 * Math.PI;
+    } else {
+      totalArc = cw ? arcCurrentAngle - finalTheta : finalTheta - arcCurrentAngle;
+      if (totalArc < 0.0) {
+        totalArc += 2 * Math.PI;
+      }
+    }
+    // Coarsest angular step that keeps every chord within tolerance, from
+    // inverting the sagitta: t = 2 * acos(1 - tolerance / radius). The acos
+    // argument is clamped to -1 for radii at or below the tolerance, where any
+    // step would satisfy it and only the MAX_SEGMENT_ANGLE cap matters. A
+    // non-finite radius flows through as NaN or a 0 step, making totalSegments
+    // non-finite; the guard below the z handling skips the loop for those.
+    const radiusMm = units == 'in' ? arcRadius * MM_PER_INCH : arcRadius;
+    const maxStep = 2 * Math.acos(Math.max(1 - this.chordTolerance / radiusMm, -1));
+    const step = Math.min(maxStep, MAX_SEGMENT_ANGLE);
+
+    let totalSegments = totalArc / step;
+    if (totalSegments < 1) {
+      totalSegments = 1;
+    }
+    let arcAngleIncrement = totalArc / totalSegments;
+    arcAngleIncrement *= cw ? -1 : 1;
+
+    // target - current. This was the other way round, so a helical arc climbing
+    // Z1 -> Z3 walked its intermediate points down to Z-0.97 and only landed on Z3 at
+    // the endpoint, leaving a visible spike in the rendered path.
+    //
+    // `??` not `||`: Z0 is a legitimate target, and `|| start.z` turned a descent to
+    // Z0 into a flat arc at the old height. This matches the endpoint below, and is
+    // only safe because the parser now drops non-finite params -- `||` was rejecting
+    // NaN here by accident, and `??` does not.
+    const zDist = (z ?? start.z) - start.z;
+    const zStep = zDist / totalSegments;
+
+    let pz = start.z;
+    let currentAngle = arcCurrentAngle;
+
+    // A degenerate arc leaves totalSegments non-finite even though every param was
+    // finite: an R-mode whole circle divides by dSquared === 0, and offsets near
+    // Number.MAX_VALUE overflow arcRadius. NaN already skipped the loop (NaN - 1
+    // fails the condition), but Infinity ran until the vertex array hit its length
+    // limit and threw, aborting the whole job. Emit no intermediate points in either
+    // case and fall through to the endpoint below.
+    if (!arcIsDegenerate && Number.isFinite(totalSegments)) {
+      for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
+        currentAngle += arcAngleIncrement;
+        pz += zStep;
+        emit(centerX + arcRadius * Math.cos(currentAngle), centerY + arcRadius * Math.sin(currentAngle), pz);
+      }
+    }
+
+    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
+    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
+    // rejecting NaN here by accident, which `??` does not do.
+    const endPoint = { x: x ?? start.x, y: y ?? start.y, z: z ?? start.z };
+    emit(endPoint.x, endPoint.y, endPoint.z);
+
+    return endPoint;
+  }
+}

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -160,7 +160,6 @@ export class GCodePreview {
     this._sceneManager = this.createSceneManager();
     // the devMode setter also creates the dev GUI, so no separate initGui() call
     this.devMode = opts?.devMode;
-    this.interpreter = new Interpreter();
 
     this.initStats();
     if (opts.droppable) makeDroppable(this);

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -35,6 +35,12 @@ type LibOptions = {
    * batch, so very low values cost draw calls on large files.
    */
   liveRenderInterval?: number;
+  /**
+   * Maximum deviation, in millimeters, between rendered G2/G3 arcs and the
+   * true arc (default 0.05). Lower values produce smoother arcs at the cost
+   * of more geometry; higher values trade smoothness for performance.
+   */
+  arcChordTolerance?: number;
 };
 
 export type GCodePreviewOptions = LibOptions & SceneManagerOptions;
@@ -145,6 +151,7 @@ export class GCodePreview {
    */
   constructor(opts: GCodePreviewOptions) {
     this.opts = opts;
+    this.interpreter = new Interpreter({ arcChordTolerance: opts.arcChordTolerance });
     this._parser = this.createParser();
     this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
     // note: reads opts.devMode because this.devMode is only assigned below,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,6 +1,24 @@
 import { GCodeCommand } from './parser/gcode-parser';
 import { Job } from './job';
-import { linearMove, arcMove, setInchUnits, setMillimeterUnits, home, selectTool } from './interpreter/commands';
+import {
+  linearMove,
+  arcMove,
+  makeArcMove,
+  setInchUnits,
+  setMillimeterUnits,
+  home,
+  selectTool
+} from './interpreter/commands';
+
+/** Options for the {@link Interpreter} */
+export interface InterpreterOptions {
+  /**
+   * Maximum deviation, in millimeters, between tessellated G2/G3 arc chords
+   * and the true arc (default 0.05). Lower values produce smoother arcs at
+   * the cost of more geometry.
+   */
+  arcChordTolerance?: number;
+}
 
 /**
  * Executes a single G-code command against a job
@@ -50,6 +68,24 @@ export const handlers: ReadonlyMap<string, CommandHandler> = new Map<string, Com
  * handler are ignored.
  */
 export class Interpreter {
+  private handlers: ReadonlyMap<string, CommandHandler>;
+
+  /**
+   * Creates an interpreter, optionally with custom arc tessellation
+   * @param options - Interpreter options
+   * @remarks
+   * A custom arcChordTolerance swaps the shared G2/G3 handler for one built
+   * around its own tessellator; every other command keeps the shared registry.
+   */
+  constructor(options: InterpreterOptions = {}) {
+    if (options.arcChordTolerance === undefined) {
+      this.handlers = handlers;
+    } else {
+      const customArcMove = makeArcMove({ chordTolerance: options.arcChordTolerance });
+      this.handlers = new Map([...handlers, ['g2', customArcMove], ['g3', customArcMove]]);
+    }
+  }
+
   /**
    * Executes an array of G-code commands, updating the provided job
    * @param commands - Array of GCodeCommand objects to execute
@@ -59,7 +95,7 @@ export class Interpreter {
   execute(commands: GCodeCommand[], job = new Job()): Job {
     job.resumeLastPath();
     commands.forEach((command) => {
-      const handler = handlers.get(command.gcode);
+      const handler = this.handlers.get(command.gcode);
       handler?.(command, job);
     });
     job.finishPath();

--- a/src/interpreter/commands/arc-move.ts
+++ b/src/interpreter/commands/arc-move.ts
@@ -1,60 +1,64 @@
 import { PathType } from '../../path';
-import { ArcTessellator } from '../../arc-tessellator';
+import { ArcTessellator, ArcTessellatorOptions } from '../../arc-tessellator';
 import type { CommandHandler } from '../../interpreter';
 
-const arcTessellator = new ArcTessellator();
-
 /**
- * Executes an arc move command (G2/G3)
- * @param command - GCodeCommand containing arc parameters
- * @param job - Job instance to update
+ * Builds an arc move handler (G2/G3) around its own tessellator
+ * @param options - Tessellation options, e.g. a custom chord tolerance
+ * @returns A handler executing arc moves with the configured tessellator
  * @remarks
- * Handles both clockwise (G2) and counter-clockwise (G3) arc moves. The arc
- * math itself lives in ArcTessellator; this handler routes the resulting
- * points into the current path and updates the job state.
+ * The handler covers both clockwise (G2) and counter-clockwise (G3) arc
+ * moves. The arc math itself lives in ArcTessellator; the handler routes the
+ * resulting points into the current path and updates the job state.
  * G2 is for clockwise arcs, G3 is for counter-clockwise arcs.
  */
-export const arcMove: CommandHandler = (command, job) => {
-  const { x, y, z, e, i, j, r } = command.params;
-  const { state } = job;
-  // Starting position for the arc, with any un-homed axis assumed at the origin.
-  const from = job.resolvePosition();
+export const makeArcMove = (options: ArcTessellatorOptions = {}): CommandHandler => {
+  const arcTessellator = new ArcTessellator(options);
+  return (command, job) => {
+    const { x, y, z, e, i, j, r } = command.params;
+    const { state } = job;
+    // Starting position for the arc, with any un-homed axis assumed at the origin.
+    const from = job.resolvePosition();
 
-  const cw = command.gcode === 'g2';
-  let currentPath = job.inprogressPath;
-  // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
-  // material laid down. The looser `e ?` used to misclassify a retracting arc as
-  // Extrusion, so it rendered as deposited filament and stretched the bounding box.
-  const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
+    const cw = command.gcode === 'g2';
+    let currentPath = job.inprogressPath;
+    // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
+    // material laid down. The looser `e ?` used to misclassify a retracting arc as
+    // Extrusion, so it rendered as deposited filament and stretched the bounding box.
+    const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
 
-  if (currentPath === undefined || currentPath.travelType !== pathType) {
-    currentPath = job.breakPath(pathType);
-  }
+    if (currentPath === undefined || currentPath.travelType !== pathType) {
+      currentPath = job.breakPath(pathType);
+    }
 
-  if (e > 0) {
-    job.stats.extrusionDistance += e;
-  }
+    if (e > 0) {
+      job.stats.extrusionDistance += e;
+    }
 
-  // The tessellator runs on the resolved position and emits every point,
-  // ending with the exact endpoint -- which equals resolvePosition() after
-  // the state update below, so no separate endpoint emission is needed.
-  arcTessellator.tessellate(
-    from,
-    { cw, x, y, z, i, j, r },
-    (px, py, pz) => {
-      currentPath.addPoint(px, py, pz);
-      if (pathType === PathType.Extrusion) {
-        job.boundingBox.update(px, py, pz);
-      }
-    },
-    state.units
-  );
+    // The tessellator runs on the resolved position and emits every point,
+    // ending with the exact endpoint -- which equals resolvePosition() after
+    // the state update below, so no separate endpoint emission is needed.
+    arcTessellator.tessellate(
+      from,
+      { cw, x, y, z, i, j, r },
+      (px, py, pz) => {
+        currentPath.addPoint(px, py, pz);
+        if (pathType === PathType.Extrusion) {
+          job.boundingBox.update(px, py, pz);
+        }
+      },
+      state.units
+    );
 
-  // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
-  // coordinate. Safe now that the parser drops non-finite params -- `||` was also
-  // rejecting NaN here by accident, which `??` does not do. An axis the command
-  // omits keeps its previous (possibly unknown) value, preserving isHomed semantics.
-  state.x = x ?? state.x;
-  state.y = y ?? state.y;
-  state.z = z ?? state.z;
+    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
+    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
+    // rejecting NaN here by accident, which `??` does not do. An axis the command
+    // omits keeps its previous (possibly unknown) value, preserving isHomed semantics.
+    state.x = x ?? state.x;
+    state.y = y ?? state.y;
+    state.z = z ?? state.z;
+  };
 };
+
+/** Executes an arc move command (G2/G3) with the default chord tolerance */
+export const arcMove: CommandHandler = makeArcMove();

--- a/src/interpreter/commands/arc-move.ts
+++ b/src/interpreter/commands/arc-move.ts
@@ -1,21 +1,21 @@
 import { PathType } from '../../path';
+import { ArcTessellator } from '../../arc-tessellator';
 import type { CommandHandler } from '../../interpreter';
+
+const arcTessellator = new ArcTessellator();
 
 /**
  * Executes an arc move command (G2/G3)
  * @param command - GCodeCommand containing arc parameters
  * @param job - Job instance to update
  * @remarks
- * Handles both clockwise (G2) and counter-clockwise (G3) arc moves. Supports
- * both I/J center offset and R radius modes. Calculates intermediate points
- * along the arc and updates the job state accordingly.
+ * Handles both clockwise (G2) and counter-clockwise (G3) arc moves. The arc
+ * math itself lives in ArcTessellator; this handler routes the resulting
+ * points into the current path and updates the job state.
  * G2 is for clockwise arcs, G3 is for counter-clockwise arcs.
  */
 export const arcMove: CommandHandler = (command, job) => {
-  const { x, y, z, e } = command.params;
-  let { i, j, r } = command.params;
-  // Set when the arc cannot be described at all, so only the endpoint is emitted.
-  let arcIsDegenerate = false;
+  const { x, y, z, e, i, j, r } = command.params;
   const { state } = job;
   // Starting position for the arc, with any un-homed axis assumed at the origin.
   const from = job.resolvePosition();
@@ -35,111 +35,26 @@ export const arcMove: CommandHandler = (command, job) => {
     job.stats.extrusionDistance += e;
   }
 
-  if (r) {
-    // in r mode a minimum radius will be applied if the distance can otherwise not be bridged
-    const deltaX = x - from.x; // assume abs mode
-    const deltaY = y - from.y;
-
-    // apply a minimal radius to bridge the distance
-    const minR = Math.sqrt(Math.pow(deltaX / 2, 2) + Math.pow(deltaY / 2, 2));
-    r = Math.max(r, minR);
-
-    const dSquared = Math.pow(deltaX, 2) + Math.pow(deltaY, 2);
-    const hSquared = Math.pow(r, 2) - dSquared / 4;
-
-    // R mode cannot describe a whole circle: with start == end the centre is
-    // undefined, and hSquared / dSquared divides by zero, which used to make i/j NaN
-    // and poison every derived value. Skip the arc and move straight to the endpoint.
-    // (hSquared < 0 needs no guard: r was just clamped to minR, so it cannot go
-    // negative.) This replaces the guard that was commented out here.
-    if (dSquared === 0) {
-      arcIsDegenerate = true;
-    } else {
-      let hDivD = Math.sqrt(hSquared / dSquared);
-
-      // Ref RRF DoArcMove for details
-      if ((cw && r < 0.0) || (!cw && r > 0.0)) {
-        hDivD = -hDivD;
-      }
-      i = deltaX / 2 + deltaY * hDivD;
-      j = deltaY / 2 - deltaX * hDivD;
-    }
-  }
-
-  const wholeCircle = from.x == x && from.y == y;
-  const centerX = from.x + i;
-  const centerY = from.y + j;
-
-  const arcRadius = Math.sqrt(i * i + j * j);
-  const arcCurrentAngle = Math.atan2(-j, -i);
-  const finalTheta = Math.atan2(y - centerY, x - centerX);
-
-  let totalArc;
-  if (wholeCircle) {
-    totalArc = 2 * Math.PI;
-  } else {
-    totalArc = cw ? arcCurrentAngle - finalTheta : finalTheta - arcCurrentAngle;
-    if (totalArc < 0.0) {
-      totalArc += 2 * Math.PI;
-    }
-  }
-  let totalSegments = (arcRadius * totalArc) / 0.5;
-  if (state.units == 'in') {
-    totalSegments *= 25;
-  }
-  if (totalSegments < 1) {
-    totalSegments = 1;
-  }
-  let arcAngleIncrement = totalArc / totalSegments;
-  arcAngleIncrement *= cw ? -1 : 1;
-
-  // target - current. This was the other way round, so a helical arc climbing
-  // Z1 -> Z3 walked its intermediate points down to Z-0.97 and only landed on Z3 at
-  // the endpoint, leaving a visible spike in the rendered path.
-  //
-  // `??` not `||`: Z0 is a legitimate target, and `|| state.z` turned a descent to
-  // Z0 into a flat arc at the old height. This matches the endpoint assignment
-  // below, and is only safe because the parser now drops non-finite params -- `||`
-  // was rejecting NaN here by accident, and `??` does not.
-  const zDist = (z ?? from.z) - from.z;
-  const zStep = zDist / totalSegments;
-
-  // get points for the arc
-  let px = from.x;
-  let py = from.y;
-  let pz = from.z;
-  // calculate segments
-  let currentAngle = arcCurrentAngle;
-
-  // A degenerate arc leaves totalSegments non-finite even though every param was
-  // finite: an R-mode whole circle divides by dSquared === 0, and offsets near
-  // Number.MAX_VALUE overflow arcRadius. NaN already skipped the loop (NaN - 1
-  // fails the condition), but Infinity ran until the vertex array hit its length
-  // limit and threw, aborting the whole job. Emit no intermediate points in either
-  // case and fall through to the endpoint below.
-  if (!arcIsDegenerate && Number.isFinite(totalSegments)) {
-    for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
-      currentAngle += arcAngleIncrement;
-      px = centerX + arcRadius * Math.cos(currentAngle);
-      py = centerY + arcRadius * Math.sin(currentAngle);
-      pz += zStep;
+  // The tessellator runs on the resolved position and emits every point,
+  // ending with the exact endpoint -- which equals resolvePosition() after
+  // the state update below, so no separate endpoint emission is needed.
+  arcTessellator.tessellate(
+    from,
+    { cw, x, y, z, i, j, r },
+    (px, py, pz) => {
       currentPath.addPoint(px, py, pz);
       if (pathType === PathType.Extrusion) {
         job.boundingBox.update(px, py, pz);
       }
-    }
-  }
+    },
+    state.units
+  );
 
   // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
   // coordinate. Safe now that the parser drops non-finite params -- `||` was also
-  // rejecting NaN here by accident, which `??` does not do.
+  // rejecting NaN here by accident, which `??` does not do. An axis the command
+  // omits keeps its previous (possibly unknown) value, preserving isHomed semantics.
   state.x = x ?? state.x;
   state.y = y ?? state.y;
   state.z = z ?? state.z;
-
-  const pos = job.resolvePosition();
-  currentPath.addPoint(pos.x, pos.y, pos.z);
-  if (pathType === PathType.Extrusion) {
-    job.boundingBox.update(pos.x, pos.y, pos.z);
-  }
 };

--- a/src/interpreter/commands/index.ts
+++ b/src/interpreter/commands/index.ts
@@ -1,5 +1,5 @@
 export { linearMove } from './linear-move';
-export { arcMove } from './arc-move';
+export { arcMove, makeArcMove } from './arc-move';
 export { setInchUnits, setMillimeterUnits } from './set-units';
 export { home } from './home';
 export { selectTool } from './select-tool';

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,3 +1,5 @@
+import { Units } from './units';
+
 /**
  * Represents the current state of the print job
  * @remarks
@@ -15,7 +17,7 @@ export class State {
   /** Currently active tool */
   tool = 0;
   /** Current units (millimeters or inches) */
-  units: 'mm' | 'in' = 'mm';
+  units: Units = 'mm';
   /**
    * Whether the axes have been homed (G28).
    * @remarks

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,0 +1,5 @@
+/** Units a G-code file can select with G20 (inches) or G21 (millimeters) */
+export type Units = 'mm' | 'in';
+
+/** Millimeters per inch, for converting values from inch-based G-code */
+export const MM_PER_INCH = 25.4;


### PR DESCRIPTION
This is one that was on my mind for a very long time but the math required was stopping me. Let's be honest, it's not the most exciting part of the codebase to write. The implementation is mostly AI, but the initial idea initially was from my meat brain before coding agents even existed. And I learned in the process that the concept in this PR has a name: tessellation.

## Summary

Extracts the G2/G3 arc math out of `Interpreter.g2` (~125 lines of inline trig + state mutation) into a dedicated `ArcTessellator` class, and upgrades the tessellation heuristic from fixed-length segments to chord-tolerance-based segmentation.

### Refactor
- **New `src/arc-tessellator.ts`**: all arc geometry (I/J center mode, R radius mode with RRF conversion, helical Z, degenerate-arc guards) lives here; the interpreter only routes points into paths and job state.
- **Zero-allocation hot path**: points stream through an `emit(x, y, z)` callback instead of a returned array, so arc-heavy files don't allocate a throwaway point object per segment. `tessellate` returns the exact endpoint for the state update.
- A provably dead branch was removed: `r < 0.0` in the RRF sign check could never be true because `r` is clamped to a positive `minR` two lines earlier.

### Chord-tolerance tessellation
The old heuristic emitted one segment per 0.5mm of arc length, so segment count grew **linearly** with radius. The new one inverts the sagitta formula — `step = 2·acos(1 − tolerance/radius)` — so every chord stays within `chordTolerance` (default **0.05mm**) of the true arc, and segment count scales with **√radius**. A 22.5° max segment angle keeps tiny circles round (≥16 segments per full turn).

Here is the same G2 quarter circle through both implementations — same 0.05 mm adherence to the true arc, a quarter of the points:

![arc tessellation before vs after](https://raw.githubusercontent.com/xyz-tools/gcode-preview/assets/arc-tessellation-screenshots/arc-tessellation-diagram.svg)

### Public API
Applications can tune the accuracy/performance trade-off via a new `GCodePreviewOptions` field:

```typescript
new GCodePreview({ canvas, arcChordTolerance: 0.01 }); // smoother arcs, more geometry
```

The option flows through a new `Interpreter` constructor into the `ArcTessellator`. A shared `src/units.ts` module now holds `MM_PER_INCH` and the `Units` type (previously duplicated between `state.ts` and the tessellator).

## Numbers

Measured on the demo's **"Arcs with G2/G3"** preset (`screw.gcode`, 5,727 arc commands), identical scene and camera:

| Metric | Before (0.5mm/segment) | After (chord tolerance) | Delta |
|---|---|---|---|
| Triangles per frame | 358,856 | 178,328 | **−50.3%** |
| Total path vertices | 50,037 | 27,471 | **−45.1%** |
| Path count | 2,363 | 2,363 | unchanged |
| Draw calls / geometries | 35 / 65 | 35 / 65 | unchanged |

## Screenshots

| | Before | After |
|---|---|---|
| **Default view** | ![before full](https://raw.githubusercontent.com/xyz-tools/gcode-preview/assets/arc-tessellation-screenshots/before-full.png) | ![after full](https://raw.githubusercontent.com/xyz-tools/gcode-preview/assets/arc-tessellation-screenshots/after-full.png) |
| **Thread closeup** (same camera) | ![before closeup](https://raw.githubusercontent.com/xyz-tools/gcode-preview/assets/arc-tessellation-screenshots/before-closeup.png) | ![after closeup](https://raw.githubusercontent.com/xyz-tools/gcode-preview/assets/arc-tessellation-screenshots/after-closeup.png) |

Half the triangles, barely visible difference: thread crests and silhouettes stay smooth at both viewing distances, with no faceting. Unchanged path count confirms only per-arc vertex density changed, not parsing semantics.

## Testing
- 14 direct `ArcTessellator` unit tests (sagitta stays within tolerance, cw/ccw sweep, R-mode conversion, helical Z, degenerate arcs, inches, tiny-circle rounding, micro-arc clamp).
- New end-to-end interpreter test proving `G3` sweeps counter-clockwise where `G2` sweeps clockwise, guarding the `g3 = this.g2` alias (a broken alias silently ignores G3).
- `src/arc-tessellator.ts` added to the 100% coverage ratchet in `vitest.config.mts`.
- `npm run check` green: 281 tests, typecheck, lint.

Assisted by Claude Code - Fable 5
