### PR TITLE
Bring Job to 100% coverage and fix three indexing bugs

### DIFF
--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -1,8 +1,8 @@
-import { test, expect, describe } from 'vitest';
+import { test, expect, describe, vi, afterEach } from 'vitest';
 import { Job } from '../job';
 import { PathType, Path } from '../path';
 import { State } from '../state';
-import { LayersIndexer } from '../indexers';
+import { LayersIndexer, NonApplicableIndexer, TravelTypeIndexer } from '../indexers';
 
 test('it has an initial state', () => {
   const job = new Job();
@@ -361,6 +361,26 @@ describe('.layers', () => {
     expect(layers.length).toEqual(2);
     expect(layers[1].z).toEqual(4);
   });
+
+  test('a previously obtained layers array is emptied when the job turns out non-planar', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+
+    const layers = job.layers;
+    expect(layers.length).toEqual(1);
+
+    append_path(job, PathType.Extrusion, [
+      [5, 6, 0],
+      [5, 6, 1]
+    ]);
+
+    expect(layers.length).toEqual(0);
+    expect(job.layers).toBe(layers);
+  });
 });
 
 describe('.extrusions', () => {
@@ -447,6 +467,22 @@ describe('.toolPaths', () => {
     expect(toolPaths[4]).toBeUndefined();
     expect(toolPaths[5].length).toEqual(1);
   });
+
+  test('a non-planar extrusion path is still indexed by tool', () => {
+    const job = new Job();
+
+    const planar = append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    const nonPlanar = append_path(job, PathType.Extrusion, [
+      [1, 2, 0],
+      [5, 6, 1]
+    ]);
+
+    expect(job.isPlanar).toEqual(false);
+    expect(job.toolPaths[0]).toEqual([planar, nonPlanar]);
+  });
 });
 
 describe('.addPath', () => {
@@ -466,6 +502,43 @@ describe('.addPath', () => {
     job.addPath(path);
 
     expect(job.extrusions).toEqual([path]);
+  });
+
+  describe('when an indexer throws an error', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test('rethrows errors that are not NonApplicableIndexer', () => {
+      const job = new Job();
+      const error = new Error('boom');
+      vi.spyOn(TravelTypeIndexer.prototype, 'sortIn').mockImplementation(() => {
+        throw error;
+      });
+      const path = new Path(PathType.Extrusion, 0.6, 0.2, 0);
+
+      expect(() => job.addPath(path)).toThrow(error);
+    });
+
+    test('removes an indexer that throws NonApplicableIndexer without clearing layers', () => {
+      const job = new Job();
+      const sortIn = vi.spyOn(TravelTypeIndexer.prototype, 'sortIn').mockImplementation(() => {
+        throw new NonApplicableIndexer('not applicable');
+      });
+
+      append_path(job, PathType.Extrusion, [
+        [0, 0, 0],
+        [1, 2, 0]
+      ]);
+      append_path(job, PathType.Extrusion, [
+        [1, 2, 0],
+        [5, 6, 0]
+      ]);
+
+      expect(sortIn).toHaveBeenCalledTimes(1);
+      expect(job.extrusions).toEqual([]);
+      expect(job.layers.length).toEqual(1);
+    });
   });
 });
 
@@ -541,6 +614,57 @@ describe('.resumeLastPath', () => {
 
     expect(job.extrusions).toEqual([]);
     expect(job.layers[job.layers.length - 1].paths).toEqual([]);
+  });
+
+  test('the path is removed from the tool index', () => {
+    const job = new Job();
+
+    append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    job.resumeLastPath();
+
+    expect(job.toolPaths[0]).toEqual([]);
+  });
+
+  test('resuming and finishing across chunks does not duplicate tool paths', () => {
+    const job = new Job();
+
+    const path = append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+
+    // simulate streaming: each chunk resumes the last path, appends and finishes it
+    for (let chunk = 0; chunk < 2; chunk++) {
+      job.resumeLastPath();
+      job.inprogressPath.addPoint(2 + chunk, 2, 0);
+      job.finishPath();
+    }
+
+    expect(job.paths).toEqual([path]);
+    expect(job.extrusions).toEqual([path]);
+    expect(job.toolPaths[0]).toEqual([path]);
+  });
+
+  test('leaves non-empty indexes that do not contain the resumed path intact', () => {
+    const job = new Job();
+
+    const extrusion = append_path(job, PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+    const travel = append_path(job, PathType.Travel, [
+      [1, 2, 0],
+      [5, 6, 0]
+    ]);
+
+    job.resumeLastPath();
+
+    expect(job.inprogressPath).toEqual(travel);
+    expect(job.extrusions).toEqual([extrusion]);
+    expect(job.travels).toEqual([]);
   });
 });
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -118,7 +118,12 @@ export class Job {
       return;
     }
     this.inprogressPath = this.paths.pop();
-    [this.extrusionPaths, this.travelPaths, this.layers[this.layers.length - 1]?.paths].forEach((indexer) => {
+    [
+      this.extrusionPaths,
+      this.travelPaths,
+      this.layers[this.layers.length - 1]?.paths,
+      this._toolPaths[this.inprogressPath.tool]
+    ].forEach((indexer) => {
       if (indexer === undefined || indexer.length === 0) {
         return;
       }
@@ -154,7 +159,9 @@ export class Job {
    * the layers will be cleared.
    */
   private indexPath(path: Path): void {
-    this.indexers.forEach((indexer) => {
+    // Iterate over a snapshot so removing a failed indexer
+    // does not skip the indexers that follow it
+    [...this.indexers].forEach((indexer) => {
       try {
         indexer.sortIn(path);
       } catch (e) {
@@ -164,7 +171,8 @@ export class Job {
 
         if (e instanceof NonPlanarExtrusionError) {
           console.warn('Non-planar path detected; clearing layer index');
-          this._layers = [];
+          // Truncate in place so consumers holding the array see it emptied
+          this._layers.length = 0;
         }
 
         // Remove the indexer that cannot handle this path

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,7 +17,8 @@ export default defineConfig({
         'src/extrusion-geometry.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
         'src/scene-manager.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
         'src/objects-manager.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
-        'src/bounding-box.ts': { statements: 100, branches: 100, functions: 100, lines: 100 }
+        'src/bounding-box.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
+        'src/job.ts': { statements: 100, branches: 100, functions: 100, lines: 100 }
       }
     }
   }


### PR DESCRIPTION
## Summary

Continues the file-by-file coverage lockdown: `src/job.ts` is now at 100% statement/branch/function/line coverage and added to the enforced thresholds in `vitest.config.mts`. Filling the gaps surfaced three real bugs in `Job`, which are fixed here with red-first regression tests.

## Coverage

- Added tests for the previously uncovered `indexPath` error-handling branches (rethrow of non-`NonApplicableIndexer` errors, removal of a failed indexer without clearing layers) and the `resumeLastPath` branch where a non-empty index does not contain the popped path.
- `src/job.ts` joins `gcode-parser`, `extrusion-geometry`, `scene-manager`, and `bounding-box` in the 100% thresholds block, so CI fails on any regression.

## Bug fixes

1. **`indexPath` skipped an indexer after removing a failed one.** It spliced the failing indexer out of `this.indexers` while iterating that same array with `forEach`, so the next indexer was skipped for that path. Concretely: the extrusion path that triggers `NonPlanarExtrusionError` never reached `ToolIndexer`, so it was missing from `toolPaths` and never rendered. Now iterates over a snapshot of the indexer list.
2. **`resumeLastPath` never un-indexed the tool index.** It removed the popped path from `extrusions`, `travels`, and the last layer, but not from `toolPaths`. Since `Interpreter.execute` resumes/finishes the in-progress path on every call, each streaming chunk boundary appended a duplicate of the same `Path` to `toolPaths[tool]` (duplicate geometry, inflated arrays for render-path slicing). Now also removes it from the path's tool array.
3. **Clearing layers left stale references.** The non-planar handler reassigned `this._layers = []`, so any consumer holding an earlier `job.layers` array kept the stale, populated one. Now truncates in place with `length = 0`.

Each fix has a regression test that was confirmed failing before the fix (the bug-1 and bug-2 tests are constructed so neither masks the other — the duplicate re-add of bug 2 could otherwise hide bug 1's skip).

## Test plan

- `npx vitest run --coverage` — 273 tests pass, `src/job.ts` at 100/100/100/100 with thresholds enforced
- `npm run lint` — clean

Assisted by Claude Code - Fable 5