### PR TITLE
Move the build volume and bounding box into the ObjectsManager

### DIFF
--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -1,7 +1,8 @@
 import { test, expect, describe, vi, beforeEach, afterEach } from 'vitest';
 import { ObjectsManager } from '../objects-manager';
 import { Path, PathType } from '../path';
-import { Scene, Color, Group, BatchedMesh } from 'three';
+import { BoundingBox } from '../bounding-box';
+import { Scene, Color, Group, BatchedMesh, LineBasicMaterial } from 'three';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 
@@ -612,6 +613,151 @@ describe('ObjectsManager', () => {
       vi.advanceTimersByTime(ObjectsManager.rebuildDebounce);
 
       expect(onRebuildNeeded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('build volume', () => {
+    const dimensions = { x: 100, y: 120, z: 50, smallGrid: false };
+
+    test('setBuildVolume adds the visualization to the scene', () => {
+      objectsManager.setBuildVolume(dimensions);
+
+      expect(objectsManager.buildVolume?.x).toBe(100);
+      expect(scene.children.some((child) => child.name === 'BuildVolume')).toBe(true);
+    });
+
+    test('setBuildVolume replaces an existing volume', () => {
+      objectsManager.setBuildVolume(dimensions);
+      const first = objectsManager.buildVolume;
+
+      objectsManager.setBuildVolume({ x: 200, y: 200, z: 100, smallGrid: true });
+
+      expect(objectsManager.buildVolume).not.toBe(first);
+      expect(objectsManager.buildVolume?.x).toBe(200);
+      expect(scene.children.filter((child) => child.name === 'BuildVolume')).toHaveLength(1);
+    });
+
+    test('setBuildVolume without dimensions removes the volume', () => {
+      objectsManager.setBuildVolume(dimensions);
+
+      objectsManager.setBuildVolume();
+
+      expect(objectsManager.buildVolume).toBeUndefined();
+      expect(scene.children.some((child) => child.name === 'BuildVolume')).toBe(false);
+    });
+
+    test('the build volume survives a geometry reset', () => {
+      objectsManager.setBuildVolume(dimensions);
+      const volume = objectsManager.buildVolume;
+
+      objectsManager.reset();
+
+      expect(objectsManager.buildVolume).toBe(volume);
+      expect(scene.children.some((child) => child.name === 'BuildVolume')).toBe(true);
+    });
+
+    test('dispose removes the build volume from the scene', () => {
+      objectsManager.setBuildVolume(dimensions);
+
+      objectsManager.dispose();
+
+      expect(objectsManager.buildVolume).toBeUndefined();
+      expect(scene.children.some((child) => child.name === 'BuildVolume')).toBe(false);
+    });
+  });
+
+  describe('bounding box', () => {
+    function createBounds(): BoundingBox {
+      const bounds = new BoundingBox();
+      bounds.update(0, 0, 0);
+      bounds.update(10, 20, 5);
+      return bounds;
+    }
+
+    function meshesInScene(): number {
+      return scene.children.filter((child) => child.name === 'bounding-box').length;
+    }
+
+    test('updateBoundingBox creates a hidden mesh when no color is set', () => {
+      objectsManager.updateBoundingBox(createBounds());
+
+      expect(objectsManager.boundingBoxMesh?.visible).toBe(false);
+      expect(meshesInScene()).toBe(1);
+    });
+
+    test('updateBoundingBox draws the box at the model min corner in the configured color', () => {
+      objectsManager.setBoundingBoxColor(new Color(0x00ff00));
+
+      objectsManager.updateBoundingBox(createBounds());
+
+      const mesh = objectsManager.boundingBoxMesh;
+      expect(mesh?.visible).toBe(true);
+      expect((mesh?.material as LineBasicMaterial).color.getHex()).toBe(0x00ff00);
+      expect(mesh?.position.x).toBe(0);
+      expect(mesh?.position.y).toBe(0);
+    });
+
+    test('updateBoundingBox ignores invalid bounds', () => {
+      objectsManager.updateBoundingBox(new BoundingBox());
+
+      expect(objectsManager.boundingBoxMesh).toBeUndefined();
+    });
+
+    test('updateBoundingBox reuses the mesh while the bounds are unchanged', () => {
+      const bounds = createBounds();
+      objectsManager.updateBoundingBox(bounds);
+      const first = objectsManager.boundingBoxMesh;
+
+      objectsManager.updateBoundingBox(bounds);
+
+      expect(objectsManager.boundingBoxMesh).toBe(first);
+      expect(meshesInScene()).toBe(1);
+    });
+
+    test('grown bounds rebuild the mesh', () => {
+      const bounds = createBounds();
+      objectsManager.updateBoundingBox(bounds);
+      const first = objectsManager.boundingBoxMesh;
+
+      bounds.update(50, 60, 40);
+      objectsManager.updateBoundingBox(bounds);
+
+      expect(objectsManager.boundingBoxMesh).not.toBe(first);
+      expect(meshesInScene()).toBe(1);
+    });
+
+    test('setBoundingBoxColor recolors and toggles the existing mesh in place', () => {
+      objectsManager.updateBoundingBox(createBounds());
+      const mesh = objectsManager.boundingBoxMesh;
+
+      objectsManager.setBoundingBoxColor(new Color(0xff00ff));
+
+      expect(objectsManager.boundingBoxMesh).toBe(mesh);
+      expect(mesh?.visible).toBe(true);
+      expect((mesh?.material as LineBasicMaterial).color.getHex()).toBe(0xff00ff);
+
+      objectsManager.setBoundingBoxColor(undefined);
+
+      expect(mesh?.visible).toBe(false);
+    });
+
+    test('the bounding box survives a geometry reset', () => {
+      objectsManager.updateBoundingBox(createBounds());
+      const mesh = objectsManager.boundingBoxMesh;
+
+      objectsManager.reset();
+
+      expect(objectsManager.boundingBoxMesh).toBe(mesh);
+      expect(meshesInScene()).toBe(1);
+    });
+
+    test('dispose removes the bounding box from the scene', () => {
+      objectsManager.updateBoundingBox(createBounds());
+
+      objectsManager.dispose();
+
+      expect(objectsManager.boundingBoxMesh).toBeUndefined();
+      expect(meshesInScene()).toBe(0);
     });
   });
 

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -503,6 +503,26 @@ describe('SceneManager properties', () => {
       expect(current.lineWidth).toBe(3);
     });
 
+    test('keeps the build volume and bounding box color for the next job', () => {
+      sceneManager.boundingBoxColor = '#00ff00';
+
+      sceneManager.clear();
+
+      expect(sceneManager.buildVolume?.x).toBe(200);
+      expect(sceneManager.buildVolume?.smallGrid).toBe(true);
+      expect((sceneManager.boundingBoxColor as Color).getHex()).toBe(0x00ff00);
+      // the box itself belonged to the cleared job
+      expect(sceneManager.boundingBoxMesh).toBeUndefined();
+    });
+
+    test('does not resurrect a build volume that was removed', () => {
+      sceneManager.buildVolume = undefined;
+
+      sceneManager.clear();
+
+      expect(sceneManager.buildVolume).toBeUndefined();
+    });
+
     test('keeps renderTubes and the lighting for the next job', () => {
       sceneManager.renderTubes = true;
       sceneManager.ambientLight = 0.7;

--- a/src/build-volume.ts
+++ b/src/build-volume.ts
@@ -3,6 +3,9 @@ import { AxesHelper, Color, Group, Vector3, Scene } from 'three';
 import { LineBox } from './helpers/line-box';
 import { type Disposable } from './helpers/three-utils';
 
+/** The dimensions a caller supplies to describe a build volume */
+export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
+
 /**
  * Represents the build volume of a 3D printer.
  */

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -1,5 +1,8 @@
 import { Path } from './path';
 import { type Disposable } from './helpers/three-utils';
+import { BuildVolume, type BuildVolumeDef } from './build-volume';
+import { type BoundingBox } from './bounding-box';
+import { LineBox } from './helpers/line-box';
 
 import {
   Group,
@@ -11,6 +14,7 @@ import {
   Euler,
   BatchedMesh,
   BufferGeometry,
+  LineBasicMaterial,
   Material
 } from 'three';
 
@@ -41,6 +45,15 @@ export class ObjectsManager {
   /** Width of extruded material. Undefined means each path uses its own width. */
   extrusionWidth?: number;
   renderTubes = false;
+
+  /** Build volume visualization, or undefined when none is drawn */
+  buildVolume?: BuildVolume;
+  /** Wireframe box around the model, created lazily on first draw */
+  boundingBoxMesh?: LineBox;
+  /** Color of the bounding box; undefined hides it */
+  boundingBoxColor?: Color;
+  /** Size the bounding box mesh was built for, to detect stale bounds */
+  private boundingBoxSize?: { x: number; y: number; z: number };
 
   /** How long to coalesce geometry rebuilds for, in ms */
   static readonly rebuildDebounce = 100;
@@ -131,6 +144,72 @@ export class ObjectsManager {
   setBrightness(value: number) {
     this.brightness = value;
     this.updateUniform('brightness', value);
+  }
+
+  // --- scene furniture: owned objects that survive geometry rebuilds ----------
+
+  /**
+   * Replaces the build volume visualization, or removes it when no dimensions are given.
+   * @param value - Build volume dimensions, or undefined to draw none
+   */
+  setBuildVolume(value?: BuildVolumeDef) {
+    this.buildVolume?.dispose();
+    this.buildVolume = undefined;
+    if (!value) return;
+
+    this.buildVolume = new BuildVolume(value.x, value.y, value.z, value.smallGrid, this.scene);
+    this.buildVolume.update();
+  }
+
+  /**
+   * Recolors the bounding box in place; undefined hides it.
+   * @param color - New color, or undefined to hide the box
+   */
+  setBoundingBoxColor(color?: Color) {
+    this.boundingBoxColor = color;
+    if (!this.boundingBoxMesh) return;
+
+    this.boundingBoxMesh.visible = color !== undefined;
+    if (color) (this.boundingBoxMesh.material as LineBasicMaterial).color = color;
+  }
+
+  /**
+   * Draws the bounding box for the given bounds, creating or resizing the mesh as needed.
+   * @remarks
+   * The mesh is kept across geometry rebuilds — only a change in the bounds themselves
+   * (a file streaming in) makes a new one. Visibility tracks whether a color is set.
+   */
+  updateBoundingBox(boundingBox: BoundingBox) {
+    if (!boundingBox.isValid) return;
+    const size = boundingBox.size;
+
+    const stale =
+      this.boundingBoxSize &&
+      (size.x !== this.boundingBoxSize.x || size.y !== this.boundingBoxSize.y || size.z !== this.boundingBoxSize.z);
+    if (stale) this.disposeBoundingBox();
+
+    if (!this.boundingBoxMesh) {
+      const mesh = new LineBox(size.x, size.z, size.y, this.boundingBoxColor, false);
+      mesh.name = 'bounding-box';
+      const min = boundingBox.corners.min.toVector3();
+      mesh.position.set(min.x, min.y, min.z);
+
+      this.boundingBoxMesh = mesh;
+      this.boundingBoxSize = { x: size.x, y: size.y, z: size.z };
+      this.scene.add(mesh);
+    }
+
+    this.boundingBoxMesh.visible = this.boundingBoxColor !== undefined;
+    if (this.boundingBoxColor) (this.boundingBoxMesh.material as LineBasicMaterial).color = this.boundingBoxColor;
+  }
+
+  private disposeBoundingBox() {
+    if (!this.boundingBoxMesh) return;
+
+    this.scene.remove(this.boundingBoxMesh);
+    this.boundingBoxMesh.dispose();
+    this.boundingBoxMesh = undefined;
+    this.boundingBoxSize = undefined;
   }
 
   // --- dimensions: baked into the buffers, so these need a rebuild ------------
@@ -282,6 +361,9 @@ export class ObjectsManager {
     this.rebuildTimeout = undefined;
     this.extrusionsGroup.removeFromParent();
     this.travelMovesGroup.removeFromParent();
+    this.buildVolume?.dispose();
+    this.buildVolume = undefined;
+    this.disposeBoundingBox();
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
   }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -1,6 +1,6 @@
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
-import { BuildVolume } from './build-volume';
+import { BuildVolume, type BuildVolumeDef } from './build-volume';
 import { type Disposable } from './helpers/three-utils';
 import { LineBox } from './helpers/line-box';
 
@@ -15,11 +15,10 @@ import {
   REVISION,
   Scene,
   WebGLRenderer,
-  MathUtils,
-  LineBasicMaterial
+  MathUtils
 } from 'three';
 
-export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
+export type { BuildVolumeDef };
 
 // Orthographic camera constants
 const PERSPECTIVE_FOV = 25;
@@ -102,8 +101,6 @@ export class SceneManager {
   private _endLayer?: number;
   /** Whether single layer mode is enabled */
   private _singleLayerMode = false;
-  /** Build volume dimensions */
-  private _buildVolume?: BuildVolume;
   /** Initial camera position [x, y, z] */
   private initialCameraPosition = [-100, 400, 450];
   /** Whether to use inches instead of millimeters */
@@ -111,10 +108,6 @@ export class SceneManager {
   /** Disable color gradient between layers */
   private _disableGradient = false;
   job: Job;
-  /** Bounding box mesh */
-  private _boundingBoxMesh?: LineBox;
-  /** Color for the bounding box */
-  private _boundingBoxColor?: Color;
 
   // rendering
   /** Disposable resources */
@@ -171,14 +164,7 @@ export class SceneManager {
     this.startLayer = opts.startLayer;
 
     if (opts.buildVolume) {
-      this._buildVolume = new BuildVolume(
-        opts.buildVolume.x,
-        opts.buildVolume.y,
-        opts.buildVolume.z,
-        opts.buildVolume.smallGrid,
-        this.scene
-      );
-      this.disposables.push(this._buildVolume);
+      this.objectsManager.setBuildVolume(opts.buildVolume);
     }
     this.initialCameraPosition = opts.initialCameraPosition ?? this.initialCameraPosition;
     // assign the backing fields directly: the setters would draw the scene before
@@ -188,7 +174,7 @@ export class SceneManager {
     this.objectsManager.renderTubes = opts.renderTubes ?? this.objectsManager.renderTubes;
 
     if (opts.boundingBoxColor !== undefined) {
-      this._boundingBoxColor = new Color(opts.boundingBoxColor);
+      this.objectsManager.setBoundingBoxColor(new Color(opts.boundingBoxColor));
     }
 
     if (!opts.canvas) {
@@ -227,7 +213,7 @@ export class SceneManager {
     this.resize();
 
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
-    this.controls.target.set(this._buildVolume.x / 2, 0, -this._buildVolume.y / 2);
+    this.controls.target.set(this.buildVolume.x / 2, 0, -this.buildVolume.y / 2);
     this.disposables.push(this.controls);
     this.loadCamera();
 
@@ -255,7 +241,7 @@ export class SceneManager {
    * @returns Current build volume or undefined if not set
    */
   get buildVolume(): BuildVolume | undefined {
-    return this._buildVolume;
+    return this.objectsManager.buildVolume;
   }
 
   /**
@@ -263,15 +249,7 @@ export class SceneManager {
    * @param value - Partial build volume properties (x, y, z, smallGrid)
    */
   set buildVolume(value: BuildVolumeDef | undefined) {
-    if (!value) {
-      this._buildVolume?.dispose();
-      this._buildVolume = undefined;
-    } else {
-      this._buildVolume = new BuildVolume(value.x, value.y, value.z, value.smallGrid, this.scene);
-
-      this.disposables.push(this._buildVolume);
-      this._buildVolume.update();
-    }
+    this.objectsManager.setBuildVolume(value);
   }
 
   /**
@@ -373,7 +351,7 @@ export class SceneManager {
    * @returns Color representation or undefined if not set
    */
   get boundingBoxColor(): ColorRepresentation | undefined {
-    return this._boundingBoxColor;
+    return this.objectsManager.boundingBoxColor;
   }
 
   /**
@@ -381,7 +359,7 @@ export class SceneManager {
    * @param value - Color value or undefined to hide the bounding box
    */
   set boundingBoxColor(value: ColorRepresentation | undefined) {
-    this._boundingBoxColor = value !== undefined ? new Color(value) : undefined;
+    this.objectsManager.setBoundingBoxColor(value !== undefined ? new Color(value) : undefined);
 
     this.renderBoundingBox();
   }
@@ -434,10 +412,7 @@ export class SceneManager {
   }
 
   get boundingBoxMesh(): LineBox | undefined {
-    return this._boundingBoxMesh;
-  }
-  set boundingBoxMesh(value: LineBox | undefined) {
-    this._boundingBoxMesh = value;
+    return this.objectsManager.boundingBoxMesh;
   }
 
   get lineWidth(): number | undefined {
@@ -608,8 +583,8 @@ export class SceneManager {
       const size = this.job.boundingBox.size;
       return Math.max(size.x, size.y, size.z) * FRUSTUM_PADDING;
     }
-    if (this._buildVolume) {
-      return Math.max(this._buildVolume.x, this._buildVolume.y, this._buildVolume.z) * FRUSTUM_PADDING;
+    if (this.buildVolume) {
+      return Math.max(this.buildVolume.x, this.buildVolume.y, this.buildVolume.z) * FRUSTUM_PADDING;
     }
     return DEFAULT_FRUSTUM_SIZE;
   }
@@ -638,11 +613,6 @@ export class SceneManager {
     this.renderPaths();
 
     this.renderBoundingBox();
-
-    if (this._buildVolume) {
-      this.disposables.push(this._buildVolume);
-      this._buildVolume.update();
-    }
   }
 
   /** Resets the scene by clearing all existing objects and re-initializing
@@ -716,7 +686,6 @@ export class SceneManager {
   private renderFrame(pathCount: number): void {
     const endPathNumber = Math.min(this.renderPathIndex + pathCount, this.job.paths.length - 1);
     this.renderPaths(endPathNumber);
-    this.renderBoundingBox();
     this.renderPathIndex = endPathNumber;
 
     this.renderBoundingBox();
@@ -725,29 +694,8 @@ export class SceneManager {
 
   private renderBoundingBox(): void {
     if (!this.job) return;
-    if (!this.job.boundingBox.isValid) {
-      return;
-    }
 
-    // create the bounding box mesh if it doesn't exist
-    if (!this.boundingBoxMesh) {
-      this.boundingBoxMesh = this.createBoundingBox();
-      this.boundingBoxMesh.name = 'bounding-box';
-      this.disposables.push(this.boundingBoxMesh);
-
-      this.scene.add(this.boundingBoxMesh);
-    }
-    this.boundingBoxMesh.visible = this._boundingBoxColor !== undefined;
-    (this.boundingBoxMesh.material as LineBasicMaterial).color = this._boundingBoxColor;
-  }
-
-  createBoundingBox(): LineBox {
-    const bb = this.job.boundingBox;
-    const size = bb.size;
-    const mesh = new LineBox(size.x, size.z, size.y, this._boundingBoxColor, false);
-    const pos = bb.corners.min.toVector3();
-    mesh.position.set(pos.x, pos.y, pos.z);
-    return mesh;
+    this.objectsManager.updateBoundingBox(this.job.boundingBox);
   }
 
   // reset parser & processing state
@@ -755,13 +703,17 @@ export class SceneManager {
     // read the settings off the outgoing manager before it is torn down
     const { lineWidth, lineHeight, extrusionWidth, renderTubes, ambientLight, directionalLight, brightness } =
       this.objectsManager;
+    const { buildVolume, boundingBoxColor } = this.objectsManager;
+    // the bounding box belongs to the outgoing job, but the build volume does not:
+    // it is recreated on the replacement manager from the same dimensions
+    const buildVolumeDef = buildVolume
+      ? { x: buildVolume.x, y: buildVolume.y, z: buildVolume.z, smallGrid: buildVolume.smallGrid }
+      : undefined;
 
     this.startLayer = undefined;
     this.endLayer = Infinity;
     this._singleLayerMode = false;
     this.job = undefined;
-    this.scene.remove(this.boundingBoxMesh);
-    this.boundingBoxMesh = undefined;
 
     // drop the old manager from disposables too, or dispose() would revisit it
     this.disposables = this.disposables.filter((d) => d !== this.objectsManager);
@@ -773,6 +725,8 @@ export class SceneManager {
     this.objectsManager.ambientLight = ambientLight;
     this.objectsManager.directionalLight = directionalLight;
     this.objectsManager.brightness = brightness;
+    this.objectsManager.boundingBoxColor = boundingBoxColor;
+    if (buildVolumeDef) this.objectsManager.setBuildVolume(buildVolumeDef);
   }
 
   resize(): void {


### PR DESCRIPTION
Stacked on #311 — closes the first item on its "Still open" list.

The build volume and bounding box are scene furniture the ObjectsManager should own, like the path groups: they survive geometry rebuilds untouched, and property changes mutate them in place. `SceneManager` keeps its public accessors and delegates.

### What moves

| | was | is now |
| --- | --- | --- |
| build volume | `SceneManager._buildVolume`, re-`update()`d and re-pushed to disposables every render | `ObjectsManager.setBuildVolume(def)` — created once, kept across rebuilds, disposed with the manager |
| bounding box | `SceneManager` mesh + color fields, created in `renderBoundingBox()` | `ObjectsManager.updateBoundingBox(bounds)` + `setBoundingBoxColor(color)` — recolor and visibility mutate in place |

### Behavior kept

- `clear()` carries the build volume dimensions and the bounding box color onto the replacement manager; the box mesh itself belongs to the cleared job and is released
- Constructing without a build volume still fails the same way (the documented `TypeError`)
- `buildVolume`, `boundingBoxColor` and `boundingBoxMesh` remain readable on `SceneManager`; the demo and DevGUI work unchanged

### Fixes that fall out of the move

- `initScene()` no longer re-pushes the build volume into `disposables` on every render — that grew the array without bound and double-disposed on teardown
- `clear()` no longer orphans the bounding box mesh (one retained geometry + material per clear); the old manager's `dispose()` releases it
- `renderFrame()` drew the bounding box twice per frame
- Bounds that grow while a file streams in now rebuild the box instead of leaving the first chunk's box around the finished model

### Breaking

- The unused public `boundingBoxMesh` setter on `SceneManager` is dropped (the getter stays)
- `BuildVolumeDef` moves to `build-volume.ts`; `scene-manager` re-exports it, so imports keep working

### Tests

15 new state-based tests: build volume create/replace/remove/survives-reset/dispose, bounding box create/recolor-in-place/visibility/reuse/rebuild-on-growth/invalid-bounds/reset/dispose, and the `clear()` carry-over branches. `objects-manager.ts` and `scene-manager.ts` stay at their 100% coverage thresholds.

Assisted by Claude Code - Fable 5