### PR TITLE
Leave the layer range unclipped at the ends of the stack

### DIFF
--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -63,6 +63,8 @@ import { ObjectsManager } from '../objects-manager';
 import { Job } from '../job';
 import { Path, PathType } from '../path';
 import { Color, Group, OrthographicCamera, PerspectiveCamera } from 'three';
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 
 describe('SceneManager properties', () => {
   let sceneManager: SceneManager;
@@ -365,6 +367,48 @@ describe('SceneManager properties', () => {
       sceneManager.endLayer = 1;
 
       expect(spy).toHaveBeenCalled();
+    });
+
+    test('an end layer at the top of the stack leaves the range unbounded', () => {
+      // the demo drives endLayer to countLayers by default; that is no
+      // restriction, so nothing — travel moves above the top layer
+      // included — should be clipped (#278)
+      sceneManager.endLayer = sceneManager.job.countLayers;
+
+      expect(objectsManager(sceneManager).clippingPlanes).toHaveLength(0);
+    });
+
+    test('a start layer at the bottom of the stack adds no lower bound', () => {
+      sceneManager.startLayer = 1;
+
+      expect(objectsManager(sceneManager).clippingPlanes).toHaveLength(0);
+    });
+
+    test('a start layer above the first still bounds the bottom of the range', () => {
+      sceneManager.startLayer = 2;
+
+      const planes = objectsManager(sceneManager).clippingPlanes;
+      const layer = sceneManager.job.layers[1];
+      expect(planes).toHaveLength(1);
+      expect(planes[0].constant).toBe(-(layer.z - layer.height));
+    });
+
+    test('travel lines above the top layer survive a full-stack range', () => {
+      sceneManager.renderTravel = true;
+
+      sceneManager.endLayer = sceneManager.job.countLayers;
+
+      const travel = travelGroup(sceneManager).children[0] as LineSegments2;
+      expect((travel.material as LineMaterial).clippingPlanes).toHaveLength(0);
+    });
+
+    test('a restricted range still clips the travel lines', () => {
+      sceneManager.renderTravel = true;
+
+      sceneManager.endLayer = 1;
+
+      const travel = travelGroup(sceneManager).children[0] as LineSegments2;
+      expect((travel.material as LineMaterial).clippingPlanes).toHaveLength(1);
     });
 
     test('an end-layer-only range leaves the lower bound open instead of NaN', () => {

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -418,8 +418,9 @@ export class ObjectsManager {
    * Applies the current clipping planes to every `LineSegments2` in the scene.
    */
   private updateLineClipping() {
-    // TODO: apply clipping selectively to travels lines and extrusion lines
-    // and/or use a clipping group
+    // travel lines share the extrusions' planes deliberately: a restricted layer
+    // range hides both. An unrestricted range produces no planes at all, which
+    // is what keeps travel moves outside the printed stack visible (#278)
     this.scene.traverse((obj) => {
       if (obj instanceof LineSegments2) {
         (obj.material as LineMaterial).clippingPlanes = this.clippingPlanes;

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -472,19 +472,21 @@ export class SceneManager {
    * Updates the clipping planes for the 3D preview based on the start and end layers.
    *
    * This method calculates the minimum and maximum Z values from the specified start and end layers.
-   * An unset start or end layer leaves that side of the range unbounded.
+   * A bound that is unset — or that sits at the very end of the layer stack — leaves that side of
+   * the range unbounded: an endLayer equal to the layer count is no restriction, so moves outside
+   * the printed layers (travel moves above the top layer, most commonly) stay visible.
    *
    * It then updates the clipping planes for shader materials and line clipping using these Z values.
    *
    */
   updateClippingPlanes() {
-    const startLayer = this.job.layers[this._startLayer - 1];
-    const endLayer = this.job.layers[this._endLayer - 1];
-    // an unset bound must stay undefined: subtracting through `?.` would produce
+    const bottomLayer = this._startLayer > 1 ? this.job.layers[this._startLayer - 1] : undefined;
+    const topLayer = this._endLayer < this.job.layers.length ? this.job.layers[this._endLayer - 1] : undefined;
+    // an open bound must stay undefined: subtracting through `?.` would produce
     // NaN, which passes the !== undefined guards and ends up in plane constants
     // and shader uniforms, where NaN comparisons are undefined behavior in GLSL
-    const minZ = startLayer ? startLayer.z - startLayer.height : undefined;
-    const maxZ = endLayer?.z;
+    const minZ = bottomLayer === undefined ? undefined : bottomLayer.z - bottomLayer.height;
+    const maxZ = topLayer?.z;
 
     this.objectsManager.updateClippingPlanes(minZ, maxZ);
   }


### PR DESCRIPTION
Stacked on #311 — fixes #278, the last-but-one item on its "Still open" list.

### The bug

Travel moves routinely rise above the topmost extrusion layer — a final park move, a wipe. But an `endLayer` equal to the layer count (which the demo sets by default after loading a file) planted a clipping plane exactly at the top extrusion layer, silently hiding every travel above it:

```
      x--------x  travel move (invisible)
----------------  clipping plane at endLayer == countLayers
================  layer n (topmost extrusion)
```

### The fix

A bound that sits at the very end of the stack is no restriction at all, so it now produces **no plane**: `updateClippingPlanes` only bounds a side whose layer is strictly inside the stack (`startLayer > 1`, `endLayer < countLayers`). With the default full range there are no clipping planes anywhere, and travels outside the printed stack stay visible.

A genuinely restricted range behaves exactly as before — it clips travel and extrusion lines alike, since hiding travels outside a range you asked for is the point of the range.

### Why not selective per-group clipping

The `TODO` in `updateLineClipping` suggested exempting travel lines from the extrusions' planes. That would fix the full-range case but also leak travel spaghetti above a *restricted* range, which nobody asked for. With no planes in the unrestricted case there is nothing left to exempt travels from, so the TODO is retired with an explanatory comment instead of implemented.

### Tests

Five new state-based tests: full-stack end layer → zero planes, bottom-of-stack start layer → zero planes, interior start layer still bounds the bottom (exact plane constant), and the #278 scenario asserted on the travel line material itself — zero planes at full range, one plane when restricted. Coverage thresholds stay at 100%.

Assisted by Claude Code - Fable 5