### PR TITLE
Move G-code parser into src/parser and normalize comments

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GCodePreview } from '../gcode-preview';
 import { SceneManager } from '../scene-manager';
-import { Parser } from '../gcode-parser';
+import { Parser } from '../parser/gcode-parser';
 import { DevGUI } from '../dev-gui';
 import { Job } from '../job';
 import { Interpreter } from '../interpreter';
@@ -10,7 +10,7 @@ import { makeDroppable } from '../extra/dom-utils';
 
 // Mock the dependencies
 vi.mock('../scene-manager');
-vi.mock('../gcode-parser');
+vi.mock('../parser/gcode-parser');
 vi.mock('../dev-gui');
 vi.mock('../job');
 vi.mock('../interpreter');

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'vitest';
-import { GCodeCommand, Parser } from '../gcode-parser';
+import { GCodeCommand, Parser } from '../parser/gcode-parser';
 import { Interpreter } from '../interpreter';
 import { Job } from '../job';
 import { PathType } from '../path';

--- a/src/__tests__/parse-thumbnail.ts
+++ b/src/__tests__/parse-thumbnail.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import { Parser } from '../gcode-parser';
+import { Parser } from '../parser/gcode-parser';
 import { Thumbnail } from '../thumbnail';
 
 const gcodeCommentsWithThumbnail = `

--- a/src/__tests__/parser/gcode-parser.ts
+++ b/src/__tests__/parser/gcode-parser.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { GCodeCommand, Parser } from '../gcode-parser';
+import { GCodeCommand, Parser } from '../../parser/gcode-parser';
 
 test('a single extrusion cmd should result in 1 command', () => {
   const parser = new Parser();
@@ -172,22 +172,32 @@ describe('parseCommand tokenizing', () => {
       const cmd = parse('G1 X1 ; move right');
       expect(cmd.gcode).toEqual('g1');
       expect(cmd.params.x).toEqual(1);
-      expect(cmd.comment).toEqual(' move right');
+      expect(cmd.comment).toEqual('move right');
     });
 
     test('stops the comment at a second semicolon', () => {
-      expect(parse('G1 X1 ; first ; second').comment).toEqual(' first ');
+      expect(parse('G1 X1 ; first ; second').comment).toEqual('first');
     });
 
     test('treats an empty comment as absent', () => {
       expect(parse('G1 X1 ;').comment).toBeUndefined();
     });
 
+    test('treats a whitespace-only comment as absent', () => {
+      expect(parse('G1 X1 ;   ').comment).toBeUndefined();
+    });
+
+    test('trims surrounding whitespace off the comment', () => {
+      // Slicers write '; comment' with a space after the semicolon; consumers
+      // (the slicer metadata parsers anchor patterns with ^) rely on the trim.
+      expect(parse('G1 X1 ;   padded   ').comment).toEqual('padded');
+    });
+
     test('parses no command from a comment-only line', () => {
       const cmd = parse('; just a comment');
       expect(cmd.gcode).toEqual('');
       expect(cmd.params).toEqual({});
-      expect(cmd.comment).toEqual(' just a comment');
+      expect(cmd.comment).toEqual('just a comment');
     });
 
     test('drops the comment when asked to', () => {

--- a/src/__tests__/parser/preserving-parser.ts
+++ b/src/__tests__/parser/preserving-parser.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest';
 
-import { Parser } from '../gcode-parser';
+import { Parser } from '../../parser/gcode-parser';
 
 describe('with keepLines', () => {
   test('all input should be preserved', () => {

--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -3,7 +3,7 @@
 import { test, expect, vi, assert } from 'vitest';
 
 import { SceneManager } from '../scene-manager';
-import { GCodeCommand } from '../gcode-parser';
+import { GCodeCommand } from '../parser/gcode-parser';
 
 // add a test for destroying the scene manager which should cancel the render loop.
 test('destroying the scene manager should dispose renderer and controls', async () => {

--- a/src/__tests__/split-chunk.ts
+++ b/src/__tests__/split-chunk.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from 'vitest';
 
 import { splitChunk } from '../helpers/split-chunk';
-import { Parser } from '../gcode-parser';
+import { Parser } from '../parser/gcode-parser';
 
 describe('splitChunk', () => {
   test('keeps the newline out of the tail', () => {

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -1,5 +1,5 @@
 import { SceneManager, SceneManagerOptions } from './scene-manager';
-import { GCodeCommand, Parser } from './gcode-parser';
+import { GCodeCommand, Parser } from './parser/gcode-parser';
 import { Interpreter } from './interpreter';
 import { Job } from './job';
 import { DevGUI, type DevModeOptions } from './dev-gui';

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,5 +1,5 @@
 import { Path, PathType } from './path';
-import { GCodeCommand } from './gcode-parser';
+import { GCodeCommand } from './parser/gcode-parser';
 import { Job } from './job';
 import { State } from './state';
 

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -1,4 +1,4 @@
-import { Thumbnail } from './thumbnail';
+import { Thumbnail } from '../thumbnail';
 
 /**
  * Parameters for G-code commands used in 3D printing.
@@ -251,7 +251,9 @@ export class Parser {
       // only the span up to the next semicolon, matching the previous split(';')[1]
       const nextSemicolon = input.indexOf(';', firstSemicolon + 1);
       const text = nextSemicolon < 0 ? input.slice(firstSemicolon + 1) : input.slice(firstSemicolon + 1, nextSemicolon);
-      comment = text || undefined;
+      // Normalized once here so every consumer sees '; layer 1' and ';layer 1'
+      // identically -- the slicer metadata parsers anchor their patterns with ^.
+      comment = text.trim() || undefined;
     }
 
     let gcode = '';


### PR DESCRIPTION
Part 1 of 4 in the slicer layer-metadata stack (splits up #347).

Relocates `gcode-parser.ts` and its tests into a `parser/` directory to make room for the upcoming slicer metadata parsers, updating all import paths. (The coverage config needs no changes: since #397 the per-file 100% thresholds are generated from the files on disk.)

Behavior change: `parseCommand` now trims the extracted comment once at the source, so every consumer sees `'; layer 1'` and `';layer 1'` identically. Real slicers emit a space after the semicolon; the metadata parsers arriving later in this stack anchor their patterns with `^` and rely on this normalization. Existing comment expectations were updated and trim-specific tests added.

**Stack:** this PR ← slicer-metadata-framework ← metadata-layer-indexing ← additional-slicer-parsers

Assisted by Claude Code - Fable 5

