### PR TITLE
Credit missing contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ Want to help out? We are open to your ideas and always willing to get you starte
 ## Contributors 
 - ❤️ Thank you @0xTHAC0 for adding the orthographic camera.
 - ❤️ Thank you @sophiedeziel for rendering extrusion as tubes and creating a new interpreter.
-- ❤️ Thank you @Sindarius for implementing G2/G3 arc support.
+- ❤️ Thank you @RickRyan26 and @Sindarius for implementing G2/G3 arc support.
 - ❤️ Thank you @Zeng95 for providing a React & Typescript example.
+- ❤️ Thank you @raulodev for parser and preview fixes.
+- ❤️ Thank you @TimTheBig for dependency and tooling updates.
 
 ## Known issues
 ### Preview doesn't render in Brave


### PR DESCRIPTION
## What

Adds three contributors with merged commits on \`develop\` who were missing from the README Contributors section, and co-credits arc support.

Verified by resolving each commit author to their GitHub handle via the API (git author names didn't always match handles):

| GitHub handle | Contribution |
|---|---|
| **@RickRyan26** | Authored the original G2/G3 arc rendering (\`addArcSegment\`, arc math in \`webgl-preview.ts\`, \`g2\`/\`g3\` parsing) — 2023-01. Now co-credited with @Sindarius, who fixed/finished it the next day. |
| **@raulodev** | Parser and preview fixes (\`gcode-parser.ts\`, \`webgl-preview.ts\`) — 2023-11→12. |
| **@TimTheBig** | Dependency and tooling updates (deps, eslint 8, formatting) — 2025-07. |

## Not missing (verified, no change needed)

- **@Sindarius** (git: Juan Rosario) — already credited for arc support.
- **@0xTHAC0** (git: Sumit Ridhal) — already credited for the orthographic camera.

Bots (dependabot, Conductor's Checkpointer) were excluded.

Assisted by Claude Code - claude-opus-4-8