### PR TITLE
Move the color state into the ObjectsManager

### DIFF
--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -409,7 +409,7 @@ describe('ObjectsManager', () => {
 
   describe('renderExtrusions', () => {
     test('renders lines when renderTubes is off', () => {
-      objectsManager.renderExtrusions([createTestPath()], new Color(0x00ff00));
+      objectsManager.renderExtrusions([createTestPath()]);
 
       expect(objectsManager.extrusionsGroup.children[0]).toBeInstanceOf(LineSegments2);
     });
@@ -417,9 +417,29 @@ describe('ObjectsManager', () => {
     test('renders tubes when renderTubes is on', () => {
       objectsManager.renderTubes = true;
 
-      objectsManager.renderExtrusions([createTestPath()], new Color(0x00ff00));
+      objectsManager.renderExtrusions([createTestPath()]);
 
       expect(objectsManager.extrusionsGroup.children[0]).toBeInstanceOf(BatchedMesh);
+    });
+
+    test('draws each tool in the color its array entry resolves to', () => {
+      objectsManager.setExtrusionColor([new Color(0xff0000), new Color(0x0000ff)]);
+
+      objectsManager.renderExtrusions([createTestPath()], 0);
+      objectsManager.renderExtrusions([createTestPath()], 1);
+
+      const [tool0, tool1] = objectsManager.extrusionsGroup.children as LineSegments2[];
+      expect((tool0.material as LineMaterial).color.getHex()).toBe(0xff0000);
+      expect((tool1.material as LineMaterial).color.getHex()).toBe(0x0000ff);
+    });
+
+    test('draws tubes in the color the tool resolves to', () => {
+      objectsManager.renderTubes = true;
+      objectsManager.setExtrusionColor([new Color(0xff0000), new Color(0x0000ff)]);
+
+      objectsManager.renderExtrusions([createTestPath()], 1);
+
+      expect(objectsManager.materials[1].uniforms.uColor.value.getHex()).toBe(0x0000ff);
     });
   });
 
@@ -501,6 +521,31 @@ describe('ObjectsManager', () => {
       expect(() => objectsManager.setBrightness(2)).not.toThrow();
 
       expect(objectsManager.materials[0].uniforms.brightness.value).toBe(2);
+    });
+
+    test('a shrunken color array repaints line-drawn tools with the fallback', () => {
+      objectsManager.setExtrusionColor([new Color(0xff0000), new Color(0x00ff00), new Color(0x0000ff)]);
+      objectsManager.renderExtrusions([createTestPath()], 0);
+      objectsManager.renderExtrusions([createTestPath()], 1);
+      objectsManager.renderExtrusions([createTestPath()], 2);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      objectsManager.setExtrusionColor([new Color(0x123456)]);
+
+      const lines = objectsManager.extrusionsGroup.children as LineSegments2[];
+      lines.forEach((line) => {
+        expect((line.material as LineMaterial).color.getHex()).toBe(0x123456);
+      });
+      warn.mockRestore();
+    });
+
+    test('setTravelColor is used as the default when travel lines draw later', () => {
+      objectsManager.setTravelColor(new Color(0x654321));
+
+      objectsManager.renderTravelLines([createTestPath()]);
+
+      const travel = objectsManager.travelMovesGroup.children[0] as LineSegments2;
+      expect((travel.material as LineMaterial).color.getHex()).toBe(0x654321);
     });
 
     test('setExtrusionColor reuses the existing geometry', () => {

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -236,7 +236,7 @@ describe('ObjectsManager', () => {
 
       expect(objectsManager.materials[0]).not.toBe(objectsManager.materials[1]);
 
-      objectsManager.setExtrusionColor(new Color(0x00ff00), 0);
+      objectsManager.setExtrusionColor([new Color(0x00ff00), color]);
 
       expect(objectsManager.materials[0].uniforms.uColor.value.getHex()).toBe(0x00ff00);
       expect(objectsManager.materials[1].uniforms.uColor.value.getHex()).toBe(0x0000ff);
@@ -433,13 +433,13 @@ describe('ObjectsManager', () => {
       expect(objectsManager.materials[0].uniforms.uColor.value).toBe(color);
     });
 
-    test('setExtrusionColor only recolors the lines of the given tool', () => {
+    test('an array setExtrusionColor recolors each tool independently', () => {
       const original = new Color(0x000000);
       const updated = new Color(0x00ff00);
       objectsManager.renderExtrusionLines([createTestPath()], original, 0);
       objectsManager.renderExtrusionLines([createTestPath()], original, 1);
 
-      objectsManager.setExtrusionColor(updated, 1);
+      objectsManager.setExtrusionColor([original, updated]);
 
       const [tool0, tool1] = objectsManager.extrusionsGroup.children as LineSegments2[];
       expect((tool0.material as LineMaterial).color.equals(original)).toBe(true);

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -250,12 +250,21 @@ describe('SceneManager properties', () => {
 
     test('travelColor recolors the travel lines', () => {
       sceneManager.renderTravel = true;
-      const spy = vi.spyOn(objectsManager(sceneManager), 'setTravelColor');
 
       sceneManager.travelColor = '#ff00ff';
 
-      expect(spy).toHaveBeenCalledWith(new Color('#ff00ff'));
+      const travel = travelGroup(sceneManager).children[0] as LineSegments2;
+      expect((travel.material as LineMaterial).color.getHex()).toBe(0xff00ff);
       expect(sceneManager.travelColor).toEqual(new Color('#ff00ff'));
+    });
+
+    test('travel lines set before drawing get the stored color when they draw', () => {
+      sceneManager.travelColor = '#ff00ff';
+
+      sceneManager.renderTravel = true;
+
+      const travel = travelGroup(sceneManager).children[0] as LineSegments2;
+      expect((travel.material as LineMaterial).color.getHex()).toBe(0xff00ff);
     });
 
     test('backgroundColor updates the scene background', () => {
@@ -530,6 +539,30 @@ describe('SceneManager properties', () => {
 
       expect((sceneManager.extrusionColor as Color).getHex()).toBe(0x123456);
       expect(sceneManager.travelColor.getHex()).toBe(0x654321);
+    });
+
+    test('a missing tool color warns again for the next job', () => {
+      // the warn-once bookkeeping belongs to the swapped manager, so a newly
+      // loaded job — which may have different tools — gets its own warning
+      const job = createJob();
+      const highToolPath = new Path(PathType.Extrusion, 0.6, 0.2, 2);
+      highToolPath.addPoint(0, 0, 0);
+      highToolPath.addPoint(5, 0, 0);
+      job.addPath(highToolPath);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fresh = createSceneManager({ job, extrusionColor: ['#00ff00'] });
+      fresh.render();
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      fresh.clear();
+      fresh.job = job;
+      fresh.render();
+
+      expect(warn).toHaveBeenCalledTimes(2);
+
+      fresh.dispose();
+      warn.mockRestore();
     });
 
     test('keeps renderTubes and the lighting for the next job', () => {

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -166,12 +166,12 @@ describe('SceneManager properties', () => {
 
     test('an array extrusionColor gives each tool its own color when drawing', () => {
       sceneManager.extrusionColor = ['#ff0000', '#0000ff'];
-      const spy = vi.spyOn(objectsManager(sceneManager), 'renderExtrusions');
 
       sceneManager.renderExtrusion = false;
       sceneManager.renderExtrusion = true;
 
-      expect(spy).toHaveBeenCalledWith(expect.anything(), new Color('#ff0000'), 0);
+      const [tool0] = extrusionGroup(sceneManager).children as LineSegments2[];
+      expect((tool0.material as LineMaterial).color.getHex()).toBe(0xff0000);
     });
 
     test('a tool without a configured color falls back to the last one, warning once', () => {
@@ -184,12 +184,11 @@ describe('SceneManager properties', () => {
       job.addPath(highToolPath);
 
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      const fresh = createSceneManager({ job, extrusionColor: ['#00ff00'] });
-      const spy = vi.spyOn(objectsManager(fresh), 'renderExtrusions');
+      const fresh = createSceneManager({ job, renderTubes: true, extrusionColor: ['#00ff00'] });
 
       expect(() => fresh.render()).not.toThrow();
 
-      expect(spy).toHaveBeenCalledWith(expect.anything(), new Color('#00ff00'), 2);
+      expect(objectsManager(fresh).materials[2].uniforms.uColor.value.getHex()).toBe(0x00ff00);
       expect(warn).toHaveBeenCalledWith('No extrusionColor configured for tool index 2, falling back to another color');
 
       fresh.render();
@@ -228,12 +227,13 @@ describe('SceneManager properties', () => {
 
     test('falls back to the default extrusion color when the color array is empty', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      const fresh = createSceneManager({ job: createJob(), extrusionColor: [] });
-      const spy = vi.spyOn(objectsManager(fresh), 'renderExtrusions');
+      const fresh = createSceneManager({ job: createJob(), renderTubes: true, extrusionColor: [] });
 
       expect(() => fresh.render()).not.toThrow();
 
-      expect(spy).toHaveBeenCalledWith(expect.anything(), SceneManager.defaultExtrusionColor, 0);
+      expect(objectsManager(fresh).materials[0].uniforms.uColor.value.getHex()).toBe(
+        SceneManager.defaultExtrusionColor.getHex()
+      );
 
       fresh.dispose();
       warn.mockRestore();
@@ -244,8 +244,7 @@ describe('SceneManager properties', () => {
 
       sceneManager.extrusionColor = ['#ff0000', '#0000ff'];
 
-      expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenLastCalledWith(new Color('#0000ff'), 1);
+      expect(spy).toHaveBeenCalledWith([new Color('#ff0000'), new Color('#0000ff')]);
       expect(sceneManager.extrusionColor).toEqual([new Color('#ff0000'), new Color('#0000ff')]);
     });
 
@@ -521,6 +520,16 @@ describe('SceneManager properties', () => {
       sceneManager.clear();
 
       expect(sceneManager.buildVolume).toBeUndefined();
+    });
+
+    test('keeps the extrusion and travel colors for the next job', () => {
+      sceneManager.extrusionColor = '#123456';
+      sceneManager.travelColor = '#654321';
+
+      sceneManager.clear();
+
+      expect((sceneManager.extrusionColor as Color).getHex()).toBe(0x123456);
+      expect(sceneManager.travelColor.getHex()).toBe(0x654321);
     });
 
     test('keeps renderTubes and the lighting for the next job', () => {

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -40,6 +40,15 @@ export class ObjectsManager {
   directionalLight = 1.3;
   brightness = 1.3;
 
+  /** Default color for extrusions when the caller supplies none */
+  static readonly defaultExtrusionColor = new Color('hotpink');
+  /** Current extrusion color(s); an array is indexed by tool */
+  extrusionColor: Color | Color[] = ObjectsManager.defaultExtrusionColor;
+  /** Current travel move color */
+  travelColor = new Color(0x990000);
+  /** Tool indices already warned about missing an entry in the extrusionColor array */
+  private warnedMissingExtrusionColorIndices = new Set<number>();
+
   lineWidth: number;
   lineHeight: number;
   /** Width of extruded material. Undefined means each path uses its own width. */
@@ -97,11 +106,61 @@ export class ObjectsManager {
   // --- appearance: mutate materials in place, no geometry work ----------------
 
   /**
-   * Recolors the extrusions belonging to one tool, or every tool at once.
-   * @param color - New color
-   * @param toolIndex - Tool to recolor; omit to recolor all tools
+   * Stores the extrusion color(s) and repaints the rendered extrusions in place.
+   * @param value - One color for every tool, or an array indexed by tool
+   * @remarks
+   * Tools already drawn past the end of an array repaint with the fallback
+   * color, so shrinking the array never leaves a tool showing a stale color.
    */
-  setExtrusionColor(color: Color, toolIndex?: number) {
+  setExtrusionColor(value: Color | Color[]) {
+    this.extrusionColor = value;
+
+    if (!Array.isArray(value)) {
+      this.applyExtrusionColor(value);
+      return;
+    }
+
+    value.forEach((color, toolIndex) => this.applyExtrusionColor(color, toolIndex));
+    this.renderedToolIndices().forEach((toolIndex) => {
+      if (toolIndex >= value.length) this.applyExtrusionColor(this.colorForTool(toolIndex), toolIndex);
+    });
+  }
+
+  setTravelColor(color: Color) {
+    this.travelColor = color;
+    this.travelMovesGroup.children.forEach((child) => {
+      if (child instanceof LineSegments2) {
+        (child.material as LineMaterial).color.set(color);
+      }
+    });
+  }
+
+  /**
+   * Resolves the color a tool draws with, falling back when the array has no entry.
+   * @param toolIndex - Tool asking for its color
+   * @remarks
+   * A gcode file can reference more tools than the caller supplied colors for
+   * (e.g. a color array sized for 2 tools rendering a 3-tool file). The array's
+   * last configured color — or the default when the array is empty — is used
+   * instead, warning once per tool index rather than throwing.
+   */
+  private colorForTool(toolIndex: number): Color {
+    if (!Array.isArray(this.extrusionColor)) return this.extrusionColor;
+
+    return this.extrusionColor[toolIndex] ?? this.fallbackExtrusionColor(toolIndex);
+  }
+
+  private fallbackExtrusionColor(toolIndex: number): Color {
+    if (!this.warnedMissingExtrusionColorIndices.has(toolIndex)) {
+      this.warnedMissingExtrusionColorIndices.add(toolIndex);
+      console.warn(`No extrusionColor configured for tool index ${toolIndex}, falling back to another color`);
+    }
+    const colors = this.extrusionColor as Color[];
+    return colors[colors.length - 1] ?? ObjectsManager.defaultExtrusionColor;
+  }
+
+  /** Mutates the materials and lines of one tool — or every tool — in place. */
+  private applyExtrusionColor(color: Color, toolIndex?: number) {
     if (toolIndex === undefined) {
       // a scalar color applies to every tool the job renders with
       this.materials.forEach((material) => {
@@ -123,12 +182,15 @@ export class ObjectsManager {
     });
   }
 
-  setTravelColor(color: Color) {
-    this.travelMovesGroup.children.forEach((child) => {
-      if (child instanceof LineSegments2) {
-        (child.material as LineMaterial).color.set(color);
-      }
+  /** The tool indices that currently have something drawn in the scene. */
+  private renderedToolIndices(): number[] {
+    const indices = new Set<number>();
+    // forEach skips the holes of the sparse per-tool array
+    this.materials.forEach((material, toolIndex) => indices.add(toolIndex));
+    this.extrusionsGroup.children.forEach((child) => {
+      if (child instanceof LineSegments2) indices.add(child.userData.toolIndex);
     });
+    return [...indices];
   }
 
   setAmbientLight(value: number) {
@@ -240,7 +302,7 @@ export class ObjectsManager {
 
   // --- rendering --------------------------------------------------------------
 
-  renderTravelLines(paths: Path[], color: Color) {
+  renderTravelLines(paths: Path[], color = this.travelColor) {
     const unrenderedPaths = this.takeUnrendered(paths);
     if (unrenderedPaths.length === 0) return;
 
@@ -248,9 +310,11 @@ export class ObjectsManager {
   }
 
   /**
-   * Renders extrusions in whichever representation is currently selected.
+   * Renders a tool's extrusions in whichever representation is currently
+   * selected, in the color the tool resolves to.
    */
-  renderExtrusions(paths: Path[], color: Color, toolIndex = 0) {
+  renderExtrusions(paths: Path[], toolIndex = 0) {
+    const color = this.colorForTool(toolIndex);
     if (this.renderTubes) {
       this.renderExtrusionTubes(paths, color, toolIndex);
     } else {

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -113,11 +113,7 @@ export class SceneManager {
   /** Disposable resources */
   private disposables: Disposable[] = [];
   /** Default extrusion color */
-  static readonly defaultExtrusionColor = new Color('hotpink');
-  /** Current extrusion color(s) */
-  private _extrusionColor: Color | Color[] = SceneManager.defaultExtrusionColor;
-  /** Tool indices already warned about missing an entry in the extrusionColor array */
-  private warnedMissingExtrusionColorIndices = new Set<number>();
+  static readonly defaultExtrusionColor = ObjectsManager.defaultExtrusionColor;
   /** Animation frame ID */
   private animationFrameId?: number;
   /** Current path index for animated rendering */
@@ -127,8 +123,6 @@ export class SceneManager {
   // colors
   /** Background color */
   private _backgroundColor = new Color(0xe0e0e0);
-  /** Travel move color */
-  private _travelColor = new Color(0x990000);
   /** Top layer color */
   private _topLayerColor?: Color;
   /** Last segment color */
@@ -257,7 +251,7 @@ export class SceneManager {
    * @returns Color or array of colors for extruded paths
    */
   get extrusionColor(): Color | Color[] {
-    return this._extrusionColor;
+    return this.objectsManager.extrusionColor;
   }
 
   /**
@@ -265,19 +259,9 @@ export class SceneManager {
    * @param value - Color value(s) as number, string, Color instance, or array of ColorRepresentation
    */
   set extrusionColor(value: number | string | Color | ColorRepresentation[]) {
-    if (Array.isArray(value)) {
-      this._extrusionColor = value.map((color) => new Color(color));
-      this._extrusionColor.forEach((color, index) => this.objectsManager.setExtrusionColor(color, index));
-      // tools past the end of the array draw with the fallback, so recolor them too
-      for (let index = this._extrusionColor.length; index < (this.job?.toolPaths.length ?? 0); index++) {
-        if (!this.job.toolPaths[index]?.length) continue;
-        this.objectsManager.setExtrusionColor(this.fallbackExtrusionColor(index), index);
-      }
-      return;
-    }
-
-    this._extrusionColor = new Color(value);
-    this.objectsManager.setExtrusionColor(this._extrusionColor);
+    this.objectsManager.setExtrusionColor(
+      Array.isArray(value) ? value.map((color) => new Color(color)) : new Color(value)
+    );
   }
 
   /**
@@ -302,7 +286,7 @@ export class SceneManager {
    * @returns Current travel move color
    */
   get travelColor(): Color {
-    return this._travelColor;
+    return this.objectsManager.travelColor;
   }
 
   /**
@@ -310,8 +294,7 @@ export class SceneManager {
    * @param value - Color value as number, string, or Color instance
    */
   set travelColor(value: number | string | Color) {
-    this._travelColor = new Color(value);
-    this.objectsManager.setTravelColor(this._travelColor);
+    this.objectsManager.setTravelColor(new Color(value));
   }
 
   /**
@@ -703,7 +686,7 @@ export class SceneManager {
     // read the settings off the outgoing manager before it is torn down
     const { lineWidth, lineHeight, extrusionWidth, renderTubes, ambientLight, directionalLight, brightness } =
       this.objectsManager;
-    const { buildVolume, boundingBoxColor } = this.objectsManager;
+    const { buildVolume, boundingBoxColor, extrusionColor, travelColor } = this.objectsManager;
     // the bounding box belongs to the outgoing job, but the build volume does not:
     // it is recreated on the replacement manager from the same dimensions
     const buildVolumeDef = buildVolume
@@ -726,6 +709,8 @@ export class SceneManager {
     this.objectsManager.directionalLight = directionalLight;
     this.objectsManager.brightness = brightness;
     this.objectsManager.boundingBoxColor = boundingBoxColor;
+    this.objectsManager.extrusionColor = extrusionColor;
+    this.objectsManager.travelColor = travelColor;
     if (buildVolumeDef) this.objectsManager.setBuildVolume(buildVolumeDef);
   }
 
@@ -790,38 +775,15 @@ export class SceneManager {
   private renderPaths(endPathNumber: number = Infinity): void {
     this.objectsManager.setTravelsVisible(this._renderTravel);
     if (this._renderTravel) {
-      this.objectsManager.renderTravelLines(
-        this.job.travels.slice(this.renderPathIndex, endPathNumber),
-        this._travelColor
-      );
+      this.objectsManager.renderTravelLines(this.job.travels.slice(this.renderPathIndex, endPathNumber));
     }
 
     this.objectsManager.setExtrusionsVisible(this._renderExtrusion);
     if (this._renderExtrusion && this.job?.toolPaths.length > 0) {
       this.job.toolPaths.forEach((toolPaths, index) => {
-        const color = Array.isArray(this._extrusionColor)
-          ? (this._extrusionColor[index] ?? this.fallbackExtrusionColor(index))
-          : this._extrusionColor;
-        this.objectsManager.renderExtrusions(toolPaths.slice(this.renderPathIndex, endPathNumber), color, index);
+        this.objectsManager.renderExtrusions(toolPaths.slice(this.renderPathIndex, endPathNumber), index);
       });
     }
-  }
-
-  /**
-   * Falls back to a usable color when extrusionColor is an array with no entry for a tool index
-   * @param toolIndex - Tool index missing a configured color
-   * @returns The array's last configured color, or the default extrusion color if the array is empty
-   * @remarks
-   * A gcode file can reference more tools than the caller supplied colors for (e.g. a color array
-   * sized for 2 tools rendering a 3-tool file). Warns once per tool index instead of throwing.
-   */
-  private fallbackExtrusionColor(toolIndex: number): Color {
-    if (!this.warnedMissingExtrusionColorIndices.has(toolIndex)) {
-      this.warnedMissingExtrusionColorIndices.add(toolIndex);
-      console.warn(`No extrusionColor configured for tool index ${toolIndex}, falling back to another color`);
-    }
-    const colors = this._extrusionColor as Color[];
-    return colors[colors.length - 1] ?? SceneManager.defaultExtrusionColor;
   }
 
   saveCamera() {


### PR DESCRIPTION
Stacked on #380 (which stacks on #311) — the next slice of moving job-derived scene state into the manager.

### The problem

The manager owned the materials and performed every recolor, but `SceneManager` held the source of truth: `_extrusionColor`, `_travelColor`, and the per-tool fallback with its warn-once bookkeeping. Every `renderPaths` call computed each tool's color before handing it over, and `clear()` only worked because the colors happened to live outside the manager being swapped.

### What moves

| | was | is now |
| --- | --- | --- |
| extrusion color(s) | `SceneManager._extrusionColor` + fallback logic in `renderPaths` | `ObjectsManager.extrusionColor` + private `colorForTool()` |
| travel color | `SceneManager._travelColor`, passed on every render call | `ObjectsManager.travelColor`; `renderTravelLines` defaults to it |
| `setExtrusionColor` | per-tool material mutator `(color, toolIndex?)` | takes the full value `(Color \| Color[])`, stores it, repaints in place |
| default color | `SceneManager.defaultExtrusionColor` | lives on the manager; the SceneManager static stays as an alias |

`renderExtrusions(paths, toolIndex)` now resolves its own color, so `renderPaths` passes no colors at all, and `clear()` carries both colors onto the replacement manager like the other settings.

### A small robustness win

Repainting tools beyond a shrunken color array now derives the tool list from what is actually drawn (the per-tool materials and the lines' `userData.toolIndex`) instead of `job.toolPaths` — the setter no longer needs the job, so it is inherently safe after `clear()`.

### Behavior notes (deliberate, minor)

- The warn-once set for missing tool colors now resets on `clear()` (it lives on the swapped manager), so a newly loaded file can warn again — arguably more correct, since it may have different tools.
- `SceneManager`'s public color accessors are unchanged; the demo and DevGUI need no edits.

### Tests

The existing color suites were rewritten against the new API — mostly turning spy assertions into state assertions on the actual materials (the fallback tests now check `uColor` uniforms instead of call arguments). A `clear()` carry-over test is added. Both files hold their 100% coverage thresholds; 394 tests green.

Assisted by Claude Code - Fable 5