### PR TITLE
Pin the public API surface with runtime and type-level tests

### DIFF
--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -48,15 +48,15 @@ describe('public API types', () => {
         | 'endLayer'
         | 'extrusionColor'
         | 'initialCameraPosition'
-        | 'lastSegmentColor' // no-op today — debated in #356
+        | 'lastSegmentColor'
         | 'lineWidth'
         | 'lineHeight'
         | 'renderExtrusion'
         | 'renderTravel'
         | 'startLayer'
-        | 'topLayerColor' // no-op today — debated in #356
+        | 'topLayerColor'
         | 'travelColor'
-        | 'disableGradient' // no-op today — debated in #356
+        | 'disableGradient'
         | 'extrusionWidth'
         | 'renderTubes'
         | 'boundingBoxColor'
@@ -75,10 +75,6 @@ describe('public API types', () => {
         ColorRepresentation | ColorRepresentation[] | undefined
       >();
       expectTypeOf<GCodePreviewOptions['travelColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
-      // topLayerColor, lastSegmentColor and disableGradient are accepted and
-      // stored but never read by the render path today. Whether they are
-      // re-implemented or removed for 3.0 is debated in #356 — if removed,
-      // drop every pin marked "#356" as part of that breaking change.
       expectTypeOf<GCodePreviewOptions['topLayerColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
       expectTypeOf<GCodePreviewOptions['lastSegmentColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
       expectTypeOf<GCodePreviewOptions['boundingBoxColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
@@ -91,7 +87,7 @@ describe('public API types', () => {
       expectTypeOf<GCodePreviewOptions['renderExtrusion']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['renderTravel']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['renderTubes']>().toEqualTypeOf<boolean | undefined>();
-      expectTypeOf<GCodePreviewOptions['disableGradient']>().toEqualTypeOf<boolean | undefined>(); // debated in #356
+      expectTypeOf<GCodePreviewOptions['disableGradient']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['orthographic']>().toEqualTypeOf<boolean | undefined>();
     });
 
@@ -113,16 +109,16 @@ describe('public API types', () => {
         | 'endLayer'
         | 'extrusionColor'
         | 'initialCameraPosition'
-        | 'lastSegmentColor' // no-op today — debated in #356
+        | 'lastSegmentColor'
         | 'lineWidth'
         | 'lineHeight'
         | 'minLayerThreshold'
         | 'renderExtrusion'
         | 'renderTravel'
         | 'startLayer'
-        | 'topLayerColor' // no-op today — debated in #356
+        | 'topLayerColor'
         | 'travelColor'
-        | 'disableGradient' // no-op today — debated in #356
+        | 'disableGradient'
         | 'extrusionWidth'
         | 'renderTubes'
         | 'boundingBoxColor'
@@ -195,8 +191,8 @@ describe('public API types', () => {
         sm.extrusionColor = ['#ff0000', '#00ff00'];
         sm.backgroundColor = '#000000';
         sm.travelColor = 0x123456;
-        sm.topLayerColor = 'red'; // no-op today — debated in #356
-        sm.lastSegmentColor = 'red'; // no-op today — debated in #356
+        sm.topLayerColor = 'red';
+        sm.lastSegmentColor = 'red';
         sm.boundingBoxColor = 'red';
         sm.buildVolume = { x: 200, y: 200, z: 200, smallGrid: undefined };
         sm.lineWidth = 2;
@@ -208,7 +204,7 @@ describe('public API types', () => {
         sm.renderExtrusion = true;
         sm.renderTravel = false;
         sm.renderTubes = true;
-        sm.disableGradient = false; // no-op today — debated in #356
+        sm.disableGradient = false;
         sm.brightness = 1;
         sm.orthographic = false;
       };

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -48,15 +48,15 @@ describe('public API types', () => {
         | 'endLayer'
         | 'extrusionColor'
         | 'initialCameraPosition'
-        | 'lastSegmentColor'
+        | 'lastSegmentColor' // no-op today — debated in #356
         | 'lineWidth'
         | 'lineHeight'
         | 'renderExtrusion'
         | 'renderTravel'
         | 'startLayer'
-        | 'topLayerColor'
+        | 'topLayerColor' // no-op today — debated in #356
         | 'travelColor'
-        | 'disableGradient'
+        | 'disableGradient' // no-op today — debated in #356
         | 'extrusionWidth'
         | 'renderTubes'
         | 'boundingBoxColor'
@@ -75,6 +75,10 @@ describe('public API types', () => {
         ColorRepresentation | ColorRepresentation[] | undefined
       >();
       expectTypeOf<GCodePreviewOptions['travelColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      // topLayerColor, lastSegmentColor and disableGradient are accepted and
+      // stored but never read by the render path today. Whether they are
+      // re-implemented or removed for 3.0 is debated in #356 — if removed,
+      // drop every pin marked "#356" as part of that breaking change.
       expectTypeOf<GCodePreviewOptions['topLayerColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
       expectTypeOf<GCodePreviewOptions['lastSegmentColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
       expectTypeOf<GCodePreviewOptions['boundingBoxColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
@@ -87,7 +91,7 @@ describe('public API types', () => {
       expectTypeOf<GCodePreviewOptions['renderExtrusion']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['renderTravel']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['renderTubes']>().toEqualTypeOf<boolean | undefined>();
-      expectTypeOf<GCodePreviewOptions['disableGradient']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['disableGradient']>().toEqualTypeOf<boolean | undefined>(); // debated in #356
       expectTypeOf<GCodePreviewOptions['orthographic']>().toEqualTypeOf<boolean | undefined>();
     });
 
@@ -109,16 +113,16 @@ describe('public API types', () => {
         | 'endLayer'
         | 'extrusionColor'
         | 'initialCameraPosition'
-        | 'lastSegmentColor'
+        | 'lastSegmentColor' // no-op today — debated in #356
         | 'lineWidth'
         | 'lineHeight'
         | 'minLayerThreshold'
         | 'renderExtrusion'
         | 'renderTravel'
         | 'startLayer'
-        | 'topLayerColor'
+        | 'topLayerColor' // no-op today — debated in #356
         | 'travelColor'
-        | 'disableGradient'
+        | 'disableGradient' // no-op today — debated in #356
         | 'extrusionWidth'
         | 'renderTubes'
         | 'boundingBoxColor'
@@ -191,8 +195,8 @@ describe('public API types', () => {
         sm.extrusionColor = ['#ff0000', '#00ff00'];
         sm.backgroundColor = '#000000';
         sm.travelColor = 0x123456;
-        sm.topLayerColor = 'red';
-        sm.lastSegmentColor = 'red';
+        sm.topLayerColor = 'red'; // no-op today — debated in #356
+        sm.lastSegmentColor = 'red'; // no-op today — debated in #356
         sm.boundingBoxColor = 'red';
         sm.buildVolume = { x: 200, y: 200, z: 200, smallGrid: undefined };
         sm.lineWidth = 2;
@@ -204,7 +208,7 @@ describe('public API types', () => {
         sm.renderExtrusion = true;
         sm.renderTravel = false;
         sm.renderTubes = true;
-        sm.disableGradient = false;
+        sm.disableGradient = false; // no-op today — debated in #356
         sm.brightness = 1;
         sm.orthographic = false;
       };

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -1,0 +1,270 @@
+/**
+ * Public API surface pins (type-level half).
+ *
+ * Checked by the vitest typecheck pass (enabled in vitest.config.mts), so
+ * these assertions run as part of `npm test` and CI. They pin the *types* a
+ * 3.x consumer compiles against: option-object fields, method signatures and
+ * setter assignability. The runtime half lives in `public-api.ts`.
+ *
+ * The typecheck pass compiles with tsconfig.typecheck.json (strict mode),
+ * because expect-type assertions silently pass without strictNullChecks.
+ * Expected types below are therefore written with explicit `undefined`/`null`
+ * members, matching what a strict-mode consumer sees.
+ */
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ColorRepresentation } from 'three';
+
+import type {
+  GCodePreview,
+  SceneManager,
+  Parser,
+  GCodeCommand,
+  Job,
+  GCodePreviewOptions,
+  SceneManagerOptions,
+  DevModeOptions
+} from '../gcode-preview';
+import {
+  GCodePreview as GCodePreviewClass,
+  SceneManager as SceneManagerClass,
+  Parser as ParserClass,
+  GCodeCommand as GCodeCommandClass,
+  Job as JobClass
+} from '../gcode-preview';
+
+describe('public API types', () => {
+  describe('GCodePreviewOptions', () => {
+    it('has exactly the documented option keys', () => {
+      expectTypeOf<keyof GCodePreviewOptions>().toEqualTypeOf<
+        // LibOptions
+        | 'devMode'
+        | 'minLayerThreshold'
+        | 'droppable'
+        | 'keepLines'
+        // SceneManagerOptions
+        | 'buildVolume'
+        | 'backgroundColor'
+        | 'canvas'
+        | 'endLayer'
+        | 'extrusionColor'
+        | 'initialCameraPosition'
+        | 'lastSegmentColor'
+        | 'lineWidth'
+        | 'lineHeight'
+        | 'renderExtrusion'
+        | 'renderTravel'
+        | 'startLayer'
+        | 'topLayerColor'
+        | 'travelColor'
+        | 'disableGradient'
+        | 'extrusionWidth'
+        | 'renderTubes'
+        | 'boundingBoxColor'
+        | 'orthographic'
+      >();
+    });
+
+    it('keeps the documented option field types', () => {
+      expectTypeOf<GCodePreviewOptions['devMode']>().toEqualTypeOf<boolean | DevModeOptions | undefined>();
+      expectTypeOf<GCodePreviewOptions['minLayerThreshold']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['droppable']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['keepLines']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['canvas']>().toEqualTypeOf<HTMLCanvasElement | undefined>();
+      expectTypeOf<GCodePreviewOptions['backgroundColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      expectTypeOf<GCodePreviewOptions['extrusionColor']>().toEqualTypeOf<
+        ColorRepresentation | ColorRepresentation[] | undefined
+      >();
+      expectTypeOf<GCodePreviewOptions['travelColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      expectTypeOf<GCodePreviewOptions['topLayerColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      expectTypeOf<GCodePreviewOptions['lastSegmentColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      expectTypeOf<GCodePreviewOptions['boundingBoxColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
+      expectTypeOf<GCodePreviewOptions['initialCameraPosition']>().toEqualTypeOf<number[] | undefined>();
+      expectTypeOf<GCodePreviewOptions['lineWidth']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['lineHeight']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['extrusionWidth']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['startLayer']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['endLayer']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodePreviewOptions['renderExtrusion']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['renderTravel']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['renderTubes']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['disableGradient']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['orthographic']>().toEqualTypeOf<boolean | undefined>();
+    });
+
+    it('keeps the buildVolume shape', () => {
+      expectTypeOf<keyof NonNullable<GCodePreviewOptions['buildVolume']>>().toEqualTypeOf<
+        'x' | 'y' | 'z' | 'smallGrid'
+      >();
+      expectTypeOf<NonNullable<GCodePreviewOptions['buildVolume']>['x']>().toEqualTypeOf<number>();
+      expectTypeOf<NonNullable<GCodePreviewOptions['buildVolume']>['y']>().toEqualTypeOf<number>();
+      expectTypeOf<NonNullable<GCodePreviewOptions['buildVolume']>['z']>().toEqualTypeOf<number>();
+      expectTypeOf<NonNullable<GCodePreviewOptions['buildVolume']>['smallGrid']>().toEqualTypeOf<boolean | undefined>();
+    });
+
+    it('SceneManagerOptions is the scene subset of GCodePreviewOptions', () => {
+      expectTypeOf<keyof SceneManagerOptions>().toEqualTypeOf<
+        | 'buildVolume'
+        | 'backgroundColor'
+        | 'canvas'
+        | 'endLayer'
+        | 'extrusionColor'
+        | 'initialCameraPosition'
+        | 'lastSegmentColor'
+        | 'lineWidth'
+        | 'lineHeight'
+        | 'minLayerThreshold'
+        | 'renderExtrusion'
+        | 'renderTravel'
+        | 'startLayer'
+        | 'topLayerColor'
+        | 'travelColor'
+        | 'disableGradient'
+        | 'extrusionWidth'
+        | 'renderTubes'
+        | 'boundingBoxColor'
+        | 'orthographic'
+      >();
+    });
+  });
+
+  describe('DevModeOptions', () => {
+    it('has exactly the documented keys and field types', () => {
+      expectTypeOf<keyof DevModeOptions>().toEqualTypeOf<
+        'camera' | 'sceneManager' | 'parser' | 'buildVolume' | 'devHelpers' | 'statsContainer'
+      >();
+      expectTypeOf<DevModeOptions['camera']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<DevModeOptions['sceneManager']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<DevModeOptions['parser']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<DevModeOptions['buildVolume']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<DevModeOptions['devHelpers']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<DevModeOptions['statsContainer']>().toEqualTypeOf<HTMLElement | undefined>();
+    });
+  });
+
+  describe('GCodePreview', () => {
+    it('is constructed from GCodePreviewOptions', () => {
+      expectTypeOf<ConstructorParameters<typeof GCodePreviewClass>>().toEqualTypeOf<[GCodePreviewOptions]>();
+    });
+
+    it('keeps its public properties and accessors', () => {
+      expectTypeOf<GCodePreview['job']>().toEqualTypeOf<Job>();
+      expectTypeOf<GCodePreview['sceneManager']>().toEqualTypeOf<SceneManager>();
+      expectTypeOf<GCodePreview['parser']>().toEqualTypeOf<Parser>();
+      expectTypeOf<GCodePreview['countLayers']>().toEqualTypeOf<number>();
+      expectTypeOf<GCodePreview['devMode']>().toEqualTypeOf<boolean | DevModeOptions | undefined>();
+      expectTypeOf<GCodePreview['onJobUpdated']>().toEqualTypeOf<((job: Job) => void) | undefined>();
+      expectTypeOf<GCodePreview['onStreamEnd']>().toEqualTypeOf<(() => void) | undefined>();
+    });
+
+    it('keeps its public method signatures', () => {
+      expectTypeOf<GCodePreview['clear']>().toEqualTypeOf<() => void>();
+      expectTypeOf<GCodePreview['dispose']>().toEqualTypeOf<() => void>();
+      expectTypeOf<GCodePreview['processGCode']>().toEqualTypeOf<(gcode: string | string[]) => Promise<void>>();
+      expectTypeOf<GCodePreview['processGCodeStream']>().toEqualTypeOf<
+        (gcode: string | string[] | ReadableStream, options?: { render?: boolean }) => Promise<void>
+      >();
+      expectTypeOf<GCodePreview['readStream']>().toEqualTypeOf<(stream: ReadableStream) => Promise<void>>();
+    });
+  });
+
+  describe('SceneManager', () => {
+    it('is constructed from SceneManagerOptions and a Job', () => {
+      expectTypeOf<ConstructorParameters<typeof SceneManagerClass>>().toEqualTypeOf<[SceneManagerOptions, Job]>();
+    });
+
+    it('keeps its public method signatures', () => {
+      expectTypeOf<SceneManager['job']>().toEqualTypeOf<Job>();
+      expectTypeOf<SceneManager['canvas']>().toEqualTypeOf<HTMLCanvasElement>();
+      expectTypeOf<SceneManager['render']>().toEqualTypeOf<() => void>();
+      expectTypeOf<SceneManager['renderAnimated']>().toEqualTypeOf<(pathCount?: number) => Promise<void>>();
+      expectTypeOf<SceneManager['dispose']>().toEqualTypeOf<() => void>();
+      expectTypeOf<SceneManager['resize']>().toEqualTypeOf<() => void>();
+      expectTypeOf<SceneManager['clear']>().toEqualTypeOf<() => void>();
+    });
+
+    it('keeps setter assignability for consumers', () => {
+      // A compile-only contract: each assignment below must keep compiling
+      // for 3.x consumers. The function is never called.
+      const setterContract = (sm: SceneManager): void => {
+        sm.extrusionColor = 'hotpink';
+        sm.extrusionColor = 0xff00ff;
+        sm.extrusionColor = ['#ff0000', '#00ff00'];
+        sm.backgroundColor = '#000000';
+        sm.travelColor = 0x123456;
+        sm.topLayerColor = 'red';
+        sm.lastSegmentColor = 'red';
+        sm.boundingBoxColor = 'red';
+        sm.buildVolume = { x: 200, y: 200, z: 200, smallGrid: undefined };
+        sm.lineWidth = 2;
+        sm.lineHeight = 0.2;
+        sm.extrusionWidth = 0.4;
+        sm.startLayer = 1;
+        sm.endLayer = 10;
+        sm.singleLayerMode = true;
+        sm.renderExtrusion = true;
+        sm.renderTravel = false;
+        sm.renderTubes = true;
+        sm.disableGradient = false;
+        sm.brightness = 1;
+        sm.orthographic = false;
+      };
+      expectTypeOf(setterContract).toBeFunction();
+    });
+  });
+
+  describe('Parser', () => {
+    it('is constructed from optional parser options', () => {
+      expectTypeOf<ConstructorParameters<typeof ParserClass>>().toEqualTypeOf<[{ keepLines?: boolean }?]>();
+    });
+
+    it('keeps its public fields and method signatures', () => {
+      expectTypeOf<Parser['lines']>().toEqualTypeOf<string[]>();
+      expectTypeOf<Parser['lineCount']>().toEqualTypeOf<number>();
+      expectTypeOf<keyof Parser['metadata']>().toEqualTypeOf<'thumbnails'>();
+      expectTypeOf<Parameters<Parser['parseGCode']>>().toEqualTypeOf<[string | string[]]>();
+      expectTypeOf<keyof ReturnType<Parser['parseGCode']>>().toEqualTypeOf<'metadata' | 'commands'>();
+      expectTypeOf<ReturnType<Parser['parseGCode']>['commands']>().toEqualTypeOf<GCodeCommand[]>();
+      expectTypeOf<Parameters<Parser['parseCommand']>>().toEqualTypeOf<[string, boolean?]>();
+      expectTypeOf<ReturnType<Parser['parseCommand']>>().toEqualTypeOf<GCodeCommand | null>();
+    });
+  });
+
+  describe('GCodeCommand', () => {
+    it('keeps its public fields', () => {
+      expectTypeOf<GCodeCommand['src']>().toEqualTypeOf<string>();
+      expectTypeOf<GCodeCommand['gcode']>().toEqualTypeOf<string>();
+      expectTypeOf<GCodeCommand['comment']>().toEqualTypeOf<string | undefined>();
+      // Well-known G-code parameters plus the open index signature.
+      expectTypeOf<GCodeCommand['params']['x']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodeCommand['params']['e']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodeCommand['params']['f']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<GCodeCommand['params']['customWord']>().toEqualTypeOf<number | undefined>();
+    });
+
+    it('is constructed from src, gcode, params and optional comment', () => {
+      expectTypeOf<ConstructorParameters<typeof GCodeCommandClass>>().toEqualTypeOf<
+        [string, string, GCodeCommand['params'], string?]
+      >();
+    });
+  });
+
+  describe('Job', () => {
+    it('is constructed from optional state and layer threshold', () => {
+      expectTypeOf<ConstructorParameters<typeof JobClass>>().toEqualTypeOf<
+        [{ state?: Job['state']; minLayerThreshold?: number }?]
+      >();
+    });
+
+    it('keeps its public fields, getters and method signatures', () => {
+      expectTypeOf<Job['countLayers']>().toEqualTypeOf<number>();
+      expectTypeOf<Job['isPlanar']>().toEqualTypeOf<boolean>();
+      expectTypeOf<Job['extrusions']>().toEqualTypeOf<Job['paths']>();
+      expectTypeOf<Job['travels']>().toEqualTypeOf<Job['paths']>();
+      expectTypeOf<Job['toolPaths']>().toEqualTypeOf<Job['paths'][]>();
+      expectTypeOf<Job['inprogressPath']>().toEqualTypeOf<Job['paths'][number] | undefined>();
+      expectTypeOf<Job['addPath']>().toEqualTypeOf<(path: Job['paths'][number]) => void>();
+      expectTypeOf<Job['finishPath']>().toEqualTypeOf<() => void>();
+      expectTypeOf<Job['resumeLastPath']>().toEqualTypeOf<() => void>();
+    });
+  });
+});

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -1,0 +1,238 @@
+/**
+ * Public API surface pins (runtime half).
+ *
+ * This file spells out the library's public contract: every named export,
+ * every public method, accessor and constructor arity a 3.x consumer can
+ * rely on. If a change lands here unintentionally, it is a breaking change.
+ * If it is intentional, update the manifest below in the same PR and call
+ * the change out in the release notes.
+ *
+ * The type-level half of the contract (options-object fields, method
+ * signatures, setter assignability) lives in `public-api.test-d.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { Color } from 'three';
+
+import * as api from '../gcode-preview';
+import { GCodePreview, SceneManager, Parser, GCodeCommand, Job } from '../gcode-preview';
+import packageJson from '../../package.json';
+
+/** Names of prototype members that are plain methods. */
+function methodNames(proto: object): string[] {
+  return Object.getOwnPropertyNames(proto).filter(
+    (name) => name !== 'constructor' && typeof Object.getOwnPropertyDescriptor(proto, name)?.value === 'function'
+  );
+}
+
+/** Names of prototype members that have a getter. */
+function getterNames(proto: object): string[] {
+  return Object.getOwnPropertyNames(proto).filter((name) => Object.getOwnPropertyDescriptor(proto, name)?.get);
+}
+
+/** Names of prototype members that have a setter. */
+function setterNames(proto: object): string[] {
+  return Object.getOwnPropertyNames(proto).filter((name) => Object.getOwnPropertyDescriptor(proto, name)?.set);
+}
+
+describe('public API surface', () => {
+  describe('package entry points', () => {
+    it('points main and types at the bundled build', () => {
+      expect(packageJson.main).toBe('dist/gcode-preview.es.js');
+      expect(packageJson.types).toBe('dist/gcode-preview.d.ts');
+      expect(packageJson.files).toEqual(['dist']);
+    });
+  });
+
+  describe('module exports', () => {
+    it('exposes exactly the documented runtime exports', () => {
+      // Type-only exports (GCodePreviewOptions, SceneManagerOptions,
+      // DevModeOptions) are erased at runtime and pinned in the .test-d file.
+      expect(Object.keys(api).sort()).toEqual(['GCodeCommand', 'GCodePreview', 'Job', 'Parser', 'SceneManager']);
+    });
+
+    it('has no default export', () => {
+      expect((api as { default?: unknown }).default).toBeUndefined();
+    });
+  });
+
+  describe('GCodePreview', () => {
+    it('takes a single required options argument', () => {
+      expect(GCodePreview.length).toBe(1);
+    });
+
+    // name -> arity of required parameters
+    const methods: Record<string, number> = {
+      clear: 0,
+      processGCode: 1,
+      processGCodeStream: 1,
+      readStream: 1,
+      dispose: 0
+    };
+
+    it.each(Object.entries(methods))('has method %s with %d required parameter(s)', (name, arity) => {
+      const method = Object.getOwnPropertyDescriptor(GCodePreview.prototype, name)?.value;
+      expect(typeof method).toBe('function');
+      expect(method).toHaveLength(arity);
+    });
+
+    it.each(['sceneManager', 'parser', 'countLayers', 'devMode'])('has getter %s', (name) => {
+      expect(getterNames(GCodePreview.prototype)).toContain(name);
+    });
+
+    it('has setter devMode', () => {
+      expect(setterNames(GCodePreview.prototype)).toContain('devMode');
+    });
+  });
+
+  describe('SceneManager', () => {
+    it('takes options and a job', () => {
+      expect(SceneManager.length).toBe(2);
+    });
+
+    it('exposes the default extrusion color as a static Color', () => {
+      expect(SceneManager.defaultExtrusionColor).toBeInstanceOf(Color);
+    });
+
+    const methods: Record<string, number> = {
+      updateClippingPlanes: 0,
+      animate: 0,
+      render: 0,
+      renderAnimated: 0,
+      createBoundingBox: 0,
+      clear: 0,
+      resize: 0,
+      dispose: 0,
+      saveCamera: 0,
+      loadCamera: 0,
+      clearCamera: 0
+    };
+
+    it.each(Object.entries(methods))('has method %s with %d required parameter(s)', (name, arity) => {
+      const method = Object.getOwnPropertyDescriptor(SceneManager.prototype, name)?.value;
+      expect(typeof method).toBe('function');
+      expect(method).toHaveLength(arity);
+    });
+
+    // Every accessor a consumer can both read and assign.
+    const accessors = [
+      'buildVolume',
+      'extrusionColor',
+      'backgroundColor',
+      'travelColor',
+      'topLayerColor',
+      'lastSegmentColor',
+      'boundingBoxColor',
+      'startLayer',
+      'endLayer',
+      'singleLayerMode',
+      'renderExtrusion',
+      'renderTravel',
+      'renderTubes',
+      'boundingBoxMesh',
+      'lineWidth',
+      'lineHeight',
+      'extrusionWidth',
+      'disableGradient',
+      'ambientLight',
+      'directionalLight',
+      'brightness',
+      'orthographic'
+    ];
+
+    it.each(accessors)('has getter and setter %s', (name) => {
+      expect(getterNames(SceneManager.prototype)).toContain(name);
+      expect(setterNames(SceneManager.prototype)).toContain(name);
+    });
+  });
+
+  describe('Parser', () => {
+    it('takes an optional options argument', () => {
+      expect(Parser.length).toBe(0);
+    });
+
+    const methods: Record<string, number> = {
+      parseGCode: 1,
+      parseCommand: 1,
+      parseMetadata: 1
+    };
+
+    it.each(Object.entries(methods))('has method %s with %d required parameter(s)', (name, arity) => {
+      const method = Object.getOwnPropertyDescriptor(Parser.prototype, name)?.value;
+      expect(typeof method).toBe('function');
+      expect(method).toHaveLength(arity);
+    });
+
+    it('starts with empty metadata, lines and lineCount', () => {
+      const parser = new Parser();
+      expect(parser.metadata).toEqual({ thumbnails: {} });
+      expect(parser.lines).toEqual([]);
+      expect(parser.lineCount).toBe(0);
+    });
+
+    it('parses a command into the documented shape', () => {
+      const { metadata, commands } = new Parser().parseGCode('G1 X10 Y20 ; hello');
+      expect(metadata).toEqual({ thumbnails: {} });
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toBeInstanceOf(GCodeCommand);
+      expect(commands[0].gcode).toBe('g1');
+      expect(commands[0].params.x).toBe(10);
+      expect(commands[0].params.y).toBe(20);
+    });
+  });
+
+  describe('GCodeCommand', () => {
+    it('takes src, gcode, params and an optional comment', () => {
+      expect(GCodeCommand.length).toBe(4);
+    });
+
+    it('exposes its constructor arguments as public fields', () => {
+      const command = new GCodeCommand('G1 X1 ; up', 'g1', { x: 1 }, 'up');
+      expect(command.src).toBe('G1 X1 ; up');
+      expect(command.gcode).toBe('g1');
+      expect(command.params).toEqual({ x: 1 });
+      expect(command.comment).toBe('up');
+    });
+  });
+
+  describe('Job', () => {
+    it('takes an optional options argument', () => {
+      expect(Job.length).toBe(0);
+    });
+
+    const methods: Record<string, number> = {
+      addPath: 1,
+      finishPath: 0,
+      resumeLastPath: 0
+    };
+
+    it.each(Object.entries(methods))('has method %s with %d required parameter(s)', (name, arity) => {
+      const method = Object.getOwnPropertyDescriptor(Job.prototype, name)?.value;
+      expect(typeof method).toBe('function');
+      expect(method).toHaveLength(arity);
+    });
+
+    it.each(['extrusions', 'travels', 'toolPaths', 'layers', 'isPlanar', 'countLayers'])('has getter %s', (name) => {
+      expect(getterNames(Job.prototype)).toContain(name);
+    });
+
+    it('starts with empty public state', () => {
+      const job = new Job();
+      expect(job.paths).toEqual([]);
+      expect(job.state).toBeDefined();
+      expect(job.boundingBox).toBeDefined();
+      expect(job.inprogressPath).toBeUndefined();
+    });
+  });
+
+  describe('no unexpected public surface shrinkage', () => {
+    // Guards against accidentally converting public members to #private
+    // (which removes them from the prototype entirely).
+    it('keeps GCodePreview prototype members visible', () => {
+      expect(methodNames(GCodePreview.prototype).length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('keeps SceneManager prototype members visible', () => {
+      expect(methodNames(SceneManager.prototype).length).toBeGreaterThanOrEqual(11);
+    });
+  });
+});

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -113,17 +113,13 @@ describe('public API surface', () => {
     });
 
     // Every accessor a consumer can both read and assign.
-    // topLayerColor, lastSegmentColor and disableGradient are stored but
-    // never read by the render path today; whether they are re-implemented
-    // or removed for 3.0 is debated in #356. If removed, drop them here as
-    // part of that breaking change.
     const accessors = [
       'buildVolume',
       'extrusionColor',
       'backgroundColor',
       'travelColor',
-      'topLayerColor', // no-op today — debated in #356
-      'lastSegmentColor', // no-op today — debated in #356
+      'topLayerColor',
+      'lastSegmentColor',
       'boundingBoxColor',
       'startLayer',
       'endLayer',
@@ -134,7 +130,7 @@ describe('public API surface', () => {
       'lineWidth',
       'lineHeight',
       'extrusionWidth',
-      'disableGradient', // no-op today — debated in #356
+      'disableGradient',
       'ambientLight',
       'directionalLight',
       'brightness',

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -114,13 +114,17 @@ describe('public API surface', () => {
     });
 
     // Every accessor a consumer can both read and assign.
+    // topLayerColor, lastSegmentColor and disableGradient are stored but
+    // never read by the render path today; whether they are re-implemented
+    // or removed for 3.0 is debated in #356. If removed, drop them here as
+    // part of that breaking change.
     const accessors = [
       'buildVolume',
       'extrusionColor',
       'backgroundColor',
       'travelColor',
-      'topLayerColor',
-      'lastSegmentColor',
+      'topLayerColor', // no-op today — debated in #356
+      'lastSegmentColor', // no-op today — debated in #356
       'boundingBoxColor',
       'startLayer',
       'endLayer',
@@ -132,7 +136,7 @@ describe('public API surface', () => {
       'lineWidth',
       'lineHeight',
       'extrusionWidth',
-      'disableGradient',
+      'disableGradient', // no-op today — debated in #356
       'ambientLight',
       'directionalLight',
       'brightness',

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -98,7 +98,6 @@ describe('public API surface', () => {
       animate: 0,
       render: 0,
       renderAnimated: 0,
-      createBoundingBox: 0,
       clear: 0,
       resize: 0,
       dispose: 0,
@@ -132,7 +131,6 @@ describe('public API surface', () => {
       'renderExtrusion',
       'renderTravel',
       'renderTubes',
-      'boundingBoxMesh',
       'lineWidth',
       'lineHeight',
       'extrusionWidth',
@@ -146,6 +144,11 @@ describe('public API surface', () => {
     it.each(accessors)('has getter and setter %s', (name) => {
       expect(getterNames(SceneManager.prototype)).toContain(name);
       expect(setterNames(SceneManager.prototype)).toContain(name);
+    });
+
+    // Read-only since #380 moved the bounding box into the ObjectsManager.
+    it('has read-only getter boundingBoxMesh', () => {
+      expect(getterNames(SceneManager.prototype)).toContain('boundingBoxMesh');
     });
   });
 
@@ -236,7 +239,7 @@ describe('public API surface', () => {
     });
 
     it('keeps SceneManager prototype members visible', () => {
-      expect(methodNames(SceneManager.prototype).length).toBeGreaterThanOrEqual(11);
+      expect(methodNames(SceneManager.prototype).length).toBeGreaterThanOrEqual(10);
     });
   });
 });

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,23 @@
+{
+  // Used only by the vitest typecheck pass (see vitest.config.mts) that runs
+  // the public API type pins in src/__tests__/*.test-d.ts.
+  //
+  // - "files" must be overridden to empty: the base config pins it to the
+  //   library entry point, which would exclude the type tests entirely and
+  //   silently skip every assertion.
+  // - strict mode is required: expect-type assertions silently pass without
+  //   strictNullChecks.
+  // - skipLibCheck: vitest's own type declarations need node16+ module
+  //   resolution; their internal resolution errors are irrelevant here.
+  //
+  // Strict errors in the library source are reported as "source errors" and
+  // ignored by the typecheck pass (ignoreSourceErrors in vitest.config.mts);
+  // the source itself is checked by `npm run typeCheck` with the real config.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "files": [],
+  "include": ["src/__tests__/**/*.test-d.ts"]
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,7 +1,7 @@
 import { readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 
 const root = dirname(fileURLToPath(import.meta.url));
 
@@ -15,8 +15,21 @@ const sourceFiles = readdirSync(join(root, 'src'), { recursive: true })
 export default defineConfig({
   test: {
     include: ['src/__tests__/**/*.ts'],
+    // *.test-d.ts files are compile-time-only pins, run by the typecheck
+    // pass below rather than as runtime tests.
+    exclude: [...defaultExclude, 'src/__tests__/**/*.test-d.ts'],
     environment: 'happy-dom',
     globals: true,
+    typecheck: {
+      enabled: true,
+      include: ['src/__tests__/**/*.test-d.ts'],
+      // Strict mode so expect-type assertions actually bite (they silently
+      // pass without strictNullChecks). Source files stay on the main
+      // tsconfig via `npm run typeCheck`, so their strict errors are noise
+      // here and are ignored.
+      tsconfig: './tsconfig.typecheck.json',
+      ignoreSourceErrors: true
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## What

Locks down the public API surface ahead of the 3.0 release so breaking changes are caught in CI instead of by consumers. Two halves:

- **`src/__tests__/public-api.ts`** (runtime, 70 tests) — pins the exact named-export list (and no default export), every public method with its required-parameter count, all getters/setters (including the 22 `SceneManager` accessors), constructor arities, `SceneManager.defaultExtrusionColor`, and the `package.json` `main`/`types`/`files` entry points.
- **`src/__tests__/public-api.test-d.ts`** (type-level, 17 tests) — pins what consumers *compile* against: the exact 23 keys of `GCodePreviewOptions` and each field's type, `SceneManagerOptions`/`DevModeOptions`/`buildVolume` shapes, public method signatures, constructor parameters, and a setter-assignability block (`sm.extrusionColor = 'hotpink'` must keep compiling).

The type pins run through vitest's typecheck pass (enabled in `vitest.config.mts`), so they execute inside plain `npm test` and the existing CI workflow — no workflow changes needed.

## Why a dedicated `tsconfig.typecheck.json`

Two traps made the type tests silently vacuous without it, both verified by mutation testing:

1. **`expect-type` assertions pass unconditionally without `strictNullChecks`** — even `expectTypeOf<string>().toEqualTypeOf<number>()` was green under the main (non-strict) tsconfig. The typecheck config turns `strict` on for the test files only; strict-mode noise from library source is ignored (`ignoreSourceErrors`), since source is still checked by `npm run typeCheck` with the real config.
2. **The base tsconfig pins `"files"` to the library entry point**, so an inherited config never type-checked the `.test-d.ts` file at all — vitest happily reported the unchecked tests as passed. The typecheck config overrides `files`/`include` itself.

## Verified with mutation testing

Each of these was applied, confirmed to fail the suite with a precise message, then reverted:

- rename `clear()` → runtime method pin fails
- rename the `keepLines` option → 2 type pins fail
- narrow `processGCode` to `string` only → signature pin fails
- delete `orthographic` from `SceneManagerOptions` → 3 type pins fail

## Design tradeoff — feedback welcome

The pins are deliberately **exact** where exactness is cheap: the export list, option keys, and method signatures. That means even a *non-breaking addition* (a new optional option, a new trailing defaulted param) fails one or two clearly-named tests and requires a 1–2 line manifest update in the same PR. That friction is intentional — it turns every surface change into an explicit sign-off, and it's the only way a rename shows up as "one key missing **and** one key extra" rather than nothing at all.

But that's a judgment call, not a law. If the friction feels wrong in practice, the pins can be loosened to "must contain at least these members" (additions become free; renames report as a removal only, and accidental surface leaks go undetected). Happy to adjust the exactness level, the set of members pinned, or the file layout based on review — consider the current shape a proposal.

Full suite: 472 tests passing, 0 type errors, `typeCheck` + lint + coverage green.

Assisted by Claude Code - Fable 5