### PR TITLE
Move progressive rendering routing into the ObjectsManager

### DIFF
--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -407,6 +407,60 @@ describe('ObjectsManager', () => {
     });
   });
 
+  describe('renderPaths', () => {
+    function createTravelPath(): Path {
+      const path = new Path(PathType.Travel, 0.6, 0.2, 0);
+      path.addPoint(0, 0, 0);
+      path.addPoint(10, 10, 0);
+      return path;
+    }
+
+    function createToolPath(tool: number): Path {
+      const path = new Path(PathType.Extrusion, 0.6, 0.2, tool);
+      path.addPoint(0, 0, 0);
+      path.addPoint(10, 0, 0);
+      return path;
+    }
+
+    test('routes each path to its category and tool', () => {
+      objectsManager.setExtrusionColor([new Color(0xff0000), new Color(0x00ff00), new Color(0x0000ff)]);
+
+      objectsManager.renderPaths([createTravelPath(), createToolPath(0), createToolPath(2)], {
+        travels: true,
+        extrusions: true
+      });
+
+      expect(objectsManager.travelMovesGroup.children).toHaveLength(1);
+      const [tool0, tool2] = objectsManager.extrusionsGroup.children as LineSegments2[];
+      expect((tool0.material as LineMaterial).color.getHex()).toBe(0xff0000);
+      expect((tool2.material as LineMaterial).color.getHex()).toBe(0x0000ff);
+    });
+
+    test('a disabled category leaves its paths unrendered for later', () => {
+      const paths = [createTravelPath(), createToolPath(0)];
+
+      objectsManager.renderPaths(paths, { travels: false, extrusions: false });
+      expect(objectsManager.travelMovesGroup.children).toHaveLength(0);
+      expect(objectsManager.extrusionsGroup.children).toHaveLength(0);
+
+      objectsManager.renderPaths(paths, { travels: true, extrusions: true });
+      expect(objectsManager.travelMovesGroup.children).toHaveLength(1);
+      expect(objectsManager.extrusionsGroup.children).toHaveLength(1);
+    });
+
+    test('a growing prefix draws each path exactly once', () => {
+      const paths = [createToolPath(0), createToolPath(0), createToolPath(0)];
+
+      objectsManager.renderPaths(paths.slice(0, 1), { travels: true, extrusions: true });
+      objectsManager.renderPaths(paths.slice(0, 3), { travels: true, extrusions: true });
+      objectsManager.renderPaths(paths.slice(0, 3), { travels: true, extrusions: true });
+
+      const lines = objectsManager.extrusionsGroup.children as LineSegments2[];
+      const segments = lines.reduce((total, line) => total + positionsOf(line).length / 6, 0);
+      expect(segments).toBe(3);
+    });
+  });
+
   describe('renderExtrusions', () => {
     test('renders lines when renderTubes is off', () => {
       objectsManager.renderExtrusions([createTestPath()]);

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -764,6 +764,37 @@ describe('SceneManager properties', () => {
       fresh.dispose();
     });
 
+    test('draws every path, including the last one', async () => {
+      // the loop's end bound used to stop one short of the combined list, so
+      // the job's final path — a travel move in this job — never appeared
+      const fresh = createSceneManager({ renderTravel: true });
+
+      await fresh.renderAnimated(1);
+
+      const segments = (travelGroup(fresh).children as LineSegments2[]).reduce(
+        (total, line) => total + positionCountOf(line) / 6,
+        0
+      );
+      expect(segments).toBe(2); // one travel move per layer of the two-layer job
+      fresh.dispose();
+    });
+
+    test('the categories keep their own pace, so travels are not exhausted early', async () => {
+      // renderPathIndex used to index the combined list but slice the travels
+      // array with it, drawing travels far ahead of the extrusions
+      const fresh = createSceneManager({ renderTravel: true });
+      const spy = vi.spyOn(objectsManager(fresh), 'renderPaths');
+
+      await fresh.renderAnimated(1);
+
+      // every frame hands over a prefix of the combined list; the manager
+      // routes by category, so no frame slices travels with an alien index
+      const firstFramePaths = spy.mock.calls[0][0];
+      expect(firstFramePaths).toHaveLength(1);
+      expect(firstFramePaths[0]).toBe(fresh.job.paths[0]);
+      fresh.dispose();
+    });
+
     test('falls back to a single pass when a frame covers the whole job', async () => {
       const fresh = createSceneManager();
 
@@ -915,6 +946,11 @@ function extrusionGroup(sceneManager: SceneManager): Group {
 
 function travelGroup(sceneManager: SceneManager): Group {
   return sceneManager.scene.children.find((child) => child.name === 'Travel Moves') as Group;
+}
+
+/** Number of floats in a line's packed position buffer; six per segment. */
+function positionCountOf(lines: LineSegments2): number {
+  return (lines.geometry.attributes.instanceStart.data.array as Float32Array).length;
 }
 
 function createSceneManager(opts: Partial<SceneManagerOptions> & { job?: Job } = {}): SceneManager {

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -1,4 +1,4 @@
-import { Path } from './path';
+import { Path, PathType } from './path';
 import { type Disposable } from './helpers/three-utils';
 import { BuildVolume, type BuildVolumeDef } from './build-volume';
 import { type BoundingBox } from './bounding-box';
@@ -301,6 +301,37 @@ export class ObjectsManager {
   }
 
   // --- rendering --------------------------------------------------------------
+
+  /**
+   * Draws a slice of the job's combined path list, routing each path to its
+   * category: travels as travel lines, extrusions per tool in the current
+   * representation.
+   * @param paths - Paths in print order, travels and extrusions interleaved
+   * @param categories - Which categories to draw. Paths of a disabled category
+   * are left unrendered, so they draw when the category is re-enabled.
+   * @remarks
+   * Already-drawn paths are skipped, so progressive rendering can pass a growing
+   * prefix of the same list and each path is built exactly once.
+   */
+  renderPaths(paths: Path[], categories: { travels: boolean; extrusions: boolean }) {
+    if (categories.travels) {
+      this.renderTravelLines(paths.filter((path) => path.travelType === PathType.Travel));
+    }
+
+    if (categories.extrusions) {
+      const byTool = new Map<number, Path[]>();
+      for (const path of paths) {
+        if (path.travelType !== PathType.Extrusion) continue;
+        const toolPaths = byTool.get(path.tool);
+        if (toolPaths) {
+          toolPaths.push(path);
+        } else {
+          byTool.set(path.tool, [path]);
+        }
+      }
+      byTool.forEach((toolPaths, toolIndex) => this.renderExtrusions(toolPaths, toolIndex));
+    }
+  }
 
   renderTravelLines(paths: Path[], color = this.travelColor) {
     const unrenderedPaths = this.takeUnrendered(paths);

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -116,8 +116,6 @@ export class SceneManager {
   static readonly defaultExtrusionColor = ObjectsManager.defaultExtrusionColor;
   /** Animation frame ID */
   private animationFrameId?: number;
-  /** Current path index for animated rendering */
-  private renderPathIndex?: number;
   /** Previous start layer before single layer mode */
   private prevStartLayer = 0;
   // colors
@@ -591,8 +589,6 @@ export class SceneManager {
    * and lighting if 3D tube rendering is enabled.
    */
   private initScene(): void {
-    this.renderPathIndex = 0;
-
     this.renderPaths();
 
     this.renderBoundingBox();
@@ -630,9 +626,7 @@ export class SceneManager {
     // sensible default for pathCount
     pathCount = pathCount ?? Math.floor(this.job.paths.length / 60);
 
-    this.renderPathIndex = 0;
-
-    if (this.renderPathIndex >= this.job.paths.length - 1) {
+    if (this.job.paths.length <= 1) {
       this.renderPaths();
     } else {
       return this.renderFrameLoop(pathCount > 0 ? Math.min(pathCount, this.job.paths.length) : 1);
@@ -643,15 +637,20 @@ export class SceneManager {
    * Animation loop that renders paths incrementally
    * @param pathCount - Number of paths to render per frame
    * @returns Promise that resolves when all paths are rendered
+   * @remarks
+   * The cursor walks the job's combined path list; the ObjectsManager routes
+   * each prefix by category and skips what it has already drawn.
    */
   private renderFrameLoop(pathCount: number): Promise<void> {
     return new Promise((resolve) => {
+      let drawnUpTo = 0;
       const loop = () => {
-        if (this.renderPathIndex >= this.job.paths.length - 1) {
+        if (drawnUpTo >= this.job.paths.length) {
           // the returned promise is the completion signal
           resolve();
         } else {
-          this.renderFrame(pathCount);
+          drawnUpTo = Math.min(drawnUpTo + pathCount, this.job.paths.length);
+          this.renderFrame(drawnUpTo);
           requestAnimationFrame(loop);
         }
       };
@@ -660,16 +659,11 @@ export class SceneManager {
   }
 
   /**
-   * Renders a frame with the specified number of paths
-   * @param pathCount - Number of paths to render in this frame
-   * @remarks
-   * Creates a new group for the frame and renders paths up to the specified count.
-   * Updates the renderPathIndex to track progress through the job's paths.
+   * Renders one animation frame containing the paths up to the given index
+   * @param endPathNumber - End index into the job's combined path list
    */
-  private renderFrame(pathCount: number): void {
-    const endPathNumber = Math.min(this.renderPathIndex + pathCount, this.job.paths.length - 1);
+  private renderFrame(endPathNumber: number): void {
     this.renderPaths(endPathNumber);
-    this.renderPathIndex = endPathNumber;
 
     this.renderBoundingBox();
     this.renderer.render(this.scene, this.camera);
@@ -752,38 +746,29 @@ export class SceneManager {
   }
 
   /**
-   * Renders paths between the current render index and specified end index
-   * @param endPathNumber - End index of paths to render (default: Infinity)
-   */
-  /**
    * Builds any paths that have not been drawn yet, across the whole job.
    * @remarks
-   * Turning a category back on reveals paths that were skipped while it was off,
-   * and those can sit anywhere in the job — not just past renderPathIndex, which
-   * indexes the combined path list rather than travels or a single tool. The
-   * ObjectsManager skips whatever it has already drawn, so this stays cheap.
+   * Turning a category back on reveals paths that were skipped while it was off.
+   * The ObjectsManager skips whatever it has already drawn, so this stays cheap.
    */
   private renderMissingPaths(): void {
     if (!this.job) return;
 
-    const resumeFrom = this.renderPathIndex;
-    this.renderPathIndex = 0;
     this.renderPaths();
-    this.renderPathIndex = resumeFrom;
   }
 
+  /**
+   * Draws the job's paths up to the given index of its combined path list
+   * @param endPathNumber - End index into job.paths (default: all of them)
+   */
   private renderPaths(endPathNumber: number = Infinity): void {
     this.objectsManager.setTravelsVisible(this._renderTravel);
-    if (this._renderTravel) {
-      this.objectsManager.renderTravelLines(this.job.travels.slice(this.renderPathIndex, endPathNumber));
-    }
-
     this.objectsManager.setExtrusionsVisible(this._renderExtrusion);
-    if (this._renderExtrusion && this.job?.toolPaths.length > 0) {
-      this.job.toolPaths.forEach((toolPaths, index) => {
-        this.objectsManager.renderExtrusions(toolPaths.slice(this.renderPathIndex, endPathNumber), index);
-      });
-    }
+
+    this.objectsManager.renderPaths(this.job.paths.slice(0, endPathNumber), {
+      travels: this._renderTravel,
+      extrusions: this._renderExtrusion
+    });
   }
 
   saveCamera() {


### PR DESCRIPTION
Closes the last item on #311's "Still open" list: `renderPathIndex` conflating `paths` / `travels` / `toolPaths`. (Originally stacked on #389, which merged while this was being opened — now based directly on `develop`.)

### The conflation

`renderPathIndex` indexed the job's **combined** path list, but `renderPaths` sliced `job.travels` and each tool's `toolPaths` with that same index. Three different index spaces, one cursor:

- travels were exhausted long before the extrusions (the travels array is much shorter than the combined list), so they appeared at the wrong pace during animation
- each tool's slice drifted from print order the same way
- `renderMissingPaths` had to zero the shared field and restore it afterwards just to repaint

### The fix

`ObjectsManager.renderPaths(paths, categories)` takes a prefix of the combined list and routes each path itself — travels to travel lines, extrusions grouped per tool — skipping whatever it has already drawn (the existing `renderedPaths` dedupe finally becomes the *only* bookkeeping). The animation loop keeps a local cursor; `renderPathIndex` is gone as a field, and every path appears at its true position in print order.

This also hands the manager the chunks it would need to consolidate for #355 later.

### Two fixes fall out

- **The last path was never drawn during an animated render** — the loop's end bound stopped one short of the combined list. For a typical job the dropped path is the final travel/park move.
- **Disabled-category paths are now guaranteed to be found on re-enable** — they're left unrendered rather than sliced and skipped.

### Tests

Six new tests: routing by category and tool (state-based, per-tool colors), disabled categories staying unrendered for later, growing-prefix draws each path exactly once, the last-path regression (asserted on drawn travel segments), and print-order pacing. Coverage thresholds hold at 100%; 412 tests green.

Assisted by Claude Code - Fable 5