### PR TITLE
Classify retracting arcs as travel moves and cover interpreter.ts

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -18,6 +18,17 @@ describe('.execute', () => {
     expect(result.state.z).toEqual(3);
   });
 
+  test('skips a command whose gcode is undefined', () => {
+    // A command with no gcode at all (guarded by `command.gcode !== undefined`).
+    const command = new GCodeCommand('', undefined as unknown as string, {});
+    const interpreter = new Interpreter();
+
+    const result = interpreter.execute([command]);
+
+    expect(result.paths.length).toEqual(0);
+    expect(result.state.x).toEqual(0);
+  });
+
   test('ignores unknown commands', () => {
     const command = new GCodeCommand('G42', 'g42', {});
     const interpreter = new Interpreter();
@@ -162,6 +173,42 @@ describe('.g0', () => {
     interpreter.g0(command, job);
 
     expect(job.paths.length).toEqual(0);
+  });
+
+  test('keeps the current Y when a move omits it', () => {
+    const command = new GCodeCommand('G0 X5', 'g0', { x: 5 });
+    const interpreter = new Interpreter();
+    const job = new Job();
+    job.state.y = 7;
+
+    interpreter.g0(command, job);
+
+    expect(job.state.x).toEqual(5);
+    expect(job.state.y).toEqual(7);
+  });
+
+  test('counts a bare feedrate change as a feedrate change, not a move', () => {
+    const command = new GCodeCommand('G0 F3000', 'g0', { f: 3000 });
+    const interpreter = new Interpreter();
+    const job = new Job();
+
+    interpreter.g0(command, job);
+
+    expect(job.paths.length).toEqual(0);
+    expect(interpreter.feedrateChanges).toEqual(1);
+    expect(job.inprogressPath).toBeUndefined();
+  });
+
+  test('counts a zero-length move with no parameters as "other"', () => {
+    const command = new GCodeCommand('G0', 'g0', {});
+    const interpreter = new Interpreter();
+    const job = new Job();
+
+    interpreter.g0(command, job);
+
+    expect(job.paths.length).toEqual(0);
+    expect(interpreter.others).toEqual(1);
+    expect(job.inprogressPath).toBeUndefined();
   });
 
   test('starts a new path if the travel type changes from Travel to Extrusion', () => {
@@ -452,5 +499,94 @@ describe('malformed coordinates through the whole pipeline', () => {
     expect(points.every((value) => Number.isFinite(value))).toBe(true);
     expect(job.boundingBox.isValid).toBe(true);
     expect(job.boundingBox.corners?.min.x).not.toBeNaN();
+  });
+});
+
+describe('.g2 / .g3 arc moves', () => {
+  const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
+
+  test('a retracting arc is a travel move, matching G0/G1 (negative E)', () => {
+    // g0/g1 classify negative E (a retraction) as Travel via `e > 0`. g2/g3 used the
+    // looser `e ?`, so a negative E arc was misclassified as Extrusion: it rendered as
+    // deposited material and, worse, stretched the bounding box out along the arc even
+    // though nothing was extruded.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E-1'].join('\n'));
+
+    // The arc must not be lumped onto the preceding extrusion path.
+    const lastPath = job.paths[job.paths.length - 1];
+    expect(lastPath.travelType).toEqual(PathType.Travel);
+
+    // A travel move never grows the print bounds, so the box stays where the
+    // extrusion left it instead of stretching to the arc's far side (x = 20).
+    expect(job.boundingBox.corners?.max.x).toEqual(10);
+  });
+
+  test('a positive-E arc still extrudes and grows the bounding box', () => {
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1'].join('\n'));
+
+    const lastPath = job.paths[job.paths.length - 1];
+    expect(lastPath.travelType).toEqual(PathType.Extrusion);
+    expect(job.boundingBox.corners?.max.x).toEqual(20);
+  });
+
+  test('keeps the current Y when an arc omits it', () => {
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 I5 J0 E1'].join('\n'));
+
+    expect(job.state.y).toEqual(10);
+    expect(job.paths.flatMap((path) => path.vertices).every((value) => Number.isFinite(value))).toBe(true);
+  });
+
+  test('R mode computes a centre and renders a curved arc', () => {
+    // R mode (radius instead of I/J offsets) has to solve for the centre. Exercise the
+    // non-degenerate branch with r larger than half the chord so the curve bulges.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 R10 E1'].join('\n'));
+
+    const arcPath = job.paths[job.paths.length - 1];
+    const points = arcPath.path();
+    // more than just start + endpoint: real intermediate segments were emitted
+    expect(points.length).toBeGreaterThan(2);
+    expect(arcPath.vertices.every((value) => Number.isFinite(value))).toBe(true);
+    // ends exactly on the requested endpoint
+    expect(points[points.length - 1]).toMatchObject({ x: 20, y: 10 });
+  });
+
+  test('R mode counter-clockwise (G3) selects the opposite centre', () => {
+    // g3 with a positive radius flips the sign of the centre offset. Both arcs share
+    // endpoints but bow to opposite sides, so their mid-point Y differs.
+    const cw = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 R10 E1'].join('\n'));
+    const ccw = run(['G1 X10 Y10 Z1 E1', 'G3 X20 Y10 R10 E1'].join('\n'));
+
+    const midY = (job: Job) => {
+      const pts = job.paths[job.paths.length - 1].path();
+      return pts[Math.floor(pts.length / 2)].y;
+    };
+
+    expect(midY(cw)).not.toBeCloseTo(midY(ccw));
+    // clockwise from (10,10) to (20,10) bows above the chord, ccw bows below
+    expect(midY(cw)).toBeGreaterThan(10);
+    expect(midY(ccw)).toBeLessThan(10);
+  });
+
+  test('arcs in inch units are segmented more finely than in mm', () => {
+    // Inch arcs multiply the segment count so the on-screen curve stays smooth despite
+    // the much smaller numeric radius.
+    const mm = run(['G21', 'G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1'].join('\n'));
+    const inch = run(['G20', 'G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1'].join('\n'));
+
+    const segCount = (job: Job) => job.paths[job.paths.length - 1].path().length;
+    expect(segCount(inch)).toBeGreaterThan(segCount(mm));
+  });
+
+  test('a tiny arc still emits at least the endpoint (segment count clamped to 1)', () => {
+    // arcRadius * totalArc / 0.5 drops below 1 for a sub-millimetre arc; the count is
+    // clamped to 1 so the endpoint is always emitted and the loop adds no interior points.
+    // A travel lead-in keeps the extrusion arc on its own path so we count only its points.
+    const job = run(['G0 X10 Y10 Z1', 'G2 X10.01 Y10 I0.005 J0 E1'].join('\n'));
+
+    const arcPath = job.paths[job.paths.length - 1];
+    const points = arcPath.path();
+    // start-of-path point + endpoint only, no interior segments
+    expect(points.length).toEqual(2);
+    expect(points[points.length - 1]).toMatchObject({ x: 10.01, y: 10 });
   });
 });

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -136,7 +136,10 @@ export class Interpreter {
 
     const cw = command.gcode === 'g2';
     let currentPath = job.inprogressPath;
-    const pathType = e ? PathType.Extrusion : PathType.Travel;
+    // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
+    // material laid down. The looser `e ?` used to misclassify a retracting arc as
+    // Extrusion, so it rendered as deposited filament and stretched the bounding box.
+    const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
 
     if (currentPath === undefined || currentPath.travelType !== pathType) {
       currentPath = this.breakPath(job, pathType);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,7 +18,8 @@ export default defineConfig({
         'src/scene-manager.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
         'src/objects-manager.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
         'src/bounding-box.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
-        'src/job.ts': { statements: 100, branches: 100, functions: 100, lines: 100 }
+        'src/job.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
+        'src/interpreter.ts': { statements: 100, branches: 100, functions: 100, lines: 100 }
       }
     }
   }


### PR DESCRIPTION
## The bug

`g2`/`g3` classified an arc's path type with a truthy check, while `g0`/`g1` use `e > 0`:

```ts
g0/g1:  const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
g2/g3:  const pathType = e     ? PathType.Extrusion : PathType.Travel;  // ← bug
```

So a **retracting arc** (negative `E`, e.g. `G2 X20 Y10 I5 J0 E-1`) was misclassified as **Extrusion**. Consequences:

- it rendered as deposited filament, and
- worse, it stretched the **bounding box** out along the arc even though no material was extruded.

A linear retraction (`G0 ... E-1`) correctly stays `Travel`, so the two paths were inconsistent. The `e ?` line has been unchanged since #211 (Oct 2024).

## The fix

Align `g2`/`g3` with `g0`/`g1` by using `e > 0`. A negative `E` is a retraction — a travel move with no material laid down.

## Relationship to the recent arc PRs

This is **distinct from** the recent arc fixes in the same `g2` method:

- #367 — parser-boundary validation + `x ?? state.x` endpoints, degenerate `dSquared === 0` circle, non-finite `totalSegments`
- #370 — `zDist` sign inversion + `z ?? state.z`

Neither touched the path-type classification line; this fills that remaining gap.

## Coverage

Brings `src/interpreter.ts` to **100%** (statements / branches / functions / lines) and locks it into the vitest thresholds. New tests cover: the retracting-arc regression, R-mode centre solving, G3 counter-clockwise centre flip, inch-unit finer segmentation, a sub-millimetre arc clamped to a single segment, the zero-length-move feedrate/other counters, an undefined-gcode skip, and the omitted-coordinate carry-over branches.

Red → green verified: the regression test fails on the old `e ?` classifier (`Received: "Extrusion"`, bbox max.x stretched to 20) and passes after the fix.

Assisted by Claude Code - Opus 4.8