### PR TITLE
Publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,11 +28,14 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
@@ -49,5 +52,3 @@ jobs:
           echo "Publishing $VERSION with npm dist-tag '$TAG'"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - run: npm publish --tag ${{ steps.tag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Why

The `v3.0.0-alpha.5` release published the GitHub Release fine but the npm publish job **failed** with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/gcode-preview - Not found
```

That 404-on-PUT is npm's misleading symptom for an **expired/invalid `NPM_TOKEN`** (the secret was last set 2025-08-22, ~1 year old). Rather than rotate another expiring token, this switches to **OIDC trusted publishing**.

## What changed

In the `publish-npm` job of `.github/workflows/npm-publish.yml`:

- Grant `id-token: write` (+ `contents: read`) so the job can mint the OIDC token.
- Bump the job to **Node 24**, which bundles **npm ≥ 11.5.1** (required for OIDC). The Node 22 LTS line stays on npm 10.x, so it is *not* enough — this job intentionally runs a newer Node than `.nvmrc` (22).
- Drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — auth now comes from the OIDC exchange with the trusted publisher.

## Required on npmjs.com (already set up by @sophiedeziel)

A trusted publisher on the `gcode-preview` package must match **exactly**:

- **Repository:** `xyz-tools/gcode-preview` (⚠️ *not* `remcoder/gcode-preview`, which is what `package.json` `repository.url` normalizes to)
- **Workflow filename:** `npm-publish.yml`
- **Environment:** *(blank — the job sets no `environment:`)*

## After merge

1. Delete + recreate the `v3.0.0-alpha.5` GitHub Release (tag stays) so the `release: published` event re-runs the updated workflow via OIDC.
2. Confirm `npm view gcode-preview dist-tags` shows `alpha: 3.0.0-alpha.5`.
3. The `NPM_TOKEN` secret can then be deleted.

Assisted by Claude Code - claude-opus-4-8