### PR TITLE
Re-implement topLayerColor and lastSegmentColor highlights

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -165,7 +165,7 @@
                   
                 </section>
 
-                <!-- <section>
+                <section>
                   <div class="controls">
                     <label for="highlight">Highlight top layer</label>
                     <input type="checkbox" v-model="settings.highlightTopLayer" :disabled="!settings.renderExtrusion" />
@@ -180,10 +180,10 @@
                   </div>
                   <div class="controls">
                     <label :class="{'has-text-grey' : !settings.highlightLastSegment}" for="last-segment-color">Last segment color</label>
-                    <input type="color" id="last-segment-color" v-model="settings.lastSegmentColor" 
+                    <input type="color" id="last-segment-color" v-model="settings.lastSegmentColor"
                     :disabled="!settings.highlightLastSegment || !settings.renderExtrusion" />
                   </div>
-                </section> -->
+                </section>
 
               </div>
             </div>

--- a/demo/js/default-settings.js
+++ b/demo/js/default-settings.js
@@ -27,7 +27,7 @@ export const defaultSettings = {
   highlightTopLayer: false,
   topLayerColor: '#40BFBF',
   highlightLastSegment: false,
-  lastSegmentColor: null,
+  lastSegmentColor: '#FFFFFF',
   drawBuildVolume: true,
   backgroundColor: '#141414',
   boundingBoxColor: '#A830F8',

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -62,7 +62,7 @@ import { SceneManager, type SceneManagerOptions } from '../scene-manager';
 import { ObjectsManager } from '../objects-manager';
 import { Job } from '../job';
 import { Path, PathType } from '../path';
-import { Color, Group, OrthographicCamera, PerspectiveCamera } from 'three';
+import { Color, Group, Object3D, OrthographicCamera, PerspectiveCamera, ShaderMaterial } from 'three';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 
@@ -312,6 +312,205 @@ describe('SceneManager properties', () => {
       sceneManager.boundingBoxColor = undefined;
       expect(sceneManager.boundingBoxMesh?.visible).toBe(false);
     });
+  });
+
+  describe('top layer and last segment highlight', () => {
+    test('topLayerColor draws the top layer as a highlight overlay', () => {
+      const fresh = createSceneManager({ topLayerColor: '#00ff00' });
+
+      const highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect(lineColor(highlights[0])).toBe(0x00ff00);
+
+      fresh.dispose();
+    });
+
+    test('setting topLayerColor at runtime redraws with the highlight', () => {
+      expect(highlights_(sceneManager).length).toBe(0);
+
+      sceneManager.topLayerColor = '#123456';
+
+      const highlights = highlights_(sceneManager);
+      expect(highlights.length).toBe(1);
+      expect(lineColor(highlights[0])).toBe(0x123456);
+    });
+
+    test('lastSegmentColor splits the final segment off the top layer', () => {
+      // the top layer's only path has three points, so it splits into a body and
+      // the final segment, each its own overlay
+      sceneManager.lastSegmentColor = '#ff0000';
+
+      const colors = highlights_(sceneManager).map(lineColor);
+      expect(colors).toContain(0xff0000);
+      // the body keeps the normal (default) extrusion color
+      expect(colors).toContain(SceneManager.defaultExtrusionColor.getHex());
+    });
+
+    test('both colors: the top layer highlights, the last segment overrides it', () => {
+      const fresh = createSceneManager({
+        job: multiPathTopLayerJob(),
+        topLayerColor: '#00ff00',
+        lastSegmentColor: '#0000ff'
+      });
+
+      const colors = highlights_(fresh).map(lineColor);
+      // two green overlays (the first path, and the last path's body), one blue segment
+      expect(colors.filter((c) => c === 0x00ff00).length).toBe(2);
+      expect(colors.filter((c) => c === 0x0000ff).length).toBe(1);
+
+      fresh.dispose();
+    });
+
+    test('a two-point final path highlights the segment with no body', () => {
+      const fresh = createSceneManager({ job: shortTopLayerJob(), lastSegmentColor: '#ff0000' });
+
+      const highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect(lineColor(highlights[0])).toBe(0xff0000);
+
+      fresh.dispose();
+    });
+
+    test('a final path too short for a segment is left un-highlighted', () => {
+      const fresh = createSceneManager({ job: singlePointFinalJob(), lastSegmentColor: '#ff0000' });
+
+      expect(highlights_(fresh).length).toBe(0);
+
+      fresh.dispose();
+    });
+
+    test('re-enabling extrusions does not duplicate the highlight', () => {
+      const fresh = createSceneManager({
+        job: multiPathTopLayerJob(),
+        topLayerColor: '#00ff00',
+        lastSegmentColor: '#0000ff'
+      });
+      const before = highlights_(fresh).length;
+
+      fresh.renderExtrusion = false;
+      fresh.renderExtrusion = true;
+
+      expect(highlights_(fresh).length).toBe(before);
+
+      fresh.dispose();
+    });
+
+    test('the last segment body keeps the tool color from a color array', () => {
+      const fresh = createSceneManager({ extrusionColor: ['#123456'], lastSegmentColor: '#ff0000' });
+
+      const colors = highlights_(fresh).map(lineColor);
+      expect(colors).toContain(0x123456);
+      expect(colors).toContain(0xff0000);
+
+      fresh.dispose();
+    });
+
+    test('the last segment body falls back when the tool has no configured color', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fresh = createSceneManager({
+        job: highToolTopLayerJob(),
+        extrusionColor: ['#00ff00'],
+        lastSegmentColor: '#ff0000'
+      });
+
+      const colors = highlights_(fresh).map(lineColor);
+      expect(colors).toContain(0x00ff00);
+      expect(colors).toContain(0xff0000);
+      expect(warn).toHaveBeenCalledWith('No extrusionColor configured for tool index 2, falling back to another color');
+
+      fresh.dispose();
+      warn.mockRestore();
+    });
+
+    test('renders the highlight as a tube with its own material', () => {
+      const fresh = createSceneManager({ renderTubes: true, topLayerColor: '#00ff00' });
+
+      const highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect((highlights[0] as { material: ShaderMaterial }).material.uniforms.uColor.value.getHex()).toBe(0x00ff00);
+
+      fresh.dispose();
+    });
+
+    test('a clipped tube highlight inherits the layer range', () => {
+      const fresh = createSceneManager({
+        job: threeLayerJob(),
+        renderTubes: true,
+        topLayerColor: '#00ff00',
+        startLayer: 2,
+        endLayer: 2
+      });
+
+      const material = (highlights_(fresh)[0] as { material: ShaderMaterial }).material;
+      expect(material.uniforms.clipMinY.value).not.toBe(-Infinity);
+      expect(material.uniforms.clipMaxY.value).not.toBe(Infinity);
+
+      fresh.dispose();
+    });
+
+    test('a scalar extrusionColor leaves the highlight color untouched', () => {
+      const fresh = createSceneManager({ topLayerColor: '#00ff00' });
+
+      fresh.extrusionColor = '#0000ff';
+
+      expect(highlights_(fresh).map(lineColor)).toContain(0x00ff00);
+
+      fresh.dispose();
+    });
+
+    test('an emptied top layer draws no highlight', () => {
+      const job = shortTopLayerJob();
+      // resumeLastPath pulls the top layer's only extrusion back out, leaving the
+      // layer present but empty of extrusions
+      job.resumeLastPath();
+      const fresh = createSceneManager({ job, topLayerColor: '#00ff00' });
+
+      expect(highlights_(fresh).length).toBe(0);
+
+      fresh.dispose();
+    });
+
+    test('a non-planar job (no layers) draws no highlight', () => {
+      const fresh = createSceneManager({ job: nonPlanarJob(), topLayerColor: '#00ff00' });
+
+      expect(highlights_(fresh).length).toBe(0);
+
+      fresh.dispose();
+    });
+
+    test.each(['topLayerColor', 'lastSegmentColor'] as const)('%s redraws only when the color changes', (property) => {
+      const fresh = createSceneManager({ [property]: '#00ff00' });
+      const spy = vi.spyOn(fresh, 'render');
+
+      fresh[property] = '#00ff00';
+      expect(spy).not.toHaveBeenCalled();
+
+      fresh[property] = '#0000ff';
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      fresh.dispose();
+    });
+
+    test.each(['topLayerColor', 'lastSegmentColor'] as const)('clearing an unset %s does nothing', (property) => {
+      const spy = vi.spyOn(sceneManager, 'render');
+
+      sceneManager[property] = undefined;
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test.each(['topLayerColor', 'lastSegmentColor'] as const)(
+      '%s is safe to set after clear drops the job',
+      (property) => {
+        sceneManager.clear();
+        const spy = vi.spyOn(sceneManager, 'render');
+
+        expect(() => {
+          sceneManager[property] = '#ff0000';
+        }).not.toThrow();
+        expect(spy).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe('lighting', () => {
@@ -994,8 +1193,107 @@ function createJob(): Job {
   return job;
 }
 
-function appendPath(job: Job, type: PathType, points: [number, number, number][]): void {
-  const path = new Path(type, 0.6, 0.2, 0);
+function appendPath(job: Job, type: PathType, points: [number, number, number][], tool = 0): void {
+  const path = new Path(type, 0.6, 0.2, tool);
   points.forEach((point) => path.addPoint(...point));
   job.addPath(path);
+}
+
+/** The highlight overlays drawn for the top layer / last segment. */
+function highlights_(sceneManager: SceneManager): Object3D[] {
+  return extrusionGroup(sceneManager).children.filter((child) => child.userData.highlight);
+}
+
+/** The hex color of a highlight line overlay. */
+function lineColor(object: Object3D): number {
+  return ((object as LineSegments2).material as LineMaterial).color.getHex();
+}
+
+/** A two layer job whose top layer holds two extrusion paths. */
+function multiPathTopLayerJob(): Job {
+  const job = new Job();
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0],
+    [10, 0, 0]
+  ]);
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0.2],
+    [10, 0, 0.2],
+    [10, 10, 0.2]
+  ]);
+  appendPath(job, PathType.Extrusion, [
+    [10, 10, 0.2],
+    [0, 10, 0.2],
+    [0, 0, 0.2]
+  ]);
+  return job;
+}
+
+/** A job whose top layer's final path is a single two-point segment. */
+function shortTopLayerJob(): Job {
+  const job = new Job();
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0],
+    [10, 0, 0]
+  ]);
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0.2],
+    [10, 0, 0.2]
+  ]);
+  return job;
+}
+
+/** A job whose top layer ends on a one-point path, too short to form a segment. */
+function singlePointFinalJob(): Job {
+  const job = new Job();
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0],
+    [10, 0, 0],
+    [10, 10, 0]
+  ]);
+  const stub = new Path(PathType.Extrusion, 0.6, 0.2, 0);
+  stub.addPoint(10, 10, 0);
+  job.addPath(stub);
+  return job;
+}
+
+/** A single-layer job whose only extrusion is on tool 2. */
+function highToolTopLayerJob(): Job {
+  const job = new Job();
+  appendPath(
+    job,
+    PathType.Extrusion,
+    [
+      [0, 0, 0],
+      [10, 0, 0],
+      [10, 10, 0]
+    ],
+    2
+  );
+  return job;
+}
+
+/** A three layer job, for exercising the clipping planes on a highlight. */
+function threeLayerJob(): Job {
+  const job = new Job();
+  [0, 0.2, 0.4].forEach((z) => {
+    appendPath(job, PathType.Extrusion, [
+      [0, 0, z],
+      [10, 0, z],
+      [10, 10, z]
+    ]);
+    job.boundingBox.update(0, 0, z);
+    job.boundingBox.update(10, 10, z);
+  });
+  return job;
+}
+
+/** A job with a non-planar extrusion, which clears the layer index. */
+function nonPlanarJob(): Job {
+  const job = new Job();
+  appendPath(job, PathType.Extrusion, [
+    [0, 0, 0],
+    [10, 0, 5]
+  ]);
+  return job;
 }

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -144,7 +144,7 @@ export class ObjectsManager {
    * last configured color — or the default when the array is empty — is used
    * instead, warning once per tool index rather than throwing.
    */
-  private colorForTool(toolIndex: number): Color {
+  colorForTool(toolIndex: number): Color {
     if (!Array.isArray(this.extrusionColor)) return this.extrusionColor;
 
     return this.extrusionColor[toolIndex] ?? this.fallbackExtrusionColor(toolIndex);
@@ -167,7 +167,9 @@ export class ObjectsManager {
         if (material?.uniforms) material.uniforms.uColor.value = color;
       });
       this.extrusionsGroup.children.forEach((child) => {
-        if (child instanceof LineSegments2) (child.material as LineMaterial).color.set(color);
+        // highlight overlays keep their own color, so a tool recolor skips them
+        if (child instanceof LineSegments2 && !child.userData.highlight)
+          (child.material as LineMaterial).color.set(color);
       });
       return;
     }
@@ -366,9 +368,46 @@ export class ObjectsManager {
     const unrenderedPaths = this.takeUnrendered(paths);
     if (unrenderedPaths.length === 0) return;
 
-    const tubes = this.renderPathsAsTubes(unrenderedPaths, color, toolIndex);
+    const tubes = this.renderPathsAsTubes(unrenderedPaths, this.getOrCreateToolMaterial(toolIndex, color));
     tubes.userData.toolIndex = toolIndex;
     this.extrusionsGroup.add(tubes);
+  }
+
+  /**
+   * Draws `paths` in a single `color` with a dedicated material, independent of
+   * the per-tool colors, and records them as rendered.
+   * @remarks
+   * Used for highlight overlays — the top layer and the last segment — that must
+   * win over the tool color. Because the material is not the cached per-tool one,
+   * recoloring a tool later leaves the highlight untouched. The object is tagged
+   * so {@link setExtrusionColor} skips it for the same reason.
+   */
+  renderExtrusionsInColor(paths: Path[], color: Color) {
+    const unrenderedPaths = this.takeUnrendered(paths);
+    if (unrenderedPaths.length === 0) return;
+
+    const object = this.renderTubes
+      ? this.renderPathsAsTubes(unrenderedPaths, this.createHighlightMaterial(color))
+      : this.renderPathsAsLines(unrenderedPaths, color);
+    object.userData.highlight = true;
+    this.extrusionsGroup.add(object);
+  }
+
+  /**
+   * Records paths as rendered without drawing them, so later batches skip them.
+   * @remarks
+   * Used when a highlight redraws part of a path — its final segment in its own
+   * color — so the per-tool batch does not also draw the original whole path.
+   */
+  claimPaths(paths: Path[]) {
+    paths.forEach((path) => this.renderedPaths.add(path));
+  }
+
+  /**
+   * Whether a path has already been drawn (or claimed) in the current scene.
+   */
+  hasRendered(path: Path): boolean {
+    return this.renderedPaths.has(path);
   }
 
   /**
@@ -525,13 +564,32 @@ export class ObjectsManager {
   }
 
   /**
+   * Builds a fresh tube material for a highlight overlay in the given color.
+   * @remarks
+   * Unlike {@link getOrCreateToolMaterial} this is never cached or shared, so a
+   * later tool recolor cannot bleed into the highlight. The current layer range
+   * still has to be respected, so the clip uniforms are seeded here.
+   */
+  private createHighlightMaterial(color: Color): ShaderMaterial {
+    const material = createColorMaterial(
+      Number(color.getHex()),
+      this.ambientLight,
+      this.directionalLight,
+      this.brightness
+    );
+    if (this.clipMinZ !== undefined) material.uniforms.clipMinY.value = this.clipMinZ;
+    if (this.clipMaxZ !== undefined) material.uniforms.clipMaxY.value = this.clipMaxZ;
+    this.disposables.push(material);
+    return material;
+  }
+
+  /**
    * Renders paths as 3D tubes
    * @param paths - Array of paths to render
-   * @param color - Color to use for the tubes
+   * @param material - Shader material shared by the batched tubes
    */
-  private renderPathsAsTubes(paths: Path[], color: Color, toolIndex: number): BatchedMesh {
+  private renderPathsAsTubes(paths: Path[], material: ShaderMaterial): BatchedMesh {
     const geometries: BufferGeometry[] = [];
-    const material = this.getOrCreateToolMaterial(toolIndex, color);
 
     paths.forEach((path) => {
       const geometry = path.geometry({

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -6,6 +6,7 @@ import { LineBox } from './helpers/line-box';
 
 import { Job } from './job';
 import { ObjectsManager } from './objects-manager';
+import { Path, PathType } from './path';
 
 import {
   Color,
@@ -179,11 +180,13 @@ export class SceneManager {
     if (opts.travelColor !== undefined) {
       this.travelColor = new Color(opts.travelColor);
     }
+    // assign the backing fields directly: the setters would draw the scene before
+    // initScene() does, and it walks the paths once anyway
     if (opts.topLayerColor !== undefined) {
-      this.topLayerColor = new Color(opts.topLayerColor);
+      this._topLayerColor = new Color(opts.topLayerColor);
     }
     if (opts.lastSegmentColor !== undefined) {
-      this.lastSegmentColor = new Color(opts.lastSegmentColor);
+      this._lastSegmentColor = new Color(opts.lastSegmentColor);
     }
     if (opts.disableGradient !== undefined) {
       this.disableGradient = opts.disableGradient;
@@ -305,10 +308,16 @@ export class SceneManager {
 
   /**
    * Sets the top layer color
+   * @remarks
+   * Highlighting the top layer picks specific paths out of the per-tool batches,
+   * so a change redraws the scene rather than recoloring in place.
    * @param value - Color value or undefined to clear
    */
   set topLayerColor(value: ColorRepresentation | undefined) {
-    this._topLayerColor = value !== undefined ? new Color(value) : undefined;
+    const next = value !== undefined ? new Color(value) : undefined;
+    if (this.sameColor(this._topLayerColor, next)) return;
+    this._topLayerColor = next;
+    if (this.job) this.render();
   }
 
   /**
@@ -321,10 +330,22 @@ export class SceneManager {
 
   /**
    * Sets the last segment color
+   * @remarks
+   * Highlighting the last segment splits the final path out of its batch, so a
+   * change redraws the scene rather than recoloring in place.
    * @param value - Color value or undefined to clear
    */
   set lastSegmentColor(value: ColorRepresentation | undefined) {
-    this._lastSegmentColor = value !== undefined ? new Color(value) : undefined;
+    const next = value !== undefined ? new Color(value) : undefined;
+    if (this.sameColor(this._lastSegmentColor, next)) return;
+    this._lastSegmentColor = next;
+    if (this.job) this.render();
+  }
+
+  /** Compares two optional colors, treating two unset colors as equal. */
+  private sameColor(a?: Color, b?: Color): boolean {
+    if (a === undefined || b === undefined) return a === b;
+    return a.equals(b);
   }
 
   /**
@@ -758,17 +779,94 @@ export class SceneManager {
   }
 
   /**
-   * Draws the job's paths up to the given index of its combined path list
+   * Draws the job's paths up to the given index of its combined path list.
    * @param endPathNumber - End index into job.paths (default: all of them)
+   * @remarks
+   * On a full render the top layer and last segment highlights claim their paths
+   * first, so the per-tool batches leave them alone. During progressive rendering
+   * the highlight is skipped: the top layer may not have been reached yet.
    */
   private renderPaths(endPathNumber: number = Infinity): void {
     this.objectsManager.setTravelsVisible(this._renderTravel);
     this.objectsManager.setExtrusionsVisible(this._renderExtrusion);
 
+    if (this._renderExtrusion && endPathNumber === Infinity) {
+      this.renderTopLayerHighlight();
+    }
+
     this.objectsManager.renderPaths(this.job.paths.slice(0, endPathNumber), {
       travels: this._renderTravel,
       extrusions: this._renderExtrusion
     });
+  }
+
+  /**
+   * Draws the topmost visible layer, and its final segment, in their highlight
+   * colors before the per-tool batches run.
+   * @remarks
+   * Whichever draw claims a path first wins, so running before the per-tool
+   * batches is what lets the highlight colors take precedence. Only runs on a
+   * full render: during progressive rendering the top layer may not have been
+   * reached yet.
+   *
+   * `topLayerColor` recolors the whole visible top layer; `lastSegmentColor`
+   * recolors just the final segment of that layer's last path. When both are set
+   * the last segment is split off so it keeps its own color. When only
+   * `lastSegmentColor` is set the rest of the layer keeps its normal tool color.
+   */
+  private renderTopLayerHighlight(): void {
+    const topColor = this._topLayerColor;
+    const segColor = this._lastSegmentColor;
+    if (topColor === undefined && segColor === undefined) return;
+
+    const layers = this.job.layers;
+    // the visible top follows the end-layer clip so the highlight is never hidden
+    const topLayer = layers[(this._endLayer ?? layers.length) - 1];
+    if (!topLayer) return;
+
+    const extrusions = topLayer.paths.filter((path) => path.travelType === PathType.Extrusion);
+    if (extrusions.length === 0) return;
+
+    const lastPath = extrusions[extrusions.length - 1];
+    // a segment needs two points; a shorter final path cannot be split
+    const splitSegment = segColor !== undefined && lastPath.vertices.length >= 6;
+
+    if (topColor !== undefined) {
+      const body = splitSegment ? extrusions.slice(0, -1) : extrusions;
+      if (body.length > 0) this.objectsManager.renderExtrusionsInColor(body, topColor);
+    }
+
+    // hasRendered guards a second pass (renderMissingPaths) from splitting again,
+    // which would draw duplicate segment pieces the dedup set cannot catch
+    if (!splitSegment || this.objectsManager.hasRendered(lastPath)) return;
+
+    this.objectsManager.claimPaths([lastPath]);
+    const bodyColor = topColor ?? this.objectsManager.colorForTool(lastPath.tool);
+    const { body, segment } = this.splitLastSegment(lastPath);
+    if (body) this.objectsManager.renderExtrusionsInColor([body], bodyColor);
+    this.objectsManager.renderExtrusionsInColor([segment], segColor);
+  }
+
+  /**
+   * Splits a path into its final segment and the body that precedes it.
+   * @param path - Path to split
+   * @returns The last two points as `segment`, and everything up to and including
+   * the segment's first point as `body` (null when the path is a single segment)
+   */
+  private splitLastSegment(path: Path): { body: Path | null; segment: Path } {
+    const vertices = path.vertices;
+    const segment = this.subPath(path, vertices.slice(vertices.length - 6));
+    const body = vertices.length > 6 ? this.subPath(path, vertices.slice(0, vertices.length - 3)) : null;
+    return { body, segment };
+  }
+
+  /** Builds a path carrying `source`'s extrusion settings over a slice of vertices. */
+  private subPath(source: Path, vertices: number[]): Path {
+    const path = new Path(source.travelType, source.extrusionWidth, source.lineHeight, source.tool);
+    for (let i = 0; i < vertices.length; i += 3) {
+      path.addPoint(vertices[i], vertices[i + 1], vertices[i + 2]);
+    }
+    return path;
   }
 
   saveCamera() {


### PR DESCRIPTION
Re-implements the `topLayerColor` and `lastSegmentColor` render options from #356, which were accepted by the API but read by no render path since the layer→toolPath refactor. The topmost visible layer and the final print segment are now drawn as dedicated overlays that claim their paths before the per-tool batches, so their colors take precedence (in both line and tube modes), and the setters redraw on change. The demo's highlight controls are re-enabled and wired to a real default color. Added focused tests keeping `scene-manager.ts` and `objects-manager.ts` at 100% coverage. The issue's other two dead options (`disableGradient`, `toolColors`) are out of scope here and remain untouched.

<img width="1258" height="821" alt="Screenshot 2026-08-23 at 18 03 58" src="https://github.com/user-attachments/assets/041a4750-99ed-4c7b-bbf2-75b7b52d7649" />


Assisted by Claude Code - claude-opus-4-8