### PR TITLE
Re-implement disableGradient and the per-layer brightness gradient

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -138,7 +138,16 @@
                     :disabled="!settings.renderExtrusion"
                   />
                 </div>
-                
+                  <div class="controls" v-show="!settings.renderTubes">
+                    <label for="disable-gradient">Disable layer gradient</label
+                    ><input
+                      type="checkbox"
+                      id="disable-gradient"
+                      v-model="settings.disableGradient"
+                      :disabled="!settings.renderExtrusion"
+                    />
+                  </div>
+
                 <div class="controls" v-show="settings.renderTubes">
                   <label>Extrusion width <output>{{settings.extrusionWidth}}</output></label>&nbsp;
                   <input

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -162,6 +162,7 @@ export const app = (window.app = createApp({
 
         preview.sceneManager.renderExtrusion = settings.value.renderExtrusion;
         preview.sceneManager.renderTubes = settings.value.renderTubes;
+        preview.sceneManager.disableGradient = settings.value.disableGradient;
         preview.sceneManager.extrusionWidth = +settings.value.extrusionWidth;
 
         preview.sceneManager.topLayerColor = settings.value.highlightTopLayer

--- a/demo/js/default-settings.js
+++ b/demo/js/default-settings.js
@@ -21,6 +21,7 @@ export const defaultSettings = {
   renderTravel: false,
   travelColor: 'red',
   renderExtrusion: true,
+  disableGradient: false,
   lineWidth: 1,
   extrusionWidth: 0.4,
   colors: ['#ff0000', '#00ff00', '#0000ff', '#ffff00'],

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -183,6 +183,71 @@ describe('ObjectsManager', () => {
         expect(positionsOf(objectsManager.extrusionsGroup.children[0] as LineSegments2)).toBeInstanceOf(Float32Array);
       });
     });
+
+    describe('layer gradient', () => {
+      test('leaves lines flat when the gradient is off', () => {
+        objectsManager.renderExtrusionLines([layerPath(0)], new Color(0x00ff00));
+
+        const line = objectsManager.extrusionsGroup.children[0] as LineSegments2;
+        expect((line.material as LineMaterial).vertexColors).toBe(false);
+        expect(line.geometry.attributes.instanceColorStart).toBeUndefined();
+      });
+
+      test('bakes a per-layer brightness into the vertex colors when enabled', () => {
+        objectsManager.gradientEnabled = true;
+        objectsManager.layerCount = 2;
+
+        objectsManager.renderExtrusionLines([layerPath(0)], new Color(0x00ff00));
+
+        const line = objectsManager.extrusionsGroup.children[0] as LineSegments2;
+        expect((line.material as LineMaterial).vertexColors).toBe(true);
+        // 3 points -> 2 segments -> 6 grayscale floats per segment
+        const colors = colorsOf(line);
+        expect(colors).toHaveLength(12);
+        // layer 0 of 2 -> 0.1 + 0.7 * 0 / 2 = 0.1, the same grayscale on every channel
+        colors.forEach((channel) => expect(channel).toBeCloseTo(0.1));
+      });
+
+      test('brightens higher layers', () => {
+        objectsManager.gradientEnabled = true;
+        objectsManager.layerCount = 2;
+
+        objectsManager.renderExtrusionLines([layerPath(1)], new Color(0x00ff00));
+
+        // layer 1 of 2 -> 0.1 + 0.7 * 1 / 2 = 0.45
+        expect(colorsOf(objectsManager.extrusionsGroup.children[0] as LineSegments2)[0]).toBeCloseTo(0.45);
+      });
+
+      test('keeps lines flat for a non-planar job with no layers', () => {
+        objectsManager.gradientEnabled = true;
+        objectsManager.layerCount = 0;
+
+        objectsManager.renderExtrusionLines([layerPath(0)], new Color(0x00ff00));
+
+        const line = objectsManager.extrusionsGroup.children[0] as LineSegments2;
+        expect((line.material as LineMaterial).vertexColors).toBe(false);
+      });
+
+      test('renders a path with no layer index at full brightness', () => {
+        objectsManager.gradientEnabled = true;
+        objectsManager.layerCount = 2;
+        const path = createTestPath(); // no layerIndex assigned
+
+        objectsManager.renderExtrusionLines([path], new Color(0x00ff00));
+
+        expect(colorsOf(objectsManager.extrusionsGroup.children[0] as LineSegments2)[0]).toBe(1);
+      });
+
+      test('never gradients travel moves', () => {
+        objectsManager.gradientEnabled = true;
+        objectsManager.layerCount = 2;
+
+        objectsManager.renderTravelLines([layerPath(0)], new Color(0xff0000));
+
+        const line = objectsManager.travelMovesGroup.children[0] as LineSegments2;
+        expect((line.material as LineMaterial).vertexColors).toBe(false);
+      });
+    });
   });
 
   describe('renderExtrusionTubes', () => {
@@ -876,6 +941,17 @@ describe('ObjectsManager', () => {
 /** The flat position buffer three.js interleaves the segment endpoints into. */
 function positionsOf(lines: LineSegments2): Float32Array {
   return lines.geometry.attributes.instanceStart.data.array as Float32Array;
+}
+
+function colorsOf(lines: LineSegments2): Float32Array {
+  return lines.geometry.attributes.instanceColorStart.data.array as Float32Array;
+}
+
+/** A three-point extrusion path tagged with the layer it belongs to. */
+function layerPath(layerIndex: number): Path {
+  const path = createTestPath();
+  path.layerIndex = layerIndex;
+  return path;
 }
 
 function createTestPath(): Path {

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -668,6 +668,36 @@ describe('SceneManager properties', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    test('singleLayerMode rebuilds so the lone layer is not left dimmed', () => {
+      const spy = vi.spyOn(objectsManager(sceneManager), 'reset');
+
+      sceneManager.singleLayerMode = true;
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('singleLayerMode skips the rebuild when the gradient is disabled', () => {
+      const fresh = createSceneManager({ disableGradient: true });
+      const spy = vi.spyOn(objectsManager(fresh), 'reset');
+
+      fresh.singleLayerMode = true;
+
+      expect(spy).not.toHaveBeenCalled();
+
+      fresh.dispose();
+    });
+
+    test('singleLayerMode skips the rebuild in tube mode', () => {
+      const fresh = createSceneManager({ renderTubes: true });
+      const spy = vi.spyOn(objectsManager(fresh), 'reset');
+
+      fresh.singleLayerMode = true;
+
+      expect(spy).not.toHaveBeenCalled();
+
+      fresh.dispose();
+    });
+
     test('endLayer follows the end layer while single layer mode is on', () => {
       sceneManager.singleLayerMode = true;
 
@@ -844,6 +874,46 @@ describe('SceneManager properties', () => {
       sceneManager.disableGradient = true;
 
       expect(sceneManager.disableGradient).toBe(true);
+    });
+
+    test('gradients the extrusion lines by default', () => {
+      const line = extrusionGroup(sceneManager).children[0] as LineSegments2;
+
+      expect((line.material as LineMaterial).vertexColors).toBe(true);
+    });
+
+    test('leaves the extrusion lines flat when disabled', () => {
+      const fresh = createSceneManager({ disableGradient: true });
+
+      const line = extrusionGroup(fresh).children[0] as LineSegments2;
+      expect((line.material as LineMaterial).vertexColors).toBe(false);
+
+      fresh.dispose();
+    });
+
+    test('rebuilds the scene so the lines pick up the change', () => {
+      const spy = vi.spyOn(objectsManager(sceneManager), 'reset');
+
+      sceneManager.disableGradient = true;
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('ignores a repeated value', () => {
+      const spy = vi.spyOn(objectsManager(sceneManager), 'reset');
+
+      sceneManager.disableGradient = false;
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('does not rebuild once the job is cleared', () => {
+      sceneManager.clear();
+      const spy = vi.spyOn(objectsManager(sceneManager), 'reset');
+
+      sceneManager.disableGradient = true;
+
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -116,7 +116,11 @@ export class LayersIndexer extends Indexer {
       }
     }
 
-    this.lastLayer?.paths.push(path);
+    if (this.lastLayer) {
+      // record which layer the path landed in so the renderer can shade it by depth
+      path.layerIndex = this.indexes.length - 1;
+      this.lastLayer.paths.push(path);
+    }
   }
 
   /**

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -55,6 +55,14 @@ export class ObjectsManager {
   extrusionWidth?: number;
   renderTubes = false;
 
+  /**
+   * Whether extrusion lines get a per-layer brightness gradient baked into their vertex colors.
+   * Only meaningful for line rendering; tubes ignore it.
+   */
+  gradientEnabled = false;
+  /** Total number of layers, used to normalize the gradient ramp */
+  layerCount = 0;
+
   /** Build volume visualization, or undefined when none is drawn */
   buildVolume?: BuildVolume;
   /** Wireframe box around the model, created lazily on first draw */
@@ -339,7 +347,7 @@ export class ObjectsManager {
     const unrenderedPaths = this.takeUnrendered(paths);
     if (unrenderedPaths.length === 0) return;
 
-    this.travelMovesGroup.add(this.renderPathsAsLines(unrenderedPaths, color));
+    this.travelMovesGroup.add(this.renderPathsAsLines(unrenderedPaths, color, false));
   }
 
   /**
@@ -359,7 +367,7 @@ export class ObjectsManager {
     const unrenderedPaths = this.takeUnrendered(paths);
     if (unrenderedPaths.length === 0) return;
 
-    const lines = this.renderPathsAsLines(unrenderedPaths, color);
+    const lines = this.renderPathsAsLines(unrenderedPaths, color, this.gradientEnabled && this.layerCount > 0);
     lines.userData.toolIndex = toolIndex;
     this.extrusionsGroup.add(lines);
   }
@@ -388,7 +396,8 @@ export class ObjectsManager {
 
     const object = this.renderTubes
       ? this.renderPathsAsTubes(unrenderedPaths, this.createHighlightMaterial(color))
-      : this.renderPathsAsLines(unrenderedPaths, color);
+      : // highlights draw in their exact color and must win, so never gradient them
+        this.renderPathsAsLines(unrenderedPaths, color, false);
     object.userData.highlight = true;
     this.extrusionsGroup.add(object);
   }
@@ -510,17 +519,66 @@ export class ObjectsManager {
     this.updateLineClipping();
   }
 
-  private renderPathsAsLines(paths: Path[], color: Color): LineSegments2 {
+  private renderPathsAsLines(paths: Path[], color: Color, gradient: boolean): LineSegments2 {
     const material = new LineMaterial({
       color: Number(color.getHex()),
       linewidth: this.lineWidth,
-      clippingPlanes: this.clippingPlanes
+      clippingPlanes: this.clippingPlanes,
+      // the gradient rides on vertex colors, multiplied against the base color, so
+      // recoloring stays a one-line material.color write and the ramp reapplies itself
+      vertexColors: gradient
     });
 
     const geometry = new LineSegmentsGeometry().setPositions(this.packLineVertices(paths));
+    if (gradient) geometry.setColors(this.packLineColors(paths));
     this.disposables.push(material);
     this.disposables.push(geometry);
     return new LineSegments2(geometry, material);
+  }
+
+  /**
+   * Builds the per-vertex color buffer that shades each segment by its layer depth.
+   * @param paths - Paths to color, in the same order and segmentation as packLineVertices
+   * @returns Six floats per segment: a grayscale brightness at each endpoint
+   * @remarks
+   * The value is a plain grayscale multiplier, not an absolute color: the shader
+   * multiplies it against the material's base color, so the same buffer works for
+   * any extrusion color and a live recolor needs no rebuild. Lower layers come out
+   * darker, matching the original per-layer brightness ramp.
+   */
+  private packLineColors(paths: Path[]): Float32Array {
+    let segments = 0;
+    for (const path of paths) {
+      segments += Math.max(0, Math.ceil((path.vertices.length - 3) / 3));
+    }
+
+    const colors = new Float32Array(segments * 6);
+    let next = 0;
+
+    for (const path of paths) {
+      const brightness = this.layerBrightness(path.layerIndex);
+      const vertices = path.vertices;
+      for (let i = 0; i < vertices.length - 3; i += 3) {
+        colors[next++] = brightness;
+        colors[next++] = brightness;
+        colors[next++] = brightness;
+        colors[next++] = brightness;
+        colors[next++] = brightness;
+        colors[next++] = brightness;
+      }
+    }
+
+    return colors;
+  }
+
+  /**
+   * Maps a layer index to a brightness in [0.1, 0.8], ramping from dark at the bottom
+   * to bright at the top. Paths with no layer (non-planar jobs) render at full brightness.
+   * @remarks Only called with layerCount > 0, so the division is always safe.
+   */
+  private layerBrightness(layerIndex?: number): number {
+    if (layerIndex === undefined) return 1;
+    return 0.1 + (0.7 * layerIndex) / this.layerCount;
   }
 
   /**

--- a/src/path.ts
+++ b/src/path.ts
@@ -31,6 +31,9 @@ export class Path {
   /** Tool number used for this path */
   public tool: number;
 
+  /** Index of the layer this path belongs to, set by the LayersIndexer; undefined for non-planar jobs */
+  public layerIndex?: number;
+
   /** Internal storage for path vertices */
   private _vertices: number[];
 

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -188,9 +188,9 @@ export class SceneManager {
     if (opts.lastSegmentColor !== undefined) {
       this._lastSegmentColor = new Color(opts.lastSegmentColor);
     }
-    if (opts.disableGradient !== undefined) {
-      this.disableGradient = opts.disableGradient;
-    }
+    // set the backing field directly: the setter re-renders, but initScene() below
+    // draws the scene once with this value already applied
+    this._disableGradient = opts.disableGradient ?? this._disableGradient;
 
     console.info('Using THREE r' + REVISION);
     console.debug('preview options', opts);
@@ -442,7 +442,22 @@ export class SceneManager {
     return this._disableGradient;
   }
   set disableGradient(value: boolean) {
+    if (value === this._disableGradient) return;
     this._disableGradient = value;
+    // the ramp is baked into the line geometry, so switching it on or off means
+    // rebuilding the extrusion lines
+    if (this.job) this.render();
+  }
+
+  /**
+   * Whether the per-layer brightness gradient should be baked into the extrusion lines.
+   * @remarks
+   * The gradient only applies to flat lines: tubes carry their own shading, and
+   * single-layer mode shows one layer that should read at full color. A non-planar
+   * job (no layers) is filtered out downstream, where the layer count is known.
+   */
+  private get gradientEnabled(): boolean {
+    return !this._disableGradient && !this._singleLayerMode && !this.renderTubes;
   }
 
   /**
@@ -522,6 +537,12 @@ export class SceneManager {
 
     // the visible range moved, so the clipping planes have to follow
     this.updateClippingPlanes();
+
+    // entering or leaving single-layer mode flips whether the gradient applies, so
+    // rebuild the lines to avoid leaving the lone visible layer dimmed by the ramp
+    if (!this._disableGradient && !this.renderTubes) {
+      this.render();
+    }
   }
 
   get ambientLight(): number {
@@ -789,6 +810,8 @@ export class SceneManager {
   private renderPaths(endPathNumber: number = Infinity): void {
     this.objectsManager.setTravelsVisible(this._renderTravel);
     this.objectsManager.setExtrusionsVisible(this._renderExtrusion);
+    this.objectsManager.gradientEnabled = this.gradientEnabled;
+    this.objectsManager.layerCount = this.job.countLayers;
 
     if (this._renderExtrusion && endPathNumber === Infinity) {
       this.renderTopLayerHighlight();


### PR DESCRIPTION
Re-implements the per-layer brightness gradient (dark bottom → bright top) that was silently dropped in the #211 interpreter extraction, which had left `disableGradient` a no-op (#356). The ramp is baked as a grayscale vertex-color multiplier on each tool's `LineSegments2`, so the base color stays in `material.color` and a live recolor needs no rebuild; `disableGradient` skips baking it, and it stays off for tube rendering and single-layer mode. `Path.layerIndex` set by the `LayersIndexer` drives the depth ramp, and toggling `disableGradient` or `singleLayerMode` rebuilds the extrusion lines since the ramp lives in the geometry. The demo gets a "Disable layer gradient" checkbox (shown in line mode) wired through to `sceneManager`. New tests cover the baking, the ramp, and the off-paths, keeping `scene-manager.ts` and `objects-manager.ts` at 100% coverage.

<img width="1392" height="973" alt="Screenshot 2026-08-23 at 18 10 53" src="https://github.com/user-attachments/assets/d56ef553-b266-4171-bf44-bf9fc85f0ff7" />
<img width="1385" height="951" alt="Screenshot 2026-08-23 at 18 10 59" src="https://github.com/user-attachments/assets/fa606751-80d4-4a33-bc6e-398a009bbbb6" />


Assisted by Claude Code - Opus 4.8