### PR TITLE
Point package.json repository.url at xyz-tools/gcode-preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:remcoder/gcode-preview.git"
+    "url": "git+https://github.com/xyz-tools/gcode-preview.git"
   },
   "homepage": "https://gcode-preview.web.app/",
   "main": "dist/gcode-preview.es.js",


### PR DESCRIPTION
## Why

The v3.0.0-alpha.5 npm publish failed with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/gcode-preview - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+ssh://git@github.com/remcoder/gcode-preview.git", expected to match "https://github.com/xyz-tools/gcode-preview" from provenance
```

The OIDC trusted publishing flow from #393 works (auth succeeded, provenance was signed), but npm's provenance validation requires `repository.url` in `package.json` to match the repository the workflow actually ran in. The URL still pointed at the pre-org-move `remcoder/gcode-preview` location.

## What

Update `repository.url` to `git+https://github.com/xyz-tools/gcode-preview.git` (the npm-normalized https form, matching what the provenance statement expects).

After this merges, the `v3.0.0-alpha.5` tag and release will be recreated on the new develop head so the publish can go through.

Assisted by Claude Code - Fable 5