### PR TITLE
Cover LineBox fully and pin it at 100%

### DIFF
--- a/src/__tests__/line-box.ts
+++ b/src/__tests__/line-box.ts
@@ -1,0 +1,123 @@
+import { test, expect, describe, vi } from 'vitest';
+import { BufferGeometry, Color, LineBasicMaterial, LineDashedMaterial, Material } from 'three';
+import { LineBox } from '../helpers/line-box';
+
+/** Collects the geometry's vertex pairs as order-independent, undirected edges */
+function edges(geometry: BufferGeometry): Set<string> {
+  const position = geometry.getAttribute('position');
+  const result = new Set<string>();
+
+  for (let i = 0; i < position.count; i += 2) {
+    const a = [position.getX(i), position.getY(i), position.getZ(i)].join(',');
+    const b = [position.getX(i + 1), position.getY(i + 1), position.getZ(i + 1)].join(',');
+    result.add([a, b].sort().join('|'));
+  }
+
+  return result;
+}
+
+function expectedBoxEdges(x: number, y: number, z: number): Set<string> {
+  const corner = (cx: number, cy: number, cz: number): string => [cx, cy, cz].join(',');
+  const edge = (a: string, b: string): string => [a, b].sort().join('|');
+
+  const result = new Set<string>();
+  // 4 edges along each axis, connecting the corners of the (0,0,0)-(x,y,z) box
+  for (const cy of [0, y]) {
+    for (const cz of [0, z]) {
+      result.add(edge(corner(0, cy, cz), corner(x, cy, cz)));
+    }
+  }
+  for (const cx of [0, x]) {
+    for (const cz of [0, z]) {
+      result.add(edge(corner(cx, 0, cz), corner(cx, y, cz)));
+    }
+  }
+  for (const cx of [0, x]) {
+    for (const cy of [0, y]) {
+      result.add(edge(corner(cx, cy, 0), corner(cx, cy, z)));
+    }
+  }
+  return result;
+}
+
+describe('.createBoxGeometry', () => {
+  test('creates the 12 edges of the box spanning (0,0,0) to (x,y,z)', () => {
+    const geometry = LineBox.createBoxGeometry(10, 20, 30);
+
+    const position = geometry.getAttribute('position');
+    expect(position.count).toEqual(24); // 12 edges, 2 vertices each
+
+    const actual = edges(geometry);
+    expect(actual.size).toEqual(12); // no duplicate or degenerate edges
+    expect(actual).toEqual(expectedBoxEdges(10, 20, 30));
+  });
+});
+
+describe('constructor', () => {
+  test('builds a box that extends into negative z, mirroring the scene z-flip', () => {
+    const box = new LineBox(10, 20, 30, 0x888888, false);
+
+    box.geometry.computeBoundingBox();
+    expect(box.geometry.boundingBox.min).toEqual({ x: 0, y: 0, z: -30 });
+    expect(box.geometry.boundingBox.max).toEqual({ x: 10, y: 20, z: 0 });
+  });
+
+  test('is dashed by default', () => {
+    const box = new LineBox(10, 20, 30, 0x888888);
+
+    expect(box.material).toBeInstanceOf(LineDashedMaterial);
+    const material = box.material as LineDashedMaterial;
+    expect(material.dashSize).toEqual(3);
+    expect(material.gapSize).toEqual(1);
+  });
+
+  test('computes line distances when dashed, so dashes actually render', () => {
+    const box = new LineBox(10, 20, 30, 0x888888);
+
+    const lineDistance = box.geometry.getAttribute('lineDistance');
+    expect(lineDistance).toBeDefined();
+    expect(lineDistance.count).toEqual(box.geometry.getAttribute('position').count);
+  });
+
+  test('uses a basic material without line distances when not dashed', () => {
+    const box = new LineBox(10, 20, 30, 0x888888, false);
+
+    expect(box.material).toBeInstanceOf(LineBasicMaterial);
+    expect(box.material).not.toBeInstanceOf(LineDashedMaterial);
+    expect(box.geometry.getAttribute('lineDistance')).toBeUndefined();
+  });
+
+  test.each([
+    ['number', 0xff8800],
+    ['string', '#ff8800'],
+    ['Color', new Color(0xff8800)]
+  ] as const)('applies the color given as a %s', (_kind, color) => {
+    const box = new LineBox(10, 20, 30, color, false);
+
+    expect((box.material as LineBasicMaterial).color).toEqual(new Color(0xff8800));
+  });
+});
+
+describe('.dispose', () => {
+  test('disposes the geometry and the material', () => {
+    const box = new LineBox(10, 20, 30, 0x888888);
+    const geometryDispose = vi.spyOn(box.geometry, 'dispose');
+    const materialDispose = vi.spyOn(box.material as Material, 'dispose');
+
+    box.dispose();
+
+    expect(geometryDispose).toHaveBeenCalledOnce();
+    expect(materialDispose).toHaveBeenCalledOnce();
+  });
+
+  test('disposes every material when the material is an array', () => {
+    const box = new LineBox(10, 20, 30, 0x888888);
+    const materials = [new LineBasicMaterial(), new LineBasicMaterial()];
+    const spies = materials.map((material) => vi.spyOn(material, 'dispose'));
+    box.material = materials;
+
+    box.dispose();
+
+    spies.forEach((spy) => expect(spy).toHaveBeenCalledOnce());
+  });
+});

--- a/src/helpers/line-box.ts
+++ b/src/helpers/line-box.ts
@@ -7,7 +7,24 @@ import {
   LineSegments
 } from 'three';
 
+/**
+ * Axis-aligned wireframe box, used for the build volume outline and the
+ * bounding box around the rendered G-code model
+ * @remarks
+ * Only the 12 edges are drawn, no faces. The box spans from the origin to
+ * (x, y, -z): the depth is negated to match the scene's z-flip convention
+ * (see BuildVolume.createAxes), so callers pass their world-space depth as
+ * a positive number.
+ */
 class LineBox extends LineSegments {
+  /**
+   * Creates a new LineBox instance
+   * @param x - Width of the box
+   * @param y - Height of the box
+   * @param z - Depth of the box, drawn towards negative z
+   * @param color - Color of the box edges
+   * @param dashed - Whether to draw dashed instead of solid lines (default: true)
+   */
   constructor(x: number, y: number, z: number, color: Color | number | string, dashed = true) {
     const geometryBox = LineBox.createBoxGeometry(x, y, -z);
     const material = dashed
@@ -21,6 +38,13 @@ class LineBox extends LineSegments {
     }
   }
 
+  /**
+   * Creates the edge geometry of a box spanning (0, 0, 0) to (x, y, z)
+   * @param x - Width of the box
+   * @param y - Height of the box
+   * @param z - Depth of the box, unnegated
+   * @returns BufferGeometry holding the box's 12 edges as line segment pairs
+   */
   static createBoxGeometry(x: number, y: number, z: number): BufferGeometry {
     const geometry = new BufferGeometry();
     const position: number[] = [];
@@ -50,6 +74,9 @@ class LineBox extends LineSegments {
     return geometry;
   }
 
+  /**
+   * Frees the GPU resources held by the box's geometry and material(s)
+   */
   dispose() {
     this.geometry.dispose();
     if (Array.isArray(this.material)) {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -49,7 +49,6 @@ export default defineConfig({
         'src/thumbnail.ts': { statements: 92.3, branches: 100, functions: 75, lines: 92.3 },
         'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 },
-        'src/helpers/line-box.ts': { statements: 80, branches: 57.14, functions: 75, lines: 85.71 },
         'src/helpers/split-chunk.ts': { statements: 75, branches: 50, functions: 100, lines: 75 }
       }
     }


### PR DESCRIPTION
## Summary

`src/helpers/line-box.ts` was grandfathered at 80% statements / 57% branches / 75% functions with no dedicated test file — it was only covered incidentally through `BuildVolume` and `ObjectsManager` tests, which all construct it with `dashed: false`.

This PR adds `src/__tests__/line-box.ts` covering the previously unexercised paths:

- the **dashed default**: `LineDashedMaterial` with the expected dash/gap sizes, and the `computeLineDistances()` call (pinned by asserting the `lineDistance` attribute exists and matches the position count — without it dashes silently don't render)
- the **non-dashed** branch: `LineBasicMaterial`, no `lineDistance` attribute
- `createBoxGeometry`: exactly the 12 undirected edges of the `(0,0,0)–(x,y,z)` box, order-independent
- the constructor's **z-negation** (box extends into −z, mirroring the scene's z-flip convention)
- color pass-through for `number`, `string`, and `Color` inputs
- `dispose()` for both the single-material and material-array branches

With the file at 100%, its grandfathered threshold entry is removed from `vitest.config.mts`, so the per-file 100% default now holds it there.

No bugs found: the edge list, the material branches, and the dispose logic all check out — so no fix was needed, just the missing tests.

## Test plan

- `npx vitest run --coverage` — 553 tests pass, `line-box.ts` at 100/100/100/100 (dropped out of the <100% table), thresholds green
- `npm run lint` and `npm run typeCheck` pass

Assisted by Claude Code - Fable 5