### PR TITLE
Model un-homed position as unknown with an isHomed flag

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -26,7 +26,9 @@ describe('.execute', () => {
     const result = interpreter.execute([command]);
 
     expect(result.paths.length).toEqual(0);
-    expect(result.state.x).toEqual(0);
+    // Nothing ran, so the axes are still un-homed and the position is unknown.
+    expect(result.state.x).toBeUndefined();
+    expect(result.state.isHomed).toBe(false);
   });
 
   test('ignores unknown commands', () => {
@@ -37,9 +39,11 @@ describe('.execute', () => {
 
     expect(result).not.toBeNull();
     expect(result).toBeInstanceOf(Job);
-    expect(result.state.x).toEqual(0);
-    expect(result.state.y).toEqual(0);
-    expect(result.state.z).toEqual(0);
+    // An unknown command leaves the axes un-homed, so the position stays unknown.
+    expect(result.state.x).toBeUndefined();
+    expect(result.state.y).toBeUndefined();
+    expect(result.state.z).toBeUndefined();
+    expect(result.state.isHomed).toBe(false);
   });
 
   test('runs multiple commands', () => {
@@ -264,18 +268,37 @@ test('.G21 sets the units to millimeters', () => {
   expect(job.state.units).toEqual('mm');
 });
 
-test('.g28 moves the state to the origin', () => {
+test('.g28 moves the state to the origin and marks it homed', () => {
   const command = new GCodeCommand('G28', 'g28', {});
   const interpreter = new Interpreter();
   const job = new Job();
   job.state.x = 3;
   job.state.y = 4;
+  expect(job.state.isHomed).toBe(false);
 
   interpreter.g28(command, job);
 
   expect(job.state.x).toEqual(0);
   expect(job.state.y).toEqual(0);
   expect(job.state.z).toEqual(0);
+  expect(job.state.isHomed).toBe(true);
+});
+
+test('an un-homed state assumes the origin so a move can still render', () => {
+  // Before G28 the position is unknown; we assume (0,0,0) to render best-effort
+  // (see #361) while isHomed stays false so callers can tell it is assumed.
+  const command = new GCodeCommand('G1 Y5 E1', 'g1', { y: 5, e: 1 });
+  const interpreter = new Interpreter();
+  const job = new Job();
+
+  interpreter.g1(command, job);
+
+  // X and Z were never given and never homed -> assumed origin in the geometry.
+  expect(job.inprogressPath?.vertices.slice(0, 3)).toEqual([0, 0, 0]);
+  expect(job.inprogressPath?.vertices.slice(3, 6)).toEqual([0, 5, 0]);
+  expect(job.state.x).toBeUndefined();
+  expect(job.state.z).toBeUndefined();
+  expect(job.state.isHomed).toBe(false);
 });
 
 test('.t0 sets the tool to 0', () => {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,8 +1,23 @@
 import { Path, PathType } from './path';
 import { GCodeCommand } from './gcode-parser';
 import { Job } from './job';
+import { State } from './state';
 
 type Method = (..._args: unknown[]) => unknown;
+
+/**
+ * Resolves a state's position for rendering.
+ * @param state - Current job state
+ * @returns The position as concrete `x`, `y`, `z` numbers
+ * @remarks
+ * An axis that has not been homed has an unknown (`undefined`) position. The
+ * interpreter chooses to assume the origin (`0`) for such axes so the viewer can
+ * still render best-effort (see #361); `state.isHomed` lets a consumer tell these
+ * assumed coordinates from real ones.
+ */
+function resolvePosition(state: State): { x: number; y: number; z: number } {
+  return { x: state.x ?? 0, y: state.y ?? 0, z: state.z ?? 0 };
+}
 
 /**
  * Interprets and executes G-code commands, updating the job state accordingly
@@ -109,7 +124,7 @@ export class Interpreter {
     state.y = y ?? state.y;
     state.z = z ?? state.z;
 
-    const pos = state.position;
+    const pos = resolvePosition(state);
     currentPath.addPoint(pos.x, pos.y, pos.z);
     if (pathType === PathType.Extrusion) {
       job.boundingBox.update(pos.x, pos.y, pos.z);
@@ -134,9 +149,8 @@ export class Interpreter {
     // Set when the arc cannot be described at all, so only the endpoint is emitted.
     let arcIsDegenerate = false;
     const { state } = job;
-    // Starting position for the arc. Any un-homed axis is unknown, so it is
-    // assumed to be at the origin (see #361) to allow best-effort rendering.
-    const from = state.position;
+    // Starting position for the arc, with any un-homed axis assumed at the origin.
+    const from = resolvePosition(state);
 
     const cw = command.gcode === 'g2';
     let currentPath = job.inprogressPath;
@@ -255,7 +269,7 @@ export class Interpreter {
     state.y = y ?? state.y;
     state.z = z ?? state.z;
 
-    const pos = state.position;
+    const pos = resolvePosition(state);
     currentPath.addPoint(pos.x, pos.y, pos.z);
     if (pathType === PathType.Extrusion) {
       job.boundingBox.update(pos.x, pos.y, pos.z);
@@ -399,7 +413,7 @@ export class Interpreter {
   private breakPath(job: Job, newType: PathType): Path {
     job.finishPath();
     const currentPath = new Path(newType, 0.6, 0.2, job.state.tool);
-    const pos = job.state.position;
+    const pos = resolvePosition(job.state);
     currentPath.addPoint(pos.x, pos.y, pos.z);
     job.inprogressPath = currentPath;
     return currentPath;

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -109,9 +109,10 @@ export class Interpreter {
     state.y = y ?? state.y;
     state.z = z ?? state.z;
 
-    currentPath.addPoint(state.x, state.y, state.z);
+    const pos = state.position;
+    currentPath.addPoint(pos.x, pos.y, pos.z);
     if (pathType === PathType.Extrusion) {
-      job.boundingBox.update(state.x, state.y, state.z);
+      job.boundingBox.update(pos.x, pos.y, pos.z);
     }
   }
 
@@ -133,6 +134,9 @@ export class Interpreter {
     // Set when the arc cannot be described at all, so only the endpoint is emitted.
     let arcIsDegenerate = false;
     const { state } = job;
+    // Starting position for the arc. Any un-homed axis is unknown, so it is
+    // assumed to be at the origin (see #361) to allow best-effort rendering.
+    const from = state.position;
 
     const cw = command.gcode === 'g2';
     let currentPath = job.inprogressPath;
@@ -151,8 +155,8 @@ export class Interpreter {
 
     if (r) {
       // in r mode a minimum radius will be applied if the distance can otherwise not be bridged
-      const deltaX = x - state.x; // assume abs mode
-      const deltaY = y - state.y;
+      const deltaX = x - from.x; // assume abs mode
+      const deltaY = y - from.y;
 
       // apply a minimal radius to bridge the distance
       const minR = Math.sqrt(Math.pow(deltaX / 2, 2) + Math.pow(deltaY / 2, 2));
@@ -180,9 +184,9 @@ export class Interpreter {
       }
     }
 
-    const wholeCircle = state.x == x && state.y == y;
-    const centerX = state.x + i;
-    const centerY = state.y + j;
+    const wholeCircle = from.x == x && from.y == y;
+    const centerX = from.x + i;
+    const centerY = from.y + j;
 
     const arcRadius = Math.sqrt(i * i + j * j);
     const arcCurrentAngle = Math.atan2(-j, -i);
@@ -215,13 +219,13 @@ export class Interpreter {
     // Z0 into a flat arc at the old height. This matches the endpoint assignment
     // below, and is only safe because the parser now drops non-finite params -- `||`
     // was rejecting NaN here by accident, and `??` does not.
-    const zDist = (z ?? state.z) - state.z;
+    const zDist = (z ?? from.z) - from.z;
     const zStep = zDist / totalSegments;
 
     // get points for the arc
-    let px = state.x;
-    let py = state.y;
-    let pz = state.z;
+    let px = from.x;
+    let py = from.y;
+    let pz = from.z;
     // calculate segments
     let currentAngle = arcCurrentAngle;
 
@@ -251,9 +255,10 @@ export class Interpreter {
     state.y = y ?? state.y;
     state.z = z ?? state.z;
 
-    currentPath.addPoint(state.x, state.y, state.z);
+    const pos = state.position;
+    currentPath.addPoint(pos.x, pos.y, pos.z);
     if (pathType === PathType.Extrusion) {
-      job.boundingBox.update(state.x, state.y, state.z);
+      job.boundingBox.update(pos.x, pos.y, pos.z);
     }
   }
 
@@ -282,12 +287,14 @@ export class Interpreter {
    * @param command - GCodeCommand containing the command
    * @param job - Job instance to update
    * @remarks
-   * Moves all axes to their home positions (0,0,0) and updates the job state.
+   * Moves all axes to their home positions (0,0,0) and marks the state as homed,
+   * so the position is now known rather than assumed.
    */
   g28(command: GCodeCommand, job: Job): void {
     job.state.x = 0;
     job.state.y = 0;
     job.state.z = 0;
+    job.state.isHomed = true;
   }
 
   /**
@@ -392,7 +399,8 @@ export class Interpreter {
   private breakPath(job: Job, newType: PathType): Path {
     job.finishPath();
     const currentPath = new Path(newType, 0.6, 0.2, job.state.tool);
-    currentPath.addPoint(job.state.x, job.state.y, job.state.z);
+    const pos = job.state.position;
+    currentPath.addPoint(pos.x, pos.y, pos.z);
     job.inprogressPath = currentPath;
     return currentPath;
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,22 +4,43 @@
  * Tracks the current position, extrusion state, active tool, and units
  */
 export class State {
-  /** Current X position */
-  x = 0;
-  /** Current Y position */
-  y = 0;
-  /** Current Z position */
-  z = 0;
+  /** Current X position, or `undefined` until the axis is homed (G28) */
+  x: number | undefined = undefined;
+  /** Current Y position, or `undefined` until the axis is homed (G28) */
+  y: number | undefined = undefined;
+  /** Current Z position, or `undefined` until the axis is homed (G28) */
+  z: number | undefined = undefined;
   /** Current extrusion amount */
   e = 0;
   /** Currently active tool */
   tool = 0;
   /** Current units (millimeters or inches) */
   units: 'mm' | 'in' = 'mm';
+  /**
+   * Whether the axes have been homed (G28).
+   * @remarks
+   * Until an axis is homed its real position is unknown. While `isHomed` is
+   * `false`, {@link State.position} assumes the origin so the viewer can still
+   * render best-effort (see https://github.com/xyz-tools/gcode-preview/issues/361).
+   * Consumers can read this flag to tell real coordinates from assumed ones.
+   */
+  isHomed = false;
+
+  /**
+   * The current position, with any un-homed axis assumed to be at the origin.
+   * @remarks
+   * `x`/`y`/`z` are `undefined` until homed; rendering needs concrete numbers,
+   * so an unknown axis falls back to `0`. Check {@link State.isHomed} to know
+   * whether these coordinates are real or assumed.
+   * @returns The position as concrete `x`, `y`, `z` numbers
+   */
+  get position(): { x: number; y: number; z: number } {
+    return { x: this.x ?? 0, y: this.y ?? 0, z: this.z ?? 0 };
+  }
 
   /**
    * Gets a new State instance with default initial values
-   * @returns New State instance with x=0, y=0, z=0, e=0, tool=0, units='mm'
+   * @returns New State with an un-homed (unknown) position, e=0, tool=0, units='mm'
    */
   static get initial(): State {
     return new State();

--- a/src/state.ts
+++ b/src/state.ts
@@ -19,24 +19,12 @@ export class State {
   /**
    * Whether the axes have been homed (G28).
    * @remarks
-   * Until an axis is homed its real position is unknown. While `isHomed` is
-   * `false`, {@link State.position} assumes the origin so the viewer can still
-   * render best-effort (see https://github.com/xyz-tools/gcode-preview/issues/361).
-   * Consumers can read this flag to tell real coordinates from assumed ones.
+   * Until an axis is homed its real position is unknown, which is why `x`/`y`/`z`
+   * can be `undefined`. Consumers can read this flag to tell real coordinates
+   * from ones a renderer may have assumed. How to render an un-homed position is
+   * the interpreter's decision, not the state's.
    */
   isHomed = false;
-
-  /**
-   * The current position, with any un-homed axis assumed to be at the origin.
-   * @remarks
-   * `x`/`y`/`z` are `undefined` until homed; rendering needs concrete numbers,
-   * so an unknown axis falls back to `0`. Check {@link State.isHomed} to know
-   * whether these coordinates are real or assumed.
-   * @returns The position as concrete `x`, `y`, `z` numbers
-   */
-  get position(): { x: number; y: number; z: number } {
-    return { x: this.x ?? 0, y: this.y ?? 0, z: this.z ?? 0 };
-  }
 
   /**
    * Gets a new State instance with default initial values

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,25 +5,23 @@
  */
 export class State {
   /** Current X position */
-  x: number;
+  x = 0;
   /** Current Y position */
-  y: number;
+  y = 0;
   /** Current Z position */
-  z: number;
+  z = 0;
   /** Current extrusion amount */
-  e: number;
+  e = 0;
   /** Currently active tool */
-  tool: number;
+  tool = 0;
   /** Current units (millimeters or inches) */
-  units: 'mm' | 'in';
+  units: 'mm' | 'in' = 'mm';
 
   /**
    * Gets a new State instance with default initial values
    * @returns New State instance with x=0, y=0, z=0, e=0, tool=0, units='mm'
    */
   static get initial(): State {
-    const state = new State();
-    Object.assign(state, { x: 0, y: 0, z: 0, e: 0, tool: 0, units: 'mm' });
-    return state;
+    return new State();
   }
 }


### PR DESCRIPTION
## What

Model the printer's position as **unknown until homed** instead of silently defaulting to the origin, and encode that as an explicit, type-safe contract.

- `State.x` / `y` / `z` are now `number | undefined` (was `number`), initialized to `undefined` — the axis position is genuinely unknown until homed.
- New exposed `State.isHomed: boolean` (default `false`), set `true` by `G28`.
- `State` stays a plain data holder with **no opinion** on rendering. The interpreter owns the policy: a module-level `resolvePosition(state)` assumes the **origin (0,0,0)** for any un-homed axis and is used by the move handlers (`g0`/`g1`, `g2`/`g3` arcs, `breakPath`).

## Why — a clear contract, documented, and type-checked

The goal is to make "position is unknown until homed" a **first-class part of the type**, so the compiler and the docs prevent a whole class of bugs instead of relying on convention.

- **Clear contract.** `number | undefined` says exactly what's true: an un-homed axis has *no* position. `isHomed` is the explicit signal a caller reads to distinguish real coordinates from assumed ones. There is no longer an ambiguous `0` standing in for two different facts.
- **Type safety prevents bugs.** Previously `x/y/z` were `number` and defaulted to `0`, which silently conflated "at the origin" with "not homed yet" — a move issued before homing was plotted against a *fake* origin with nothing flagging it. With `number | undefined`, every consumer of a raw axis is forced by the type system to decide what an unknown position means; the one place that assumes the origin (`resolvePosition`) is deliberate, named, and documented rather than an accidental default scattered across the code.
- **Documentation.** `State.x/y/z`, `State.isHomed`, `resolvePosition`, and `g28` all carry doc comments spelling out the un-homed semantics and the origin assumption, linking the rationale to the best-effort "render like a browser" failure model in #361.

Behaviour for the common case is unchanged: the origin assumption reproduces the previous `0`-default geometry, so existing renders are identical. `isHomed` is the non-obtrusive signal a consuming app can read to tell assumed coordinates from real ones.

`e`, `tool`, and `units` keep concrete defaults (`0`, `0`, `'mm'`) — those match firmware defaults and aren't "unknown until homed."

## Notes

- `State.x/y/z` changing from `number` to `number | undefined` is a public API change (alpha), and a deliberate one: it tightens the contract so callers handle the unknown case.
- Started as a `strictPropertyInitialization` fix (all 6 `TS2564` live in `state.ts`); this supersedes that with the correct domain model. `state.ts` is fully strict-clean and no new strict errors are introduced (repo-wide strict burndown holds at 72).

## Verification

- `npm run typeCheck` ✅
- `npm run lint` ✅
- 554 tests ✅ (added: `isHomed` after G28, and an un-homed move rendering at the assumed origin)
- Coverage thresholds ✅ (`state.ts` and `interpreter.ts` stay 100%)

Assisted by Claude Code - Opus 4.8