### PR TITLE
Cover BuildVolume fully and pin it at 100%

### DIFF
--- a/src/__tests__/build-volume.ts
+++ b/src/__tests__/build-volume.ts
@@ -1,6 +1,6 @@
 import { test, describe, expect, vi } from 'vitest';
 import { BuildVolume } from '../build-volume';
-import { AxesHelper, Scene } from 'three';
+import { AxesHelper, Color, Object3D, Scene } from 'three';
 import { Grid } from '../helpers/grid';
 import { LineBox } from '../helpers/line-box';
 
@@ -22,6 +22,68 @@ describe('BuildVolume', () => {
     expect(buildVolume.x).toEqual(10);
     expect(buildVolume.y).toEqual(20);
     expect(buildVolume.z).toEqual(30);
+  });
+
+  describe('invalid dimensions never throw (#300/#301)', () => {
+    // Dimensions are often bound to live UI inputs (issue #300: a Vue-bound
+    // input crashed mid-edit), so BuildVolume must tolerate transient invalid
+    // values by clamping to 0 — never by throwing (policy set in PR #301).
+
+    test('never throws at construction; negative dimensions clamp to 0', () => {
+      const scene = new Scene();
+
+      expect(() => new BuildVolume(-1, -1, -1, false, scene)).not.toThrow();
+
+      const buildVolume = new BuildVolume(-1, -1, -1, false, scene);
+      expect(buildVolume.x).toEqual(0);
+      expect(buildVolume.y).toEqual(0);
+      expect(buildVolume.z).toEqual(0);
+    });
+
+    test('never throws when x is set to a negative value; clamps to 0', () => {
+      const buildVolume = new BuildVolume(10, 20, 30, false, new Scene());
+
+      expect(() => {
+        buildVolume.x = -5;
+      }).not.toThrow();
+
+      expect(buildVolume.x).toEqual(0);
+    });
+
+    test('never throws when y is set to a negative value; clamps to 0', () => {
+      const buildVolume = new BuildVolume(10, 20, 30, false, new Scene());
+
+      expect(() => {
+        buildVolume.y = -5;
+      }).not.toThrow();
+
+      expect(buildVolume.y).toEqual(0);
+    });
+
+    test('never throws when z is set to a negative value; clamps to 0 and still updates', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      expect(() => {
+        buildVolume.z = -1;
+      }).not.toThrow();
+
+      expect(buildVolume.z).toEqual(0);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('accepts 0 without throwing; a zero-sized volume simply renders nothing', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      expect(() => {
+        buildVolume.x = 0;
+      }).not.toThrow();
+
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('.createAxes', () => {
@@ -75,6 +137,18 @@ describe('BuildVolume', () => {
       expect(group.children[1]).toBeInstanceOf(Grid);
       expect(group.children[2]).toBeInstanceOf(AxesHelper);
     });
+
+    test('it includes a small grid when smallGrid is true', () => {
+      const buildVolume = new BuildVolume(10, 20, 30, true, mockScene);
+
+      const group = buildVolume.createGroup();
+
+      expect(group.children.length).toEqual(4);
+      expect(group.children[0]).toBeInstanceOf(LineBox);
+      expect(group.children[1]).toBeInstanceOf(Grid);
+      expect(group.children[2]).toBeInstanceOf(Grid);
+      expect(group.children[3]).toBeInstanceOf(AxesHelper);
+    });
   });
 
   describe('.dispose', () => {
@@ -85,6 +159,7 @@ describe('BuildVolume', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const group = buildVolume['_group']!;
+      group.add(new Object3D()); // a child without a dispose method is skipped
       const spies = group.children
         .filter((c): c is typeof c & { dispose: () => void } => 'dispose' in c)
         .map((c) => vi.spyOn(c, 'dispose'));
@@ -93,6 +168,16 @@ describe('BuildVolume', () => {
 
       spies.forEach((spy) => expect(spy).toHaveBeenCalled());
       expect(sceneRemoveSpy).toHaveBeenCalledWith(group);
+    });
+
+    test('it does nothing when no group exists', () => {
+      const scene = new Scene();
+      const sceneRemoveSpy = vi.spyOn(scene, 'remove');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.dispose();
+
+      expect(sceneRemoveSpy).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -106,7 +191,125 @@ describe('BuildVolume', () => {
 
       expect(sceneAddSpy).toHaveBeenCalledTimes(1);
     });
+
+    test('it replaces an existing group, disposing the old one', () => {
+      const scene = new Scene();
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+      buildVolume.update();
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const firstGroup = buildVolume['_group']!;
+      firstGroup.add(new Object3D()); // a child without a dispose method is skipped
+      const disposeSpies = firstGroup.children
+        .filter((c): c is typeof c & { dispose: () => void } => 'dispose' in c)
+        .map((c) => vi.spyOn(c, 'dispose'));
+      const sceneRemoveSpy = vi.spyOn(scene, 'remove');
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+
+      buildVolume.update();
+
+      expect(sceneRemoveSpy).toHaveBeenCalledWith(firstGroup);
+      disposeSpies.forEach((spy) => expect(spy).toHaveBeenCalled());
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+      expect(buildVolume['_group']).not.toBe(firstGroup);
+    });
+
+    test('it does not add a group when x is 0', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(0, 20, 30, false, scene);
+
+      buildVolume.update();
+
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test('it does not add a group when y is 0', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 0, 30, false, scene);
+
+      buildVolume.update();
+
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test('it removes the existing group without re-adding one when x becomes 0', () => {
+      const scene = new Scene();
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+      buildVolume.update();
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const group = buildVolume['_group']!;
+      const sceneRemoveSpy = vi.spyOn(scene, 'remove');
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+
+      buildVolume.x = 0;
+
+      expect(sceneRemoveSpy).toHaveBeenCalledWith(group);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('.x', () => {
+    test('setting a value updates it and triggers an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.x = 15;
+
+      expect(buildVolume.x).toEqual(15);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('.y', () => {
+    test('setting a value updates it and triggers an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.y = 25;
+
+      expect(buildVolume.y).toEqual(25);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('.z', () => {
+    test('setting a valid value updates it and triggers an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.z = 35;
+
+      expect(buildVolume.z).toEqual(35);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('.smallGrid', () => {
+    test('changing the value triggers an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.smallGrid = true;
+
+      expect(buildVolume.smallGrid).toEqual(true);
+      expect(sceneAddSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('setting the same value does not trigger an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.smallGrid = false;
+
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
   });
 });
-
-import { Color } from 'three';

--- a/src/build-volume.ts
+++ b/src/build-volume.ts
@@ -38,9 +38,10 @@ export class BuildVolume {
     private _smallGrid: boolean | undefined,
     private scene: Scene
   ) {
-    this._x = x;
-    this._y = y;
-    this._z = z;
+    // Negative dimensions clamp to 0, like the setters
+    this._x = Math.max(0, x);
+    this._y = Math.max(0, y);
+    this._z = Math.max(0, z);
   }
 
   get x(): number {
@@ -67,10 +68,10 @@ export class BuildVolume {
     return this._z;
   }
   set z(value: number) {
-    if (value < 0) {
-      throw new Error('Height (z) must be equal to or greater than 0');
-    }
     this._z = value;
+    if (this._z < 0) {
+      this._z = 0;
+    }
     this.update(); // Update the build volume when z changes
   }
   get smallGrid(): boolean | undefined {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -41,7 +41,6 @@ export default defineConfig({
       thresholds: {
         perFile: true,
         ...Object.fromEntries(sourceFiles.map((file) => [file, fullCoverage])),
-        'src/build-volume.ts': { statements: 65.07, branches: 39.13, functions: 70.58, lines: 66.12 },
         'src/dev-gui.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/gcode-preview.ts': { statements: 93.9, branches: 79.48, functions: 100, lines: 94.87 },
         'src/indexers.ts': { statements: 96.66, branches: 96.15, functions: 100, lines: 96.66 },


### PR DESCRIPTION
## Summary

Next file in the effort to reach 100% test coverage one file at a time (following #390, #397, #399): `src/build-volume.ts`, previously grandfathered at 65% statements / 39% branches / 70% functions.

- **All missing tests written**: the `x`/`y`/`z`/`smallGrid` setters (clamping, update-triggering, same-value no-op), `update()` group replacement/disposal and its early-return guard, the `smallGrid` 4-child `createGroup()` path, and `dispose()` edge cases. The file now sits at **100/100/100/100**.
- **Threshold entry removed**: the grandfathered `src/build-volume.ts` line is deleted from `vitest.config.mts`, so the file falls under the default per-file 100% threshold and can't regress silently.

## Bug found along the way

Writing the constructor tests surfaced an inconsistency with #301 (fixes #300), which established that invalid build-volume values must not throw — dimensions are often bound to live UI inputs. That fix only covered the `x`/`y` setters:

- the `z` setter still threw `Height (z) must be equal to or greater than 0`, and
- the constructor bypassed validation entirely (`new BuildVolume(10, 20, -30, ...)` silently rendered the volume box below the bed).

Both are now consistent with the #301 policy: the constructor and all three setters clamp negatives to 0, never throw. Each fix was done red-green (failing regression test first), and a dedicated `describe('invalid dimensions never throw (#300/#301)')` spec block pins the contract so it reads as documentation.

Assisted by Claude Code - Fable 5