### PR TITLE
Clear the previous job before streaming a new file in the demo loader

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -68,10 +68,11 @@ export const app = (window.app = createApp({
         return;
       }
 
-      const gcodeStream = response.body.pipeThrough(new TextDecoderStream());
+      // drop the previous job before streaming in the new one, otherwise
+      // processGCodeStream appends to the existing job and doubles memory
+      preview.clear();
 
-      const prevDevMode = preview.devMode;
-      preview.devMode = prevDevMode;
+      const gcodeStream = response.body.pipeThrough(new TextDecoderStream());
 
       await preview.processGCodeStream(gcodeStream); // rendering will be done reactively
       updateUI();


### PR DESCRIPTION
## Problem

`loadGCodeFromServer` in the demo never called `preview.clear()` — only `selectPreset` did. Since `loadGCodeFromServer` is exposed to the template directly, calling it without a preset switch made `processGCodeStream` **append** the new file's paths into the existing `Job`, doubling memory and stacking a second copy of the model in the scene.

## Fix

Call `preview.clear()` inside `loadGCodeFromServer`, after the fetch status check (so a failed request leaves the current model intact) and before streaming. The `clear()` in `selectPreset` stays for instant visual feedback on preset switch; `sceneManager.clear()` doesn't touch the camera, so the preset's `initialCameraPosition` survives.

Also removes a dead read/write of `preview.devMode` (`const prevDevMode = preview.devMode; preview.devMode = prevDevMode;`) that did nothing.

## Browser evidence

Verified live in Chrome against the demo (`npm run dev`), measuring the job and GPU state through `window._preview` after each scenario:

| Scenario | `job.paths` | Vertex floats | GPU triangles |
|---|---:|---:|---:|
| Baseline — initial 3DBenchy load | 7,023 | 347,256 | 803,608 |
| 2nd `loadGCodeFromServer()` of the same file (**this fix**) | 7,023 | 347,256 | 803,608 |
| Re-stream without `clear()` (**pre-fix behavior**) | 14,045 | 694,509 | 1,607,216 |

- **Fixed path**: reloading the same file leaves paths, vertices and triangles exactly flat.
- **Pre-fix simulation**: streaming the same file again without `clear()` doubles all three — confirming the bug was real.
- **Recovery**: calling the fixed loader on the doubled state brought it back to 7,023 paths, so `clear()` also reclaims an already-leaked copy.
- **Progressive rendering intact**: the stream still parses and executes chunk-by-chunk into the job (incremental `onJobUpdated` calls observed during the stream); the final render is visually identical, with the layer count and thumbnail populated as before.

Assisted by Claude Code - Fable 5
