### PR TITLE
Fix DevGUI crash on un-homed (undefined) position

### DIFF
--- a/src/__tests__/dev-gui.ts
+++ b/src/__tests__/dev-gui.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { DevGUI } from '../dev-gui';
+import { Job } from '../job';
+import type { GCodePreview } from '../gcode-preview';
+
+// A stub is enough for the Job panel: it only reads job.state, job.paths and
+// parser.lineCount. The real SceneManager needs WebGL, which the test
+// environment does not have.
+function makePreview(job = new Job()): GCodePreview {
+  return {
+    sceneManager: {},
+    job,
+    parser: { lineCount: 0 }
+  } as unknown as GCodePreview;
+}
+
+describe('DevGUI', () => {
+  afterEach(() => {
+    document.querySelectorAll('.lil-gui').forEach((el) => el.remove());
+  });
+
+  it('builds the Job panel while the position is still unknown (un-homed)', () => {
+    // Regression: state.x/y/z start as undefined since the un-homed position
+    // became unknown (#401), and lil-gui cannot build a controller for an
+    // undefined value — add() returned undefined and .listen() threw.
+    const gui = new DevGUI(makePreview(), { parser: true });
+
+    const labels = Array.from(document.querySelectorAll('.lil-gui .name')).map((el) => el.textContent);
+    expect(labels).toEqual(expect.arrayContaining(['x', 'y', 'z', 'isHomed']));
+
+    gui.destroy();
+  });
+
+  it('shows unknown axes as NaN and real coordinates once homed', () => {
+    const job = new Job();
+    const gui = new DevGUI(makePreview(job), { parser: true });
+
+    const inputs = Array.from(document.querySelectorAll('.lil-gui input[type="text"]')) as HTMLInputElement[];
+    const [x] = inputs;
+    expect(x.value).toBe('NaN');
+
+    job.state.x = 12.5;
+    // listen() only refreshes on animation frames; poke the display directly
+    // by re-reading through the controller's live getter.
+    gui.reset();
+    const refreshed = Array.from(document.querySelectorAll('.lil-gui input[type="text"]')) as HTMLInputElement[];
+    expect(refreshed[0].value).toBe('12.5');
+
+    gui.destroy();
+  });
+});

--- a/src/dev-gui.ts
+++ b/src/dev-gui.ts
@@ -180,9 +180,36 @@ class DevGUI {
     parser.onOpenClose(() => {
       this.saveOpenFolders();
     });
-    parser.add(this.gcodePreview.job.state, 'x').listen();
-    parser.add(this.gcodePreview.job.state, 'y').listen();
-    parser.add(this.gcodePreview.job.state, 'z').listen();
+    // x/y/z are undefined until the job is homed (G28), and lil-gui cannot
+    // create a controller for an undefined value (add() returns undefined and
+    // .listen() throws). Read through a wrapper that shows NaN for an unknown
+    // axis so the controller stays numeric; reads are live so a job swap after
+    // clear() is picked up too.
+    const preview = this.gcodePreview;
+    const position = {
+      get x(): number {
+        return preview.job.state.x ?? NaN;
+      },
+      set x(value: number) {
+        preview.job.state.x = value;
+      },
+      get y(): number {
+        return preview.job.state.y ?? NaN;
+      },
+      set y(value: number) {
+        preview.job.state.y = value;
+      },
+      get z(): number {
+        return preview.job.state.z ?? NaN;
+      },
+      set z(value: number) {
+        preview.job.state.z = value;
+      }
+    };
+    parser.add(position, 'x').listen();
+    parser.add(position, 'y').listen();
+    parser.add(position, 'z').listen();
+    parser.add(this.gcodePreview.job.state, 'isHomed').listen();
     parser.add(this.gcodePreview.job.paths, 'length').name('paths.count').listen();
     parser.add(this.gcodePreview.parser, 'lineCount').name('lines.count').listen();
   }


### PR DESCRIPTION
## Problem

After #401 modeled the un-homed position as unknown, the demo broke with:

```
TypeError: Cannot read properties of undefined (reading 'listen')
    at DevGUI.setupParserFolder (dev-gui.ts:183)
```

`state.x/y/z` now start as `undefined`, and lil-gui cannot infer a controller type for an `undefined` value — `add()` logs `gui.add failed`, returns `undefined`, and the chained `.listen()` throws. The demo enables `devMode.parser`, so `GCodePreview` initialization died on page load.

## Fix

- In `setupParserFolder`, read the position through a wrapper whose getters present an unknown axis as `NaN`, keeping the controller numeric while still reading as "unknown" in the panel. Setters write through to the state so the fields stay editable.
- Reads go through `preview.job` (not a captured state object), so a job swapped in by `clear()` is picked up live.
- The panel now also shows the `isHomed` flag introduced in #401.

## Tests

- New `src/__tests__/dev-gui.ts` regression test constructs a real `DevGUI` (the existing `GCodePreview` tests mock it entirely, which is how this slipped through). It fails with the exact demo TypeError before the fix and passes after.
- `npm run check`: 556 tests, typecheck, and lint all pass.

Assisted by Claude Code - Fable 5