### PR TITLE
Finish the port of progressive rendering

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -56,6 +56,7 @@ describe('GCodePreview', () => {
       processGCode: vi.fn().mockResolvedValue(undefined),
       render: vi.fn(),
       renderAnimated: vi.fn().mockResolvedValue(undefined),
+      renderProgressive: vi.fn(),
       dispose: vi.fn()
     };
 
@@ -278,7 +279,43 @@ describe('GCodePreview', () => {
 
         await preview.processGCodeStream(stream);
 
-        expect(readStreamSpy).toHaveBeenCalledWith(stream);
+        expect(readStreamSpy).toHaveBeenCalledWith(stream, { render: true });
+      });
+
+      const makeStream = (chunks: string[]) =>
+        new ReadableStream({
+          start(controller) {
+            chunks.forEach((chunk) => controller.enqueue(chunk));
+            controller.close();
+          }
+        });
+
+      it('should draw progressively while reading a stream', async () => {
+        // advance the clock past the throttle interval on every call
+        let now = 0;
+        const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => (now += 1000));
+
+        await preview.processGCodeStream(makeStream(['G0 X0 Y0\n', 'G1 X10 Y10\n', 'G1 X20 Y20\n']));
+
+        expect(mockSceneManager.renderProgressive).toHaveBeenCalledTimes(3);
+        expect(mockSceneManager.renderAnimated).toHaveBeenCalled();
+        nowSpy.mockRestore();
+      });
+
+      it('should throttle progressive draws to the render interval', async () => {
+        // the clock never advances, so only the first chunk triggers a draw
+        const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+
+        await preview.processGCodeStream(makeStream(['G0 X0 Y0\n', 'G1 X10 Y10\n', 'G1 X20 Y20\n']));
+
+        expect(mockSceneManager.renderProgressive).toHaveBeenCalledTimes(1);
+        nowSpy.mockRestore();
+      });
+
+      it('should not draw progressively when render is false', async () => {
+        await preview.processGCodeStream(makeStream(['G0 X0 Y0\n']), { render: false });
+
+        expect(mockSceneManager.renderProgressive).not.toHaveBeenCalled();
       });
     });
 

--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -312,6 +312,17 @@ describe('GCodePreview', () => {
         nowSpy.mockRestore();
       });
 
+      it('should draw on every chunk when liveRenderInterval is 0', async () => {
+        // the clock never advances, so only the interval of 0 lets every chunk draw
+        const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+        preview = new GCodePreview({ canvas: mockCanvas, liveRenderInterval: 0 });
+
+        await preview.processGCodeStream(makeStream(['G0 X0 Y0\n', 'G1 X10 Y10\n', 'G1 X20 Y20\n']));
+
+        expect(mockSceneManager.renderProgressive).toHaveBeenCalledTimes(3);
+        nowSpy.mockRestore();
+      });
+
       it('should not draw progressively when render is false', async () => {
         await preview.processGCodeStream(makeStream(['G0 X0 Y0\n']), { render: false });
 

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -322,57 +322,81 @@ describe('ObjectsManager', () => {
   });
 
   describe('renderExtrusionsInColor / revertHighlight', () => {
-    test('draws and returns the created object', () => {
+    const highlights = () => objectsManager.extrusionsGroup.children.filter((child) => child.userData.highlight);
+
+    test('draws the paths as a highlight overlay', () => {
       const path = createTestPath();
 
-      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+      objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
 
-      expect(object).toBeDefined();
-      expect(objectsManager.extrusionsGroup.children).toContain(object);
-      expect(object?.userData.highlight).toBe(true);
+      expect(highlights().length).toBe(1);
     });
 
-    test('returns undefined and draws nothing for paths already claimed', () => {
+    test('draws nothing for paths already claimed', () => {
       const path = createTestPath();
       objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
-      const childrenAfterFirstDraw = objectsManager.extrusionsGroup.children.length;
 
-      const object = objectsManager.renderExtrusionsInColor([path], new Color(0xff0000));
+      objectsManager.renderExtrusionsInColor([path], new Color(0xff0000));
 
-      expect(object).toBeUndefined();
-      expect(objectsManager.extrusionsGroup.children.length).toBe(childrenAfterFirstDraw);
+      expect(highlights().length).toBe(1);
     });
 
-    test('revertHighlight removes the object and forgets its paths were rendered', () => {
+    test('revertHighlight removes the overlay and forgets its paths were rendered', () => {
       const path = createTestPath();
-      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+      objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
 
-      objectsManager.revertHighlight(object ? [object] : [], [path]);
+      objectsManager.revertHighlight();
 
-      expect(objectsManager.extrusionsGroup.children).not.toContain(object);
-      // the path is drawable again, in a different color, proving it was unclaimed
-      const redrawn = objectsManager.renderExtrusionsInColor([path], new Color(0x0000ff));
-      expect(redrawn).toBeDefined();
+      expect(highlights().length).toBe(0);
+      // the path is drawable again, proving it was unclaimed
+      objectsManager.renderExtrusionsInColor([path], new Color(0x0000ff));
+      expect(highlights().length).toBe(1);
+    });
+
+    test('revertHighlight leaves paths the per-tool batches drew rendered', () => {
+      // the highlight only claims its own draws — reverting must not unclaim a
+      // normally drawn path, or the next render would draw it a second time
+      const normal = createTestPath();
+      const highlighted = createTestPath();
+      objectsManager.renderExtrusions([normal]);
+      objectsManager.renderExtrusionsInColor([highlighted], new Color(0x00ff00));
+
+      objectsManager.revertHighlight();
+      const childrenBefore = objectsManager.extrusionsGroup.children.length;
+      objectsManager.renderPaths([normal], { travels: false, extrusions: true });
+
+      expect(objectsManager.extrusionsGroup.children.length).toBe(childrenBefore);
     });
 
     test('revertHighlight disposes a tube highlight', () => {
       objectsManager.renderTubes = true;
       const path = createTestPath();
-      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00)) as BatchedMesh;
-      const disposeSpy = vi.spyOn(object, 'dispose');
+      objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+      const disposeSpy = vi.spyOn(highlights()[0] as BatchedMesh, 'dispose');
 
-      objectsManager.revertHighlight([object], [path]);
+      objectsManager.revertHighlight();
 
       expect(disposeSpy).toHaveBeenCalledTimes(1);
     });
 
-    test('revertHighlight on an already-reset manager is a no-op', () => {
+    test('revertHighlight unclaims paths recorded through claimPaths', () => {
       const path = createTestPath();
-      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+      objectsManager.claimPaths([path]);
+
+      objectsManager.revertHighlight();
+
+      objectsManager.renderExtrusionsInColor([path], new Color(0x0000ff));
+      expect(highlights().length).toBe(1);
+    });
+
+    test('reset drops the highlight tracking, making a later revert a no-op', () => {
+      const path = createTestPath();
+      objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
 
       objectsManager.reset();
 
-      expect(() => objectsManager.revertHighlight(object ? [object] : [], [path])).not.toThrow();
+      expect(() => objectsManager.revertHighlight()).not.toThrow();
+      expect(objectsManager.extrusionsGroup.children.length).toBe(0);
     });
   });
 

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -321,6 +321,61 @@ describe('ObjectsManager', () => {
     });
   });
 
+  describe('renderExtrusionsInColor / revertHighlight', () => {
+    test('draws and returns the created object', () => {
+      const path = createTestPath();
+
+      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+
+      expect(object).toBeDefined();
+      expect(objectsManager.extrusionsGroup.children).toContain(object);
+      expect(object?.userData.highlight).toBe(true);
+    });
+
+    test('returns undefined and draws nothing for paths already claimed', () => {
+      const path = createTestPath();
+      objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+      const childrenAfterFirstDraw = objectsManager.extrusionsGroup.children.length;
+
+      const object = objectsManager.renderExtrusionsInColor([path], new Color(0xff0000));
+
+      expect(object).toBeUndefined();
+      expect(objectsManager.extrusionsGroup.children.length).toBe(childrenAfterFirstDraw);
+    });
+
+    test('revertHighlight removes the object and forgets its paths were rendered', () => {
+      const path = createTestPath();
+      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+
+      objectsManager.revertHighlight(object ? [object] : [], [path]);
+
+      expect(objectsManager.extrusionsGroup.children).not.toContain(object);
+      // the path is drawable again, in a different color, proving it was unclaimed
+      const redrawn = objectsManager.renderExtrusionsInColor([path], new Color(0x0000ff));
+      expect(redrawn).toBeDefined();
+    });
+
+    test('revertHighlight disposes a tube highlight', () => {
+      objectsManager.renderTubes = true;
+      const path = createTestPath();
+      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00)) as BatchedMesh;
+      const disposeSpy = vi.spyOn(object, 'dispose');
+
+      objectsManager.revertHighlight([object], [path]);
+
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('revertHighlight on an already-reset manager is a no-op', () => {
+      const path = createTestPath();
+      const object = objectsManager.renderExtrusionsInColor([path], new Color(0x00ff00));
+
+      objectsManager.reset();
+
+      expect(() => objectsManager.revertHighlight(object ? [object] : [], [path])).not.toThrow();
+    });
+  });
+
   describe('dispose', () => {
     test('removes extrusionsGroup from parent', () => {
       objectsManager.dispose();

--- a/src/__tests__/path.ts
+++ b/src/__tests__/path.ts
@@ -164,3 +164,45 @@ describe('.line', () => {
     expect(points.length).toEqual(0);
   });
 });
+
+describe('.splitLastSegment', () => {
+  test('splits a multi-segment path into a body and the final segment', () => {
+    const path = new Path(PathType.Extrusion, 0.5, 0.3, 2);
+    path.addPoint(0, 0, 0);
+    path.addPoint(10, 0, 0);
+    path.addPoint(10, 10, 0);
+
+    const { body, segment } = path.splitLastSegment();
+
+    expect(segment.vertices).toEqual([10, 0, 0, 10, 10, 0]);
+    // the body ends on the segment's first point, so no gap opens between them
+    expect(body?.vertices).toEqual([0, 0, 0, 10, 0, 0]);
+  });
+
+  test('a two-point path splits into the segment alone', () => {
+    const path = new Path(PathType.Extrusion, 0.5, 0.3, 0);
+    path.addPoint(0, 0, 0);
+    path.addPoint(10, 0, 0);
+
+    const { body, segment } = path.splitLastSegment();
+
+    expect(body).toBeNull();
+    expect(segment.vertices).toEqual([0, 0, 0, 10, 0, 0]);
+  });
+
+  test('both halves carry the source travel type, extrusion settings and tool', () => {
+    const path = new Path(PathType.Extrusion, 0.5, 0.3, 2);
+    path.addPoint(0, 0, 0);
+    path.addPoint(10, 0, 0);
+    path.addPoint(10, 10, 0);
+
+    const { body, segment } = path.splitLastSegment();
+
+    [body, segment].forEach((half) => {
+      expect(half.travelType).toBe(PathType.Extrusion);
+      expect(half.extrusionWidth).toBe(0.5);
+      expect(half.lineHeight).toBe(0.3);
+      expect(half.tool).toBe(2);
+    });
+  });
+});

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -181,7 +181,6 @@ describe('public API types', () => {
       expectTypeOf<SceneManager['canvas']>().toEqualTypeOf<HTMLCanvasElement>();
       expectTypeOf<SceneManager['render']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['renderAnimated']>().toEqualTypeOf<(pathCount?: number) => Promise<void>>();
-      expectTypeOf<SceneManager['renderProgressive']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['dispose']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['resize']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['clear']>().toEqualTypeOf<() => void>();

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -163,7 +163,9 @@ describe('public API types', () => {
       expectTypeOf<GCodePreview['processGCodeStream']>().toEqualTypeOf<
         (gcode: string | string[] | ReadableStream, options?: { render?: boolean }) => Promise<void>
       >();
-      expectTypeOf<GCodePreview['readStream']>().toEqualTypeOf<(stream: ReadableStream) => Promise<void>>();
+      expectTypeOf<GCodePreview['readStream']>().toEqualTypeOf<
+        (stream: ReadableStream, options?: { render?: boolean }) => Promise<void>
+      >();
     });
   });
 
@@ -177,6 +179,7 @@ describe('public API types', () => {
       expectTypeOf<SceneManager['canvas']>().toEqualTypeOf<HTMLCanvasElement>();
       expectTypeOf<SceneManager['render']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['renderAnimated']>().toEqualTypeOf<(pathCount?: number) => Promise<void>>();
+      expectTypeOf<SceneManager['renderProgressive']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['dispose']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['resize']>().toEqualTypeOf<() => void>();
       expectTypeOf<SceneManager['clear']>().toEqualTypeOf<() => void>();

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -41,6 +41,7 @@ describe('public API types', () => {
         | 'minLayerThreshold'
         | 'droppable'
         | 'keepLines'
+        | 'liveRenderInterval'
         // SceneManagerOptions
         | 'buildVolume'
         | 'backgroundColor'
@@ -69,6 +70,7 @@ describe('public API types', () => {
       expectTypeOf<GCodePreviewOptions['minLayerThreshold']>().toEqualTypeOf<number | undefined>();
       expectTypeOf<GCodePreviewOptions['droppable']>().toEqualTypeOf<boolean | undefined>();
       expectTypeOf<GCodePreviewOptions['keepLines']>().toEqualTypeOf<boolean | undefined>();
+      expectTypeOf<GCodePreviewOptions['liveRenderInterval']>().toEqualTypeOf<number | undefined>();
       expectTypeOf<GCodePreviewOptions['canvas']>().toEqualTypeOf<HTMLCanvasElement | undefined>();
       expectTypeOf<GCodePreviewOptions['backgroundColor']>().toEqualTypeOf<ColorRepresentation | undefined>();
       expectTypeOf<GCodePreviewOptions['extrusionColor']>().toEqualTypeOf<

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -98,7 +98,6 @@ describe('public API surface', () => {
       animate: 0,
       render: 0,
       renderAnimated: 0,
-      renderProgressive: 0,
       clear: 0,
       resize: 0,
       dispose: 0,

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -98,6 +98,7 @@ describe('public API surface', () => {
       animate: 0,
       render: 0,
       renderAnimated: 0,
+      renderProgressive: 0,
       clear: 0,
       resize: 0,
       dispose: 0,

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -590,6 +590,35 @@ describe('SceneManager properties', () => {
       fresh.dispose();
     });
 
+    test('a moving highlight never re-draws paths the per-tool batches already drew', () => {
+      // with only lastSegmentColor set, the rest of the layer is drawn by the
+      // normal per-tool batches; when the highlight moves to a newer path it
+      // must only unclaim its own draws, or those batches would be drawn again
+      const job = new Job();
+      const fresh = createSceneManager({ job, lastSegmentColor: '#0000ff' });
+      const addPath = () =>
+        appendPath(job, PathType.Extrusion, [
+          [0, 0, 0],
+          [10, 0, 0],
+          [10, 10, 0]
+        ]);
+
+      for (let i = 0; i < 5; i++) {
+        addPath();
+        fresh.renderProgressive();
+      }
+
+      // 4 paths are visible (the 5th is the held-back tail); the newest visible
+      // one belongs to the highlight, the other 3 to the per-tool batches —
+      // each exactly once, at 2 segments per path
+      const normalSegments = (extrusionGroup(fresh).children as LineSegments2[])
+        .filter((child) => !child.userData.highlight)
+        .reduce((total, line) => total + positionCountOf(line) / 6, 0);
+      expect(normalSegments).toBe(6);
+
+      fresh.dispose();
+    });
+
     test('renderAnimated only highlights a layer once its own paths are actually revealed', async () => {
       // the whole job is known upfront here (unlike a live stream), but the
       // highlight must still wait for the reveal to reach the top layer

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -511,6 +511,103 @@ describe('SceneManager properties', () => {
         expect(spy).not.toHaveBeenCalled();
       }
     );
+
+    test('a two-point final path with both colors set leaves the top layer with no body', () => {
+      // the top layer's only path splits entirely into the segment; there is
+      // nothing left over for a topColor "body" draw
+      const fresh = createSceneManager({
+        job: shortTopLayerJob(),
+        topLayerColor: '#00ff00',
+        lastSegmentColor: '#ff0000'
+      });
+
+      const highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect(lineColor(highlights[0])).toBe(0xff0000);
+
+      fresh.dispose();
+    });
+
+    test('extrusions disabled at construction draws no highlight', () => {
+      const fresh = createSceneManager({
+        job: multiPathTopLayerJob(),
+        renderExtrusion: false,
+        topLayerColor: '#00ff00'
+      });
+
+      expect(highlights_(fresh).length).toBe(0);
+
+      fresh.dispose();
+    });
+
+    test('a live highlight follows a stream in, reverting the layer it moves off of', () => {
+      // simulates readStream: paths land on the job one at a time and
+      // renderProgressive draws in between, holding back whichever path just
+      // landed since it may still be growing
+      const job = new Job();
+      // tubes so the reverted highlight is a BatchedMesh, exercising its dispose()
+      const fresh = createSceneManager({ job, renderTubes: true, topLayerColor: '#00ff00' });
+      const tubeColor = (object: Object3D) =>
+        ((object as { material: ShaderMaterial }).material.uniforms.uColor.value as Color).getHex();
+
+      appendPath(job, PathType.Extrusion, [
+        [0, 0, 0],
+        [10, 0, 0]
+      ]);
+      fresh.renderProgressive();
+      // the only path so far is held back as the still-growing tail
+      expect(highlights_(fresh).length).toBe(0);
+
+      appendPath(job, PathType.Extrusion, [
+        [0, 0, 0],
+        [10, 0, 0]
+      ]);
+      fresh.renderProgressive();
+      // the first path is now safe and is layer 0's only visible content
+      let highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect(tubeColor(highlights[0])).toBe(0x00ff00);
+
+      appendPath(job, PathType.Extrusion, [
+        [0, 0, 0.2],
+        [10, 0, 0.2]
+      ]);
+      fresh.renderProgressive();
+      // layer 1 has begun, but its only path is the new held-back tail: the
+      // highlight lets go of layer 0 rather than keep showing it as stale
+      expect(highlights_(fresh).length).toBe(0);
+
+      appendPath(job, PathType.Extrusion, [
+        [10, 0, 0.2],
+        [10, 10, 0.2]
+      ]);
+      fresh.renderProgressive();
+      // layer 1's first path is now safe and becomes the live highlight
+      highlights = highlights_(fresh);
+      expect(highlights.length).toBe(1);
+      expect(tubeColor(highlights[0])).toBe(0x00ff00);
+
+      fresh.dispose();
+    });
+
+    test('renderAnimated only highlights a layer once its own paths are actually revealed', async () => {
+      // the whole job is known upfront here (unlike a live stream), but the
+      // highlight must still wait for the reveal to reach the top layer
+      // instead of jumping ahead of the per-tool draw
+      const fresh = createSceneManager({ job: threeLayerJob(), topLayerColor: '#00ff00' });
+      let sawEmptyFrame = false;
+      const spy = vi.spyOn(objectsManager(fresh), 'renderExtrusionsInColor').mockImplementation((...args) => {
+        if (highlights_(fresh).length === 0) sawEmptyFrame = true;
+        return ObjectsManager.prototype.renderExtrusionsInColor.apply(objectsManager(fresh), args);
+      });
+
+      await fresh.renderAnimated(1);
+
+      expect(sawEmptyFrame).toBe(true); // the highlight was absent on at least one early frame
+      expect(highlights_(fresh).length).toBe(1); // and present once the reveal finished
+      spy.mockRestore();
+      fresh.dispose();
+    });
   });
 
   describe('lighting', () => {

--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -67,6 +67,45 @@ test('cancelAnimation should cancel the render loop', async () => {
   expect(callCountAfterDestroy).toBe(callCountAfterDestroy2);
 });
 
+test('renderProgressive draws the paths parsed so far, holding back the still-growing last one', () => {
+  const mock = createMockSceneManager() as ReturnType<typeof createMockSceneManager> & {
+    job?: { paths: number[] };
+    renderPaths: ReturnType<typeof vi.fn>;
+  };
+  mock.job = { paths: [1, 2, 3] };
+  mock.renderPaths = vi.fn();
+
+  SceneManager.prototype.renderProgressive.call(mock);
+
+  expect(mock.renderPaths).toHaveBeenCalledWith(2);
+});
+
+test('renderProgressive never passes a negative path count', () => {
+  const mock = createMockSceneManager() as ReturnType<typeof createMockSceneManager> & {
+    job?: { paths: number[] };
+    renderPaths: ReturnType<typeof vi.fn>;
+  };
+  mock.job = { paths: [] };
+  mock.renderPaths = vi.fn();
+
+  SceneManager.prototype.renderProgressive.call(mock);
+
+  expect(mock.renderPaths).toHaveBeenCalledWith(0);
+});
+
+test('renderProgressive does nothing without a job', () => {
+  const mock = createMockSceneManager() as ReturnType<typeof createMockSceneManager> & {
+    job?: { paths: number[] };
+    renderPaths: ReturnType<typeof vi.fn>;
+  };
+  mock.job = undefined;
+  mock.renderPaths = vi.fn();
+
+  SceneManager.prototype.renderProgressive.call(mock);
+
+  expect(mock.renderPaths).not.toHaveBeenCalled();
+});
+
 function createMockSceneManager() {
   const renderer = {
     render: vi.fn(() => {}),

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -7,6 +7,9 @@ import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { makeDroppable } from './extra/dom-utils';
 import { splitChunk } from './helpers/split-chunk';
 
+/** While streaming, how often (at most) the paths parsed so far are drawn. */
+const LIVE_RENDER_INTERVAL_MS = 250;
+
 /**
  * Options for configuring the G-code preview
  */
@@ -185,7 +188,7 @@ export class GCodePreview {
     options: { render?: boolean } = { render: true }
   ): Promise<void> {
     if (gcode instanceof ReadableStream) {
-      await this.readStream(gcode);
+      await this.readStream(gcode, { render: options.render });
     } else {
       const { commands } = this.parser.parseGCode(gcode);
       this.executeCommands(commands);
@@ -202,11 +205,12 @@ export class GCodePreview {
     }
   }
 
-  async readStream(stream: ReadableStream): Promise<void> {
+  async readStream(stream: ReadableStream, options: { render?: boolean } = {}): Promise<void> {
     const reader = stream.getReader();
     let result;
     let tail = '';
     let size = 0;
+    let lastDrawnAt = -Infinity;
 
     do {
       result = await reader.read();
@@ -219,11 +223,19 @@ export class GCodePreview {
       const split = splitChunk(tail, result.value);
       tail = split.tail;
 
-      // parse increments but don't render yet
       const { commands } = this.parser.parseGCode(split.complete);
 
       // we'll execute the commands immediately, for now
       this.executeCommands(commands);
+
+      // draw what has arrived so far, so the model grows on screen while the
+      // stream is still coming in. Throttled: each call only builds the paths
+      // that are not drawn yet, but a geometry batch per chunk would still
+      // pile up draw calls
+      if (options.render && performance.now() - lastDrawnAt >= LIVE_RENDER_INTERVAL_MS) {
+        this.sceneManager.renderProgressive();
+        lastDrawnAt = performance.now();
+      }
     } while (!result.done);
 
     console.debug('total read from stream', Math.floor(size / 1024), 'kB');

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -26,6 +26,15 @@ type LibOptions = {
    * it costs several megabytes on a large file.
    */
   keepLines?: boolean;
+  /**
+   * How often, in milliseconds, the paths parsed so far are drawn while a
+   * G-code stream is being read.
+   * @remarks
+   * Defaults to 250. Lower values grow the model more smoothly — 0 draws on
+   * every chunk, effectively once per frame — but every draw adds a geometry
+   * batch, so very low values cost draw calls on large files.
+   */
+  liveRenderInterval?: number;
 };
 
 export type GCodePreviewOptions = LibOptions & SceneManagerOptions;
@@ -232,7 +241,10 @@ export class GCodePreview {
       // stream is still coming in. Throttled: each call only builds the paths
       // that are not drawn yet, but a geometry batch per chunk would still
       // pile up draw calls
-      if (options.render && performance.now() - lastDrawnAt >= LIVE_RENDER_INTERVAL_MS) {
+      if (
+        options.render &&
+        performance.now() - lastDrawnAt >= (this.opts?.liveRenderInterval ?? LIVE_RENDER_INTERVAL_MS)
+      ) {
         this.sceneManager.renderProgressive();
         lastDrawnAt = performance.now();
       }

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -6,6 +6,7 @@ import { LineBox } from './helpers/line-box';
 
 import {
   Group,
+  Object3D,
   Scene,
   Color,
   Plane,
@@ -390,9 +391,9 @@ export class ObjectsManager {
    * recoloring a tool later leaves the highlight untouched. The object is tagged
    * so {@link setExtrusionColor} skips it for the same reason.
    */
-  renderExtrusionsInColor(paths: Path[], color: Color) {
+  renderExtrusionsInColor(paths: Path[], color: Color): Object3D | undefined {
     const unrenderedPaths = this.takeUnrendered(paths);
-    if (unrenderedPaths.length === 0) return;
+    if (unrenderedPaths.length === 0) return undefined;
 
     const object = this.renderTubes
       ? this.renderPathsAsTubes(unrenderedPaths, this.createHighlightMaterial(color))
@@ -400,6 +401,28 @@ export class ObjectsManager {
         this.renderPathsAsLines(unrenderedPaths, color, false);
     object.userData.highlight = true;
     this.extrusionsGroup.add(object);
+    return object;
+  }
+
+  /**
+   * Removes a previously drawn highlight and forgets that its paths were
+   * rendered, so the next render call redraws them in their normal color.
+   * @remarks
+   * Used to move a live top-layer/last-segment highlight forward as newer
+   * layers or segments arrive, without leaving stale highlighted geometry
+   * behind on the layer or path it has moved past. The object's own geometry
+   * and material are disposed; the per-path source geometries they were built
+   * from are left for the next full {@link reset} — the paths get redrawn
+   * through the normal path, which builds its own fresh geometry anyway.
+   */
+  revertHighlight(objects: Object3D[], paths: Path[]): void {
+    objects.forEach((object) => {
+      object.removeFromParent();
+      const disposable = object as unknown as Partial<Disposable>;
+      this.disposables = this.disposables.filter((d) => d !== (disposable as Disposable));
+      disposable.dispose?.();
+    });
+    paths.forEach((path) => this.renderedPaths.delete(path));
   }
 
   /**
@@ -410,13 +433,6 @@ export class ObjectsManager {
    */
   claimPaths(paths: Path[]) {
     paths.forEach((path) => this.renderedPaths.add(path));
-  }
-
-  /**
-   * Whether a path has already been drawn (or claimed) in the current scene.
-   */
-  hasRendered(path: Path): boolean {
-    return this.renderedPaths.has(path);
   }
 
   /**

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -77,6 +77,10 @@ export class ObjectsManager {
   static readonly rebuildDebounce = 100;
 
   private renderedPaths = new Set<Path>();
+  /** Scene objects drawn by the current top-layer/last-segment highlight */
+  private highlightObjects: Object3D[] = [];
+  /** Paths the current highlight drew or claimed, to unclaim on revert */
+  private highlightedPaths: Path[] = [];
   private onRebuildNeeded?: RebuildRequest;
   private rebuildTimeout?: ReturnType<typeof setTimeout>;
   /** Current layer range, kept so materials created later start out clipped correctly */
@@ -391,9 +395,9 @@ export class ObjectsManager {
    * recoloring a tool later leaves the highlight untouched. The object is tagged
    * so {@link setExtrusionColor} skips it for the same reason.
    */
-  renderExtrusionsInColor(paths: Path[], color: Color): Object3D | undefined {
+  renderExtrusionsInColor(paths: Path[], color: Color): void {
     const unrenderedPaths = this.takeUnrendered(paths);
-    if (unrenderedPaths.length === 0) return undefined;
+    if (unrenderedPaths.length === 0) return;
 
     const object = this.renderTubes
       ? this.renderPathsAsTubes(unrenderedPaths, this.createHighlightMaterial(color))
@@ -401,28 +405,35 @@ export class ObjectsManager {
         this.renderPathsAsLines(unrenderedPaths, color, false);
     object.userData.highlight = true;
     this.extrusionsGroup.add(object);
-    return object;
+    // tracked so revertHighlight can undo exactly this draw later
+    this.highlightObjects.push(object);
+    this.highlightedPaths.push(...unrenderedPaths);
   }
 
   /**
-   * Removes a previously drawn highlight and forgets that its paths were
+   * Removes the currently drawn highlight and forgets that its paths were
    * rendered, so the next render call redraws them in their normal color.
    * @remarks
    * Used to move a live top-layer/last-segment highlight forward as newer
    * layers or segments arrive, without leaving stale highlighted geometry
-   * behind on the layer or path it has moved past. The object's own geometry
-   * and material are disposed; the per-path source geometries they were built
-   * from are left for the next full {@link reset} — the paths get redrawn
-   * through the normal path, which builds its own fresh geometry anyway.
+   * behind on the layer or path it has moved past. Only what the highlight
+   * itself drew or claimed is unclaimed — paths the per-tool batches drew
+   * stay rendered, so they are not drawn a second time. The overlay's own
+   * geometry and material are disposed; the per-path source geometries they
+   * were built from are left for the next full {@link reset} — the paths get
+   * redrawn through the normal path, which builds its own fresh geometry
+   * anyway.
    */
-  revertHighlight(objects: Object3D[], paths: Path[]): void {
-    objects.forEach((object) => {
+  revertHighlight(): void {
+    this.highlightObjects.forEach((object) => {
       object.removeFromParent();
       const disposable = object as unknown as Partial<Disposable>;
       this.disposables = this.disposables.filter((d) => d !== (disposable as Disposable));
       disposable.dispose?.();
     });
-    paths.forEach((path) => this.renderedPaths.delete(path));
+    this.highlightObjects = [];
+    this.highlightedPaths.forEach((path) => this.renderedPaths.delete(path));
+    this.highlightedPaths = [];
   }
 
   /**
@@ -430,9 +441,12 @@ export class ObjectsManager {
    * @remarks
    * Used when a highlight redraws part of a path — its final segment in its own
    * color — so the per-tool batch does not also draw the original whole path.
+   * The claim is part of the current highlight and is undone by
+   * {@link revertHighlight}.
    */
   claimPaths(paths: Path[]) {
     paths.forEach((path) => this.renderedPaths.add(path));
+    this.highlightedPaths.push(...paths);
   }
 
   /**
@@ -449,6 +463,9 @@ export class ObjectsManager {
     this.renderedPaths.clear();
     this.extrusionsGroup.clear();
     this.travelMovesGroup.clear();
+    // the groups and disposables above already dropped the highlight overlay
+    this.highlightObjects = [];
+    this.highlightedPaths = [];
   }
 
   /**

--- a/src/path.ts
+++ b/src/path.ts
@@ -161,12 +161,4 @@ export class Path {
 
     return new LineSegmentsGeometry().setPositions(lineVertices);
   }
-
-  /**
-   * Checks if the path contains any vertical moves
-   * @returns True if any Z coordinates differ from the initial Z
-   */
-  hasVerticalMoves(): boolean {
-    return this.vertices.some((_, i, arr) => i % 3 === 2 && arr[i] !== arr[2]);
-  }
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -71,6 +71,30 @@ export class Path {
   }
 
   /**
+   * Splits the path into its final segment and the body that precedes it.
+   * @returns The last two points as `segment`, and everything up to and including
+   * the segment's first point as `body` (null when the path is a single segment).
+   * Both carry this path's travel type, extrusion settings and tool.
+   * @remarks
+   * Requires at least two points; used to draw the final segment of a print in
+   * its own highlight color while the rest of the path keeps another one.
+   */
+  splitLastSegment(): { body: Path | null; segment: Path } {
+    const segment = this.subPath(this._vertices.slice(this._vertices.length - 6));
+    const body = this._vertices.length > 6 ? this.subPath(this._vertices.slice(0, this._vertices.length - 3)) : null;
+    return { body, segment };
+  }
+
+  /** Builds a path carrying this path's extrusion settings over a slice of vertices. */
+  private subPath(vertices: number[]): Path {
+    const path = new Path(this.travelType, this.extrusionWidth, this.lineHeight, this.tool);
+    for (let i = 0; i < vertices.length; i += 3) {
+      path.addPoint(vertices[i], vertices[i + 1], vertices[i + 2]);
+    }
+    return path;
+  }
+
+  /**
    * Checks if a point continues the current line
    * @param x - X coordinate to check
    * @param y - Y coordinate to check

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -11,7 +11,6 @@ import { Path, PathType } from './path';
 import {
   Color,
   ColorRepresentation,
-  Object3D,
   OrthographicCamera,
   PerspectiveCamera,
   REVISION,
@@ -131,10 +130,6 @@ export class SceneManager {
   private _highlightedLayerIndex?: number;
   /** The path the highlight last treated as the layer's last-received path */
   private _highlightedLastPath?: Path;
-  /** Scene objects the current highlight drew, so they can be reverted */
-  private _highlightObjects: Object3D[] = [];
-  /** Paths the current highlight claimed, so they can be unclaimed on revert */
-  private _highlightedPaths: Path[] = [];
   /** Last render time in milliseconds */
   lastRenderTime = 0;
   /** Whether to render in wireframe mode */
@@ -908,9 +903,7 @@ export class SceneManager {
     // (including both being empty, e.g. a non-planar job with no layers at all)
     if (topLayerIndex === this._highlightedLayerIndex && lastPath === this._highlightedLastPath) return;
 
-    this.objectsManager.revertHighlight(this._highlightObjects, this._highlightedPaths);
-    this._highlightObjects = [];
-    this._highlightedPaths = [...layerExtrusions];
+    this.objectsManager.revertHighlight();
     this._highlightedLayerIndex = topLayerIndex;
     this._highlightedLastPath = lastPath;
 
@@ -921,60 +914,28 @@ export class SceneManager {
 
     if (topColor !== undefined) {
       const body = splitSegment ? layerExtrusions.slice(0, -1) : layerExtrusions;
-      this.pushHighlight(body, topColor);
+      this.objectsManager.renderExtrusionsInColor(body, topColor);
     }
 
     if (!splitSegment) return;
 
     this.objectsManager.claimPaths([lastPath]);
     const bodyColor = topColor ?? this.objectsManager.colorForTool(lastPath.tool);
-    const { body, segment } = this.splitLastSegment(lastPath);
-    if (body) this.pushHighlight([body], bodyColor);
-    this.pushHighlight([segment], segColor);
+    const { body, segment } = lastPath.splitLastSegment();
+    if (body) this.objectsManager.renderExtrusionsInColor([body], bodyColor);
+    this.objectsManager.renderExtrusionsInColor([segment], segColor);
   }
 
-  /** Draws `paths` in `color` and tracks the result for the next revert. */
-  private pushHighlight(paths: Path[], color: Color): void {
-    if (paths.length === 0) return;
-    // paths here are always freshly computed from the job, or freshly split
-    // off one, never ones an earlier call in this same pass already drew —
-    // renderExtrusionsInColor only returns undefined for paths it is asked
-    // to draw a second time, which cannot happen here
-    this._highlightObjects.push(this.objectsManager.renderExtrusionsInColor(paths, color) as Object3D);
-  }
-
-  /** Forgets the current top-layer/last-segment highlight without reverting it.
+  /** Forgets which layer and path the highlight was last drawn on.
    * @remarks
-   * Used when the scene it was drawn into is already being discarded wholesale
-   * (a full reset or a fresh ObjectsManager), so there is nothing left to revert.
+   * Used when the scene it was drawn into is being discarded wholesale (a
+   * full reset or a fresh ObjectsManager), which drops the overlay objects
+   * themselves — without this the next draw would think the highlight is
+   * still in place and skip redrawing it.
    */
   private resetHighlightTracking(): void {
     this._highlightedLayerIndex = undefined;
     this._highlightedLastPath = undefined;
-    this._highlightObjects = [];
-    this._highlightedPaths = [];
-  }
-
-  /**
-   * Splits a path into its final segment and the body that precedes it.
-   * @param path - Path to split
-   * @returns The last two points as `segment`, and everything up to and including
-   * the segment's first point as `body` (null when the path is a single segment)
-   */
-  private splitLastSegment(path: Path): { body: Path | null; segment: Path } {
-    const vertices = path.vertices;
-    const segment = this.subPath(path, vertices.slice(vertices.length - 6));
-    const body = vertices.length > 6 ? this.subPath(path, vertices.slice(0, vertices.length - 3)) : null;
-    return { body, segment };
-  }
-
-  /** Builds a path carrying `source`'s extrusion settings over a slice of vertices. */
-  private subPath(source: Path, vertices: number[]): Path {
-    const path = new Path(source.travelType, source.extrusionWidth, source.lineHeight, source.tool);
-    for (let i = 0; i < vertices.length; i += 3) {
-      path.addPoint(vertices[i], vertices[i + 1], vertices[i + 2]);
-    }
-    return path;
   }
 
   saveCamera() {

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -11,6 +11,7 @@ import { Path, PathType } from './path';
 import {
   Color,
   ColorRepresentation,
+  Object3D,
   OrthographicCamera,
   PerspectiveCamera,
   REVISION,
@@ -126,6 +127,14 @@ export class SceneManager {
   private _topLayerColor?: Color;
   /** Last segment color */
   private _lastSegmentColor?: Color;
+  /** Layer index the top-layer/last-segment highlight is currently drawn on */
+  private _highlightedLayerIndex?: number;
+  /** The path the highlight last treated as the layer's last-received path */
+  private _highlightedLastPath?: Path;
+  /** Scene objects the current highlight drew, so they can be reverted */
+  private _highlightObjects: Object3D[] = [];
+  /** Paths the current highlight claimed, so they can be unclaimed on revert */
+  private _highlightedPaths: Path[] = [];
   /** Last render time in milliseconds */
   lastRenderTime = 0;
   /** Whether to render in wireframe mode */
@@ -643,6 +652,8 @@ export class SceneManager {
    */
   private resetScene() {
     this.objectsManager.reset();
+    // reset() already disposed of any tracked highlight objects in bulk
+    this.resetHighlightTracking();
     this.initScene();
   }
 
@@ -681,9 +692,9 @@ export class SceneManager {
    * Called repeatedly while a G-code stream is read, so the model grows on
    * screen as chunks arrive. Only paths that have not been drawn yet are
    * built, and the last path is held back: it may still be growing, and a
-   * path is only ever built once. The top-layer highlight is skipped because
-   * the top layer may not have arrived yet. The continuous animation loop
-   * presents the new geometry on the next frame.
+   * path is only ever built once. The top-layer/last-segment highlight, if
+   * configured, moves onto whatever has most recently arrived. The continuous
+   * animation loop presents the new geometry on the next frame.
    */
   renderProgressive(): void {
     if (!this.job) return;
@@ -753,6 +764,8 @@ export class SceneManager {
     // drop the old manager from disposables too, or dispose() would revisit it
     this.disposables = this.disposables.filter((d) => d !== this.objectsManager);
     this.objectsManager.dispose();
+    // dispose() already tore down any tracked highlight objects with it
+    this.resetHighlightTracking();
     this.objectsManager = this.createObjectsManager(lineWidth, lineHeight, extrusionWidth);
     // assign the fields directly: the fresh manager has no materials or geometry
     // yet, so the setters' uniform writes and rebuild requests have nothing to do
@@ -819,9 +832,8 @@ export class SceneManager {
    * Draws the job's paths up to the given index of its combined path list.
    * @param endPathNumber - End index into job.paths (default: all of them)
    * @remarks
-   * On a full render the top layer and last segment highlights claim their paths
-   * first, so the per-tool batches leave them alone. During progressive rendering
-   * the highlight is skipped: the top layer may not have been reached yet.
+   * The top layer and last segment highlights claim their paths first, so the
+   * per-tool batches leave them alone.
    */
   private renderPaths(endPathNumber: number = Infinity): void {
     this.objectsManager.setTravelsVisible(this._renderTravel);
@@ -829,11 +841,13 @@ export class SceneManager {
     this.objectsManager.gradientEnabled = this.gradientEnabled;
     this.objectsManager.layerCount = this.job.countLayers;
 
-    if (this._renderExtrusion && endPathNumber === Infinity) {
-      this.renderTopLayerHighlight();
+    const paths = this.job.paths.slice(0, endPathNumber);
+
+    if (this._renderExtrusion) {
+      this.renderTopLayerHighlight(paths);
     }
 
-    this.objectsManager.renderPaths(this.job.paths.slice(0, endPathNumber), {
+    this.objectsManager.renderPaths(paths, {
       travels: this._renderTravel,
       extrusions: this._renderExtrusion
     });
@@ -842,48 +856,101 @@ export class SceneManager {
   /**
    * Draws the topmost visible layer, and its final segment, in their highlight
    * colors before the per-tool batches run.
+   * @param paths - The paths visible to this render call (the streaming-safe
+   * prefix during progressive rendering, or the whole job on a full render)
    * @remarks
    * Whichever draw claims a path first wins, so running before the per-tool
-   * batches is what lets the highlight colors take precedence. Only runs on a
-   * full render: during progressive rendering the top layer may not have been
-   * reached yet.
+   * batches is what lets the highlight colors take precedence.
+   *
+   * "Top layer" and "last segment" both mean the most recently *received* layer
+   * and segment, not the ones a finished print would settle on: while a stream
+   * is still being read the highlight keeps moving forward onto whatever just
+   * arrived, the same way it would on a printer's own live status display. Each
+   * time the highlighted layer or its last path changes, the previous highlight
+   * is reverted first so the layer it moved off of falls back to its normal
+   * tool color instead of staying stuck highlighted.
    *
    * `topLayerColor` recolors the whole visible top layer; `lastSegmentColor`
    * recolors just the final segment of that layer's last path. When both are set
    * the last segment is split off so it keeps its own color. When only
    * `lastSegmentColor` is set the rest of the layer keeps its normal tool color.
+   *
+   * A structurally new top layer reverts the old highlight even if the new
+   * layer has nothing visible yet (its only path may be the streaming-safe
+   * window's held-back tail) — otherwise the previous layer would stay
+   * highlighted for as long as the new one takes to produce anything to show.
    */
-  private renderTopLayerHighlight(): void {
+  private renderTopLayerHighlight(paths: Path[]): void {
     const topColor = this._topLayerColor;
     const segColor = this._lastSegmentColor;
     if (topColor === undefined && segColor === undefined) return;
 
     const layers = this.job.layers;
     // the visible top follows the end-layer clip so the highlight is never hidden
-    const topLayer = layers[(this._endLayer ?? layers.length) - 1];
-    if (!topLayer) return;
+    const topLayerIndex = (this._endLayer ?? layers.length) - 1;
+    const topLayer = layers[topLayerIndex];
 
-    const extrusions = topLayer.paths.filter((path) => path.travelType === PathType.Extrusion);
-    if (extrusions.length === 0) return;
+    // `paths` may be a prefix of the job — either the streaming-safe window
+    // during progressive rendering, or the current frame of a reveal animation
+    // — so a layer's paths only count once they have actually reached it
+    const layerExtrusions: Path[] = [];
+    if (topLayer) {
+      const visiblePaths = new Set(paths);
+      layerExtrusions.push(
+        ...topLayer.paths.filter((path) => path.travelType === PathType.Extrusion && visiblePaths.has(path))
+      );
+    }
+    const lastPath: Path | undefined = layerExtrusions[layerExtrusions.length - 1];
 
-    const lastPath = extrusions[extrusions.length - 1];
+    // nothing new has arrived since the last draw: same layer, same last path
+    // (including both being empty, e.g. a non-planar job with no layers at all)
+    if (topLayerIndex === this._highlightedLayerIndex && lastPath === this._highlightedLastPath) return;
+
+    this.objectsManager.revertHighlight(this._highlightObjects, this._highlightedPaths);
+    this._highlightObjects = [];
+    this._highlightedPaths = [...layerExtrusions];
+    this._highlightedLayerIndex = topLayerIndex;
+    this._highlightedLastPath = lastPath;
+
+    if (lastPath === undefined) return; // reverted; nothing visible yet to draw in its place
+
     // a segment needs two points; a shorter final path cannot be split
     const splitSegment = segColor !== undefined && lastPath.vertices.length >= 6;
 
     if (topColor !== undefined) {
-      const body = splitSegment ? extrusions.slice(0, -1) : extrusions;
-      if (body.length > 0) this.objectsManager.renderExtrusionsInColor(body, topColor);
+      const body = splitSegment ? layerExtrusions.slice(0, -1) : layerExtrusions;
+      this.pushHighlight(body, topColor);
     }
 
-    // hasRendered guards a second pass (renderMissingPaths) from splitting again,
-    // which would draw duplicate segment pieces the dedup set cannot catch
-    if (!splitSegment || this.objectsManager.hasRendered(lastPath)) return;
+    if (!splitSegment) return;
 
     this.objectsManager.claimPaths([lastPath]);
     const bodyColor = topColor ?? this.objectsManager.colorForTool(lastPath.tool);
     const { body, segment } = this.splitLastSegment(lastPath);
-    if (body) this.objectsManager.renderExtrusionsInColor([body], bodyColor);
-    this.objectsManager.renderExtrusionsInColor([segment], segColor);
+    if (body) this.pushHighlight([body], bodyColor);
+    this.pushHighlight([segment], segColor);
+  }
+
+  /** Draws `paths` in `color` and tracks the result for the next revert. */
+  private pushHighlight(paths: Path[], color: Color): void {
+    if (paths.length === 0) return;
+    // paths here are always freshly computed from the job, or freshly split
+    // off one, never ones an earlier call in this same pass already drew —
+    // renderExtrusionsInColor only returns undefined for paths it is asked
+    // to draw a second time, which cannot happen here
+    this._highlightObjects.push(this.objectsManager.renderExtrusionsInColor(paths, color) as Object3D);
+  }
+
+  /** Forgets the current top-layer/last-segment highlight without reverting it.
+   * @remarks
+   * Used when the scene it was drawn into is already being discarded wholesale
+   * (a full reset or a fresh ObjectsManager), so there is nothing left to revert.
+   */
+  private resetHighlightTracking(): void {
+    this._highlightedLayerIndex = undefined;
+    this._highlightedLastPath = undefined;
+    this._highlightObjects = [];
+    this._highlightedPaths = [];
   }
 
   /**

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -676,6 +676,22 @@ export class SceneManager {
   }
 
   /**
+   * Draws the paths parsed so far on top of what is already on screen
+   * @remarks
+   * Called repeatedly while a G-code stream is read, so the model grows on
+   * screen as chunks arrive. Only paths that have not been drawn yet are
+   * built, and the last path is held back: it may still be growing, and a
+   * path is only ever built once. The top-layer highlight is skipped because
+   * the top layer may not have arrived yet. The continuous animation loop
+   * presents the new geometry on the next frame.
+   */
+  renderProgressive(): void {
+    if (!this.job) return;
+
+    this.renderPaths(Math.max(0, this.job.paths.length - 1));
+  }
+
+  /**
    * Animation loop that renders paths incrementally
    * @param pathCount - Number of paths to render per frame
    * @returns Promise that resolves when all paths are rendered

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -688,9 +688,11 @@ export class SceneManager {
 
   /**
    * Draws the paths parsed so far on top of what is already on screen
+   * @internal
    * @remarks
-   * Called repeatedly while a G-code stream is read, so the model grows on
-   * screen as chunks arrive. Only paths that have not been drawn yet are
+   * Called by GCodePreview.readStream while a G-code stream is read, so the
+   * model grows on screen as chunks arrive — use processGCodeStream rather
+   * than calling this directly. Only paths that have not been drawn yet are
    * built, and the last path is held back: it may still be growing, and a
    * path is only ever built once. The top-layer/last-segment highlight, if
    * configured, moves onto whatever has most recently arrived. The continuous

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,7 +44,6 @@ export default defineConfig({
         'src/dev-gui.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/gcode-preview.ts': { statements: 93.9, branches: 79.48, functions: 100, lines: 94.87 },
         'src/indexers.ts': { statements: 96.66, branches: 96.15, functions: 100, lines: 96.66 },
-        'src/path.ts': { statements: 95.12, branches: 89.47, functions: 83.33, lines: 97.29 },
         'src/thumbnail.ts': { statements: 92.3, branches: 100, functions: 75, lines: 92.3 },
         'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,7 +44,7 @@ export default defineConfig({
         'src/dev-gui.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/gcode-preview.ts': { statements: 93.9, branches: 79.48, functions: 100, lines: 94.87 },
         'src/indexers.ts': { statements: 96.66, branches: 96.15, functions: 100, lines: 96.66 },
-        'src/path.ts': { statements: 93.93, branches: 88.23, functions: 80, lines: 96.66 },
+        'src/path.ts': { statements: 95.12, branches: 89.47, functions: 83.33, lines: 97.29 },
         'src/thumbnail.ts': { statements: 92.3, branches: 100, functions: 75, lines: 92.3 },
         'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 },


### PR DESCRIPTION
## What

The model now draws **live while a G-code stream is being read** — the print grows on screen as chunks arrive, instead of the canvas staying empty until the stream ends.

| ~20% streamed | ~80% streamed | complete |
|---|---|---|
| ![early](https://raw.githubusercontent.com/xyz-tools/gcode-preview/f7a4147a14173a5e48be1313367eaaf990b3eaa7/early.png) | ![mid](https://raw.githubusercontent.com/xyz-tools/gcode-preview/f7a4147a14173a5e48be1313367eaaf990b3eaa7/mid.png) | ![complete](https://raw.githubusercontent.com/xyz-tools/gcode-preview/f7a4147a14173a5e48be1313367eaaf990b3eaa7/complete.png) |

*(3DBenchy preset streamed over emulated Fast 3G with a cold cache; screenshots taken mid-stream in Chrome, with `highlightTopLayer`/`highlightLastSegment` on and contrasting colors — orange top layer, blue last segment — against the model's mint-green. The orange ring visibly climbs the hull as the print streams in, well before the model is finished — layer 78/240 and 113/240 above, vs. the finished chimney at 240/240.)*

## How it works

As chunks arrive from the network, `readStream` parses and executes them into the job as before — the new part is that between chunks it now asks the scene to draw what has accumulated so far, instead of waiting for the stream to end:

```mermaid
sequenceDiagram
    participant N as Network stream
    participant R as GCodePreview.readStream
    participant J as Job
    participant S as SceneManager
    participant O as ObjectsManager

    loop each chunk
        N->>R: decoded text chunk
        R->>J: parse + execute (paths accumulate)
        opt ≥ liveRenderInterval since last draw
            R->>S: renderProgressive()
            S->>O: renderPaths(all paths except the last)
            Note over O: builds only the not-yet-drawn tail<br/>as one new geometry batch
        end
    end
    R->>S: renderAnimated()
    Note over S,O: draws whatever remains,<br/>including the held-back final path
```

The reason this is cheap is a contract the `ObjectsManager` already had: it remembers every path it has built (`renderedPaths`), so progressive rendering can hand it a *growing prefix of the same list* on every call and each path is built exactly once — each `renderProgressive()` call materializes only the paths that arrived since the previous one, as a single geometry batch. Nothing needs to present the result explicitly either: the continuous `animate()` loop is already rendering the scene every frame, so new geometry simply appears on the next frame after it is added.

Two decisions shape what each progressive draw is allowed to touch:

```mermaid
flowchart LR
    A[paths in the job] --> B{already built?}
    B -- yes --> C[skipped<br/>renderedPaths]
    B -- no --> D{is it the job's last path?}
    D -- yes --> E[held back<br/>it may still be growing]
    D -- no --> F[built into this draw's batch]
```

- **Throttling.** A path is built per chunk arrival, but chunks can arrive far faster than 60 fps, and every draw adds a geometry batch that costs a draw call for the rest of the session. So draws are rate-limited to one per `liveRenderInterval` milliseconds (default **250** — the throttled ~22 s test stream produced 83 draw calls). Lower values grow the model more smoothly; `0` draws on every chunk, effectively once per frame.
- **The held-back tail.** The interpreter keeps appending vertices to the job's last path across chunk boundaries, but a path is only ever *built* once — drawing it early would freeze it with whatever vertices it happened to have at that moment, and its later vertices would never appear. Browser verification caught exactly this: without the holdback the final scene was missing precisely the tail geometry (789,608 vs 803,608 triangles). Each draw therefore stops one path short of the end; the final `renderAnimated()` at stream end picks up whatever remains, so the finished scene is identical to a non-progressive render.

`renderProgressive()` is tagged `@internal` (like `animate()`) — it only exists so `readStream` can call it across the class boundary; consumers keep using `processGCodeStream`, whose `render: false` option now flows down into `readStream` and skips live drawing entirely.

## Fix: the top-layer/last-segment highlight now tracks the stream live

`highlightTopLayer`/`highlightLastSegment` originally only redrew on a full render, so with a stream still coming in the highlight stayed off until the whole model finished — "top layer" and "last segment" meant the ones a *finished* print settles on, not the ones most recently *received*, which is what a live view should show.

`SceneManager` now re-evaluates the highlight on every `renderPaths()` call, including progressive ones, remembering which layer and path it last drew on so it can revert the highlight it's moving off of before drawing the new one. The split follows the policy/mechanism boundary between the two classes: `SceneManager` keeps only that memo (deciding *when* the top layer moved needs job and end-layer knowledge), while `ObjectsManager` — which already owns the groups, disposables and rendered-path bookkeeping — tracks what the highlight actually drew and claimed, and undoes exactly that in its new `revertHighlight()` (unclaim + remove + dispose). Tracking per actual draw/claim matters: reverting whole-layer path lists would also unclaim paths the per-tool batches drew normally (the `lastSegmentColor`-without-`topLayerColor` case), and the next progressive draw would then draw them a second time, stacking duplicate geometry each time the highlight moved — a regression test pins this. Splitting a path into its final segment and body moved onto `Path.splitLastSegment()`, since vertex slicing is path-domain work with no dependence on camera, scene or policy.

A structurally new top layer reverts the old highlight even before the new layer has anything visible yet (its only path may be the streaming-safe window's held-back tail) — otherwise the previous layer would stay highlighted for as long as the new one takes to produce something to draw. "Top layer" selection still keys off `job.layers` rather than raw path indices, so a structurally-empty trailing layer or a non-planar job correctly shows no highlight instead of falling back to an earlier one — matching the pre-existing full-render behavior. Layer identity alone isn't enough, though: the layer's own paths are intersected with the paths visible to *this specific render call*, so `renderAnimated`'s frame-by-frame reveal of an already-complete job doesn't jump the highlight ahead of the per-tool draw it's supposed to follow — caught by a dedicated test before it shipped.

## Browser evidence

Fast 3G, cold cache, 3.7 MB 3DBenchy (measured through `window._preview`):

| Time | Paths in job | On-screen triangles |
|---:|---:|---:|
| mid-stream (early) | 1,378 | 180,008 |
| mid-stream (later) | 5,696 | 731,472 |
| complete | 7,023 | **803,608** — identical to the non-progressive baseline |

Before this change the on-screen triangle count stayed **0** for the entire stream.

The screenshots live on the orphan branch `pr-assets-live-stream-rendering`, safe to delete after merge.

Assisted by Claude Code - Fable 5






