### PR TITLE
Cover split-chunk and thumbnail fully and pin them at 100%

### DIFF
--- a/src/__tests__/parse-thumbnail.ts
+++ b/src/__tests__/parse-thumbnail.ts
@@ -41,6 +41,12 @@ test('not matching size should be invalid', () => {
   expect(thumb.isValid).toBeFalsy();
 });
 
+test('src should be a jpeg data URL of the base64 chars', () => {
+  const thumb = new Thumbnail('16x16', 16, 16, encodedImg.length);
+  thumb.chars = encodedImg;
+  expect(thumb.src).toEqual('data:image/jpeg;base64,' + encodedImg);
+});
+
 test('well-formatted thumbnail should be parsed', () => {
   const parser = new Parser(0);
   const parsed = parser.parseGCode(gcodeCommentsWithThumbnail);

--- a/src/__tests__/split-chunk.ts
+++ b/src/__tests__/split-chunk.ts
@@ -24,6 +24,15 @@ describe('splitChunk', () => {
     expect(complete).toEqual('G1 X0\nG1 X1');
     expect(tail).toEqual('');
   });
+
+  test('a chunk with no newline is split before its last character', () => {
+    // Documented legacy quirk: without a newline, the split falls just
+    // before the last character of the chunk.
+    const { complete, tail } = splitChunk('G1 ', 'X42');
+
+    expect(complete).toEqual('G1 X4');
+    expect(tail).toEqual('2');
+  });
 });
 
 describe('streaming across a chunk boundary', () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,10 +44,8 @@ export default defineConfig({
         'src/dev-gui.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
         'src/gcode-preview.ts': { statements: 93.9, branches: 79.48, functions: 100, lines: 94.87 },
         'src/indexers.ts': { statements: 96.66, branches: 96.15, functions: 100, lines: 96.66 },
-        'src/thumbnail.ts': { statements: 92.3, branches: 100, functions: 75, lines: 92.3 },
         'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
-        'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 },
-        'src/helpers/split-chunk.ts': { statements: 75, branches: 50, functions: 100, lines: 75 }
+        'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 }
       }
     }
   }


### PR DESCRIPTION
## What

Brings `src/helpers/split-chunk.ts` and `src/thumbnail.ts` to 100% test coverage and removes their grandfathered entries from the vitest coverage thresholds, so both now sit on the 100%-per-file default.

- **split-chunk**: covers the `idxNewLine < 0` early return — a chunk containing no newline at all. The test pins the documented legacy quirk: such a chunk is split just before its last character.
- **thumbnail**: covers the `src` getter, asserting it returns `data:image/jpeg;base64,` prefixed onto the stored chars. The new test constructs `Thumbnail` with its real four constructor args instead of the legacy zero-arg style.
- **vitest.config.mts**: deletes the two grandfathered threshold entries; the `fullCoverage` default now applies to both files.

## Why

Two fewer files on the grandfather list — coverage regressions in either file will now fail CI.

## Verification

- `npx vitest run --coverage`: 596 tests pass, both files at 100% statements/branches/functions/lines, per-file thresholds pass with the entries removed
- `npm run typeCheck` and `npm run lint`: clean

Assisted by Claude Code - Fable 5