### PR TITLE
Cover grid, indexers and gcode-preview fully and pin them at 100%

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -24,6 +24,7 @@ describe('GCodePreview', () => {
   let mockDevGui: ReturnType<typeof vi.fn>;
   let mockJob: ReturnType<typeof vi.fn>;
   let mockInterpreter: ReturnType<typeof vi.fn>;
+  let mockStats: { update: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; dom: HTMLDivElement };
 
   beforeEach(() => {
     // Create mock canvas
@@ -88,16 +89,20 @@ describe('GCodePreview', () => {
     vi.mocked(DevGUI).mockImplementation(function () {
       return mockDevGui;
     } as never);
+    mockStats = {
+      update: vi.fn(),
+      end: vi.fn(),
+      dom: document.createElement('div')
+    };
     vi.mocked(Stats).mockImplementation(function () {
-      return {
-        update: vi.fn(),
-        dom: document.createElement('div')
-      };
+      return mockStats;
     } as never);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    // initStats appends the stats dom to document.body by default
+    mockStats.dom.remove();
   });
 
   describe('constructor', () => {
@@ -518,13 +523,55 @@ describe('GCodePreview', () => {
   describe('initStats method', () => {
     it('should not create stats when devMode is false', () => {
       preview = new GCodePreview({ canvas: mockCanvas, devMode: false });
+      expect(Stats).not.toHaveBeenCalled();
       expect(preview.stats).toBeUndefined();
     });
 
-    it('should not create stats initially when devMode is not set', () => {
+    it('should not create stats when devMode is not set', () => {
       preview = new GCodePreview({ canvas: mockCanvas });
-      // Stats should not be created initially because devMode is undefined at line 92
+      expect(Stats).not.toHaveBeenCalled();
       expect(preview.stats).toBeUndefined();
+    });
+
+    // regression: the constructor used to read this.devMode before assigning
+    // it from opts, so stats were never created even with devMode enabled
+    it('should create stats and append them to document.body when devMode is true', () => {
+      preview = new GCodePreview({ canvas: mockCanvas, devMode: true });
+
+      expect(Stats).toHaveBeenCalledTimes(1);
+      expect(mockStats.dom.parentElement).toBe(document.body);
+      expect(mockStats.dom.classList.contains('stats')).toBe(true);
+    });
+
+    it('should append stats to the statsContainer from devMode options', () => {
+      const statsContainer = document.createElement('div');
+      preview = new GCodePreview({ canvas: mockCanvas, devMode: { statsContainer } });
+
+      expect(mockStats.dom.parentElement).toBe(statsContainer);
+      expect(mockStats.dom.classList.contains('stats')).toBe(true);
+    });
+
+    it('should fall back to document.body when devMode options have no statsContainer', () => {
+      preview = new GCodePreview({ canvas: mockCanvas, devMode: {} });
+
+      expect(mockStats.dom.parentElement).toBe(document.body);
+    });
+  });
+
+  describe('stats updates on rendered frames', () => {
+    it('should update stats when the sceneManager reports a rendered frame', () => {
+      preview = new GCodePreview({ canvas: mockCanvas, devMode: true });
+
+      mockSceneManager.onFrameRendered();
+
+      expect(mockStats.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should tolerate rendered frames when stats are disabled', () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+
+      expect(() => mockSceneManager.onFrameRendered()).not.toThrow();
+      expect(mockStats.update).not.toHaveBeenCalled();
     });
   });
 
@@ -538,6 +585,35 @@ describe('GCodePreview', () => {
       // Should not throw when disposing without stats
       expect(() => preview.dispose()).not.toThrow();
       expect(mockSceneManager.dispose).toHaveBeenCalled();
+    });
+
+    it('should stop stats and remove their dom element when stats exist', () => {
+      preview = new GCodePreview({ canvas: mockCanvas, devMode: true });
+      expect(mockStats.dom.parentElement).toBe(document.body);
+
+      preview.dispose();
+
+      expect(mockStats.end).toHaveBeenCalled();
+      expect(mockStats.dom.parentElement).toBeNull();
+    });
+  });
+
+  describe('initGui edge cases', () => {
+    it('should not create a dev GUI once the sceneManager is disposed', () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+      preview.dispose();
+
+      preview.devMode = true;
+
+      expect(DevGUI).not.toHaveBeenCalled();
+    });
+
+    it('should not create a dev GUI for a truthy devMode that is neither boolean nor object', () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+
+      preview.devMode = 'invalid' as never;
+
+      expect(DevGUI).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/grid.ts
+++ b/src/__tests__/grid.ts
@@ -1,0 +1,113 @@
+import { test, expect, describe, vi } from 'vitest';
+import { BufferGeometry, Color, LineBasicMaterial, Material } from 'three';
+import { Grid } from '../helpers/grid';
+
+/** Collects the geometry's vertex pairs as order-independent, undirected edges */
+function edges(geometry: BufferGeometry): Set<string> {
+  const position = geometry.getAttribute('position');
+  const result = new Set<string>();
+  // The constructor rotates the geometry, which leaves tiny floating point
+  // residue (sin(PI) is not exactly 0), so round the coordinates.
+  const round = (value: number): number => Math.round(value * 1e6) / 1e6;
+
+  for (let i = 0; i < position.count; i += 2) {
+    const a = [round(position.getX(i)), round(position.getY(i)), round(position.getZ(i))].join(',');
+    const b = [round(position.getX(i + 1)), round(position.getY(i + 1)), round(position.getZ(i + 1))].join(',');
+    result.add([a, b].sort().join('|'));
+  }
+
+  return result;
+}
+
+function expectedGridEdges(sizeX: number, stepX: number, sizeZ: number, stepZ: number): Set<string> {
+  const edge = (a: number[], b: number[]): string => [a.join(','), b.join(',')].sort().join('|');
+
+  const result = new Set<string>();
+  // The grid is rotated onto the XZ plane, extending into negative z
+  for (let z = 0; z <= sizeZ; z += stepZ) {
+    result.add(edge([0, 0, -z], [sizeX, 0, -z]));
+  }
+  for (let x = 0; x <= sizeX; x += stepX) {
+    result.add(edge([x, 0, 0], [x, 0, -sizeZ]));
+  }
+  return result;
+}
+
+describe('constructor', () => {
+  test('draws a line at every step along both axes, flipped into negative z', () => {
+    const grid = new Grid(10, 5, 20, 10);
+
+    const position = grid.geometry.getAttribute('position');
+    expect(position.count).toEqual(12); // 3 lines per axis, 2 vertices each
+
+    const actual = edges(grid.geometry);
+    expect(actual.size).toEqual(6); // no duplicate or degenerate lines
+    expect(actual).toEqual(expectedGridEdges(10, 5, 20, 10));
+  });
+
+  test('uses a basic material driven by vertex colors', () => {
+    const grid = new Grid(10, 5, 20, 10);
+
+    expect(grid.material).toBeInstanceOf(LineBasicMaterial);
+    const material = grid.material as LineBasicMaterial;
+    expect(material.vertexColors).toEqual(true);
+    expect(material.toneMapped).toEqual(false);
+  });
+
+  test.each([
+    ['number', 0xff8800],
+    ['string', '#ff8800'],
+    ['Color', new Color(0xff8800)]
+  ] as const)('applies the color given as a %s to every vertex', (_kind, color) => {
+    const grid = new Grid(10, 5, 20, 10, color);
+
+    const colors = grid.geometry.getAttribute('color');
+    const expected = new Color(0xff8800);
+    expect(colors.count).toEqual(grid.geometry.getAttribute('position').count);
+    for (let i = 0; i < colors.count; i++) {
+      expect(colors.getX(i)).toBeCloseTo(expected.r, 5);
+      expect(colors.getY(i)).toBeCloseTo(expected.g, 5);
+      expect(colors.getZ(i)).toBeCloseTo(expected.b, 5);
+    }
+  });
+
+  test('defaults to a gray (0x888888) grid when no color is given', () => {
+    const grid = new Grid(10, 5, 20, 10);
+
+    const colors = grid.geometry.getAttribute('color');
+    const expected = new Color(0x888888);
+    for (let i = 0; i < colors.count; i++) {
+      expect(colors.getX(i)).toBeCloseTo(expected.r, 5);
+      expect(colors.getY(i)).toBeCloseTo(expected.g, 5);
+      expect(colors.getZ(i)).toBeCloseTo(expected.b, 5);
+    }
+  });
+
+  test('reports the GridHelper type', () => {
+    expect(new Grid(10, 5, 20, 10).type).toEqual('GridHelper');
+  });
+});
+
+describe('.dispose', () => {
+  test('disposes the geometry and the material', () => {
+    const grid = new Grid(10, 5, 20, 10);
+    const geometryDispose = vi.spyOn(grid.geometry, 'dispose');
+    const materialDispose = vi.spyOn(grid.material as Material, 'dispose');
+
+    grid.dispose();
+
+    expect(geometryDispose).toHaveBeenCalledOnce();
+    expect(materialDispose).toHaveBeenCalledOnce();
+  });
+
+  test('disposes every material when the material is an array', () => {
+    const grid = new Grid(10, 5, 20, 10);
+    const materials = [new LineBasicMaterial(), new LineBasicMaterial()];
+    const spies = materials.map((material) => vi.spyOn(material, 'dispose'));
+    grid.material = materials;
+
+    grid.dispose();
+
+    spies.forEach((spy) => expect(spy).toHaveBeenCalledOnce());
+  });
+});

--- a/src/__tests__/indexers.ts
+++ b/src/__tests__/indexers.ts
@@ -1,0 +1,247 @@
+import { test, expect, describe } from 'vitest';
+import { Path, PathType } from '../path';
+import { Layer } from '../layer';
+import {
+  LayersIndexer,
+  NonApplicableIndexer,
+  NonPlanarExtrusionError,
+  ToolIndexer,
+  TravelTypeIndexer
+} from '../indexers';
+
+function makePath(travelType: PathType, points: [number, number, number][] = [], tool: number = 0): Path {
+  const path = new Path(travelType, 0.6, 0.2, tool);
+  points.forEach((point) => path.addPoint(...point));
+  return path;
+}
+
+describe('TravelTypeIndexer', () => {
+  test('sorts extrusion paths into the extrusion index', () => {
+    const indexes: Record<string, Path[]> = { extrusion: [], travel: [] };
+    const indexer = new TravelTypeIndexer(indexes);
+    const path = makePath(PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+
+    indexer.sortIn(path);
+
+    expect(indexes.extrusion).toEqual([path]);
+    expect(indexes.travel).toEqual([]);
+  });
+
+  test('sorts travel paths into the travel index', () => {
+    const indexes: Record<string, Path[]> = { extrusion: [], travel: [] };
+    const indexer = new TravelTypeIndexer(indexes);
+    const path = makePath(PathType.Travel, [
+      [0, 0, 0],
+      [1, 2, 0]
+    ]);
+
+    indexer.sortIn(path);
+
+    expect(indexes.extrusion).toEqual([]);
+    expect(indexes.travel).toEqual([path]);
+  });
+});
+
+describe('LayersIndexer', () => {
+  test('the first extrusion path creates a layer at the path z, with z as height', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+    const path = makePath(PathType.Extrusion, [
+      [0, 0, 2],
+      [1, 2, 2]
+    ]);
+
+    indexer.sortIn(path);
+
+    expect(layers.length).toEqual(1);
+    expect(layers[0].z).toEqual(2);
+    expect(layers[0].height).toEqual(2);
+    expect(layers[0].paths).toEqual([path]);
+  });
+
+  test('an extrusion path within tolerance joins the current layer', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+    const first = makePath(PathType.Extrusion, [
+      [0, 0, 0.2],
+      [1, 2, 0.2]
+    ]);
+    const second = makePath(PathType.Extrusion, [
+      [1, 2, 0.2 + LayersIndexer.DEFAULT_TOLERANCE],
+      [5, 6, 0.2 + LayersIndexer.DEFAULT_TOLERANCE]
+    ]);
+
+    indexer.sortIn(first);
+    indexer.sortIn(second);
+
+    expect(layers.length).toEqual(1);
+    expect(layers[0].paths).toEqual([first, second]);
+  });
+
+  test('an extrusion path above tolerance creates a new layer with the height difference', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+
+    indexer.sortIn(
+      makePath(PathType.Extrusion, [
+        [0, 0, 0.2],
+        [1, 2, 0.2]
+      ])
+    );
+    indexer.sortIn(
+      makePath(PathType.Extrusion, [
+        [1, 2, 0.5],
+        [5, 6, 0.5]
+      ])
+    );
+
+    expect(layers.length).toEqual(2);
+    expect(layers[1].z).toEqual(0.5);
+    expect(layers[1].height).toBeCloseTo(0.3);
+  });
+
+  test('records the layer index on each sorted path', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+    const first = makePath(PathType.Extrusion, [
+      [0, 0, 0.2],
+      [1, 2, 0.2]
+    ]);
+    const second = makePath(PathType.Extrusion, [
+      [1, 2, 0.5],
+      [5, 6, 0.5]
+    ]);
+
+    indexer.sortIn(first);
+    indexer.sortIn(second);
+
+    expect(first.layerIndex).toEqual(0);
+    expect(second.layerIndex).toEqual(1);
+  });
+
+  test('travel paths join the current layer without creating one', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+    const extrusion = makePath(PathType.Extrusion, [
+      [0, 0, 0.2],
+      [1, 2, 0.2]
+    ]);
+    const travel = makePath(PathType.Travel, [
+      [1, 2, 0.2],
+      [5, 6, 42]
+    ]);
+
+    indexer.sortIn(extrusion);
+    indexer.sortIn(travel);
+
+    expect(layers.length).toEqual(1);
+    expect(layers[0].paths).toEqual([extrusion, travel]);
+    expect(travel.layerIndex).toEqual(0);
+  });
+
+  test('travel paths before the first extrusion are dropped', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers);
+    const travel = makePath(PathType.Travel, [
+      [0, 0, 0],
+      [1, 2, 5]
+    ]);
+
+    indexer.sortIn(travel);
+
+    expect(layers).toEqual([]);
+    expect(travel.layerIndex).toBeUndefined();
+  });
+
+  test('throws NonPlanarExtrusionError when an extrusion path changes z above tolerance', () => {
+    const indexer = new LayersIndexer([]);
+    const nonPlanar = makePath(PathType.Extrusion, [
+      [0, 0, 0],
+      [1, 2, 1]
+    ]);
+
+    expect(() => indexer.sortIn(nonPlanar)).toThrow(NonPlanarExtrusionError);
+    expect(() => indexer.sortIn(nonPlanar)).toThrow(NonApplicableIndexer);
+  });
+
+  test('respects a custom tolerance', () => {
+    const layers: Layer[] = [];
+    const indexer = new LayersIndexer(layers, 0.1);
+    const wavy = makePath(PathType.Extrusion, [
+      [0, 0, 0.2],
+      [1, 2, 0.29]
+    ]);
+    const next = makePath(PathType.Extrusion, [
+      [1, 2, 0.29],
+      [5, 6, 0.29]
+    ]);
+
+    expect(() => indexer.sortIn(wavy)).not.toThrow();
+    indexer.sortIn(next);
+
+    expect(layers.length).toEqual(1);
+  });
+});
+
+describe('ToolIndexer', () => {
+  test('the first extrusion path for a tool creates its index', () => {
+    const indexes: Path[][] = [];
+    const indexer = new ToolIndexer(indexes);
+    const path = makePath(PathType.Extrusion, [], 0);
+
+    indexer.sortIn(path);
+
+    expect(indexes[0]).toEqual([path]);
+  });
+
+  test('subsequent extrusion paths for the same tool are appended', () => {
+    const indexes: Path[][] = [];
+    const indexer = new ToolIndexer(indexes);
+    const first = makePath(PathType.Extrusion, [], 0);
+    const second = makePath(PathType.Extrusion, [], 0);
+
+    indexer.sortIn(first);
+    indexer.sortIn(second);
+
+    expect(indexes[0]).toEqual([first, second]);
+  });
+
+  test('travel paths are not indexed', () => {
+    const indexes: Path[][] = [];
+    const indexer = new ToolIndexer(indexes);
+
+    indexer.sortIn(makePath(PathType.Travel, [], 0));
+
+    expect(indexes).toEqual([]);
+  });
+
+  test('tools are indexed independently', () => {
+    const indexes: Path[][] = [];
+    const indexer = new ToolIndexer(indexes);
+    const tool0 = makePath(PathType.Extrusion, [], 0);
+    const tool1 = makePath(PathType.Extrusion, [], 1);
+    const tool0Again = makePath(PathType.Extrusion, [], 0);
+
+    indexer.sortIn(tool0);
+    indexer.sortIn(tool1);
+    indexer.sortIn(tool0Again);
+
+    expect(indexes[0]).toEqual([tool0, tool0Again]);
+    expect(indexes[1]).toEqual([tool1]);
+  });
+
+  test('sparse tool numbers leave gaps undefined', () => {
+    const indexes: Path[][] = [];
+    const indexer = new ToolIndexer(indexes);
+    const path = makePath(PathType.Extrusion, [], 5);
+
+    indexer.sortIn(path);
+
+    expect(indexes.length).toEqual(6);
+    expect(indexes[5]).toEqual([path]);
+    expect(indexes[3]).toBeUndefined();
+  });
+});

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -147,7 +147,9 @@ export class GCodePreview {
     this.opts = opts;
     this._parser = this.createParser();
     this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
-    this.stats = this.devMode ? new Stats() : undefined;
+    // note: reads opts.devMode because this.devMode is only assigned below,
+    // once the scene manager needed by its setter exists
+    this.stats = opts.devMode ? new Stats() : undefined;
     this._sceneManager = this.createSceneManager();
     // the devMode setter also creates the dev GUI, so no separate initGui() call
     this.devMode = opts?.devMode;

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -164,9 +164,6 @@ export class ToolIndexer extends Indexer {
   sortIn(path: Path): void {
     if (path.travelType === PathType.Extrusion) {
       this.indexes[path.tool] = this.indexes[path.tool] || [];
-      if (this.indexes[path.tool] === undefined) {
-        this.indexes[path.tool] = [];
-      }
       this.indexes[path.tool].push(path);
     }
   }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -42,10 +42,7 @@ export default defineConfig({
         perFile: true,
         ...Object.fromEntries(sourceFiles.map((file) => [file, fullCoverage])),
         'src/dev-gui.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
-        'src/gcode-preview.ts': { statements: 93.9, branches: 79.48, functions: 100, lines: 94.87 },
-        'src/indexers.ts': { statements: 96.66, branches: 96.15, functions: 100, lines: 96.66 },
-        'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 },
-        'src/helpers/grid.ts': { statements: 93.33, branches: 66.66, functions: 66.66, lines: 96.29 }
+        'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 }
       }
     }
   }


### PR DESCRIPTION
## Summary

Brings `src/helpers/grid.ts`, `src/indexers.ts` and `src/gcode-preview.ts` to 100% test coverage and unpins them in `vitest.config.mts` so they now sit on the 100%-or-fail default. Along the way, covering the "unreachable" lines surfaced a real regression.

## Bug fix: the Stats FPS meter was never created

The `GCodePreview` constructor read `this.devMode` (still its field-initializer value `false`) *before* `this.devMode = opts?.devMode` runs a few lines later — the devMode setter needs the scene manager, so it can't be moved up. As a result `this.stats` was always `undefined`, `initStats()` was unreachable dead code, and the FPS meter silently vanished for every `devMode: true` user. The reorder was introduced when `webgl-preview.ts` was extracted into `gcode-preview.ts` (`c2887a4`).

Fix: read `opts.devMode` directly when creating `Stats`, with a regression test pinning the behavior.

## Other changes

- **`src/indexers.ts`**: deleted an unreachable `if (... === undefined)` block in `ToolIndexer.sortIn` — the preceding `|| []` assignment already guarantees the entry exists (pure dead-code removal, no behavior change).
- **`src/__tests__/indexers.ts`** (new): 15 unit tests for `TravelTypeIndexer`, `LayersIndexer` (tolerance merge, height fallback, travels-before-first-extrusion, `NonPlanarExtrusionError`, custom tolerance) and `ToolIndexer` (sparse tool numbers, travels ignored). Previously this file was only covered indirectly through `job.ts` tests.
- **`src/__tests__/grid.ts`** (new): 9 tests for `Grid` — line placement along both axes, default-color branch, material settings, and both `dispose()` paths (single material and the defensive array branch).
- **`src/__tests__/gcode-preview.ts`**: upgraded the `Stats` mock to a shared instance with DOM cleanup; new tests for `initStats` (statsContainer, `document.body` fallback), `onFrameRendered` → `stats.update()`, `dispose()` → `stats.end()`, and `initGui` edge cases.
- **`vitest.config.mts`**: removed the grandfathered threshold pins for the three files. Only `dev-gui.ts` and `extra/dom-utils.ts` remain pinned below 100%.

Assisted by Claude Code - Fable 5