### PR TITLE
Cover dom-utils fully and pin the whole repo at 100%

### DIFF
--- a/src/__tests__/dom-utils.ts
+++ b/src/__tests__/dom-utils.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeDroppable } from '../extra/dom-utils';
+import type { GCodePreview } from '../gcode-preview';
+
+// The real GCodePreview needs WebGL; the drop handling only touches the
+// canvas, the job counters and the two methods stubbed here.
+function makePreview() {
+  const canvas = document.createElement('canvas');
+  const received: string[] = [];
+  const stub = {
+    sceneManager: { canvas, endLayer: 0 },
+    job: { layers: [{}, {}, {}], paths: [{}, {}] },
+    clear: vi.fn(),
+    processGCodeStream: vi.fn(async (stream: ReadableStream<string>) => {
+      for await (const chunk of stream) received.push(chunk);
+    })
+  };
+  makeDroppable(stub as unknown as GCodePreview);
+  return { canvas, received, stub };
+}
+
+// happy-dom has no DragEvent; a plain Event with a dataTransfer property
+// bolted on walks and quacks the same for these listeners.
+function dragEvent(type: string, dataTransfer?: { files: File[]; dropEffect?: string }): Event {
+  const evt = new Event(type);
+  if (dataTransfer) Object.assign(evt, { dataTransfer });
+  vi.spyOn(evt, 'preventDefault');
+  return evt;
+}
+
+describe('makeDroppable', () => {
+  it('marks the canvas and requests a copy cursor while dragging over', () => {
+    const { canvas } = makePreview();
+    const dataTransfer = { files: [], dropEffect: 'none' };
+
+    const evt = dragEvent('dragover', dataTransfer);
+    canvas.dispatchEvent(evt);
+
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(dataTransfer.dropEffect).toBe('copy');
+    expect(canvas.classList.contains('dragging')).toBe(true);
+  });
+
+  it('still marks the canvas when the dragover has no dataTransfer', () => {
+    const { canvas } = makePreview();
+
+    canvas.dispatchEvent(dragEvent('dragover'));
+
+    expect(canvas.classList.contains('dragging')).toBe(true);
+  });
+
+  it('unmarks the canvas when the drag leaves', () => {
+    const { canvas } = makePreview();
+    canvas.dispatchEvent(dragEvent('dragover'));
+
+    const evt = dragEvent('dragleave');
+    canvas.dispatchEvent(evt);
+
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(canvas.classList.contains('dragging')).toBe(false);
+  });
+
+  it('clears the preview, streams the dropped file and announces the update', async () => {
+    const { canvas, received, stub } = makePreview();
+    canvas.dispatchEvent(dragEvent('dragover'));
+    const file = new File(['G1 X1 Y1\nG1 X2 Y2'], 'benchy.gcode');
+    const update = new Promise<CustomEvent>((resolve) => {
+      canvas.addEventListener('update', (evt) => resolve(evt as CustomEvent), { once: true });
+    });
+
+    canvas.dispatchEvent(dragEvent('drop', { files: [file] }));
+
+    const evt = await update;
+    expect(canvas.classList.contains('dragging')).toBe(false);
+    expect(stub.clear).toHaveBeenCalledOnce();
+    expect(received.join('')).toBe('G1 X1 Y1\nG1 X2 Y2');
+    expect(stub.sceneManager.endLayer).toBe(3);
+    expect(evt.detail).toEqual({ filename: 'benchy.gcode', size: file.size, layers: 3, paths: 2 });
+  });
+
+  it('leaves the scene alone when the drop carries no file', async () => {
+    // Regression: dropping anything without a file (plain text, or an empty
+    // file list) cleared the scene anyway and then crashed on
+    // undefined.stream() in the async listener — an unhandled rejection.
+    const { canvas, stub } = makePreview();
+    canvas.dispatchEvent(dragEvent('dragover'));
+
+    canvas.dispatchEvent(dragEvent('drop', { files: [] }));
+    canvas.dispatchEvent(dragEvent('drop'));
+    await vi.waitFor(() => expect(canvas.classList.contains('dragging')).toBe(false));
+
+    expect(stub.clear).not.toHaveBeenCalled();
+    expect(stub.processGCodeStream).not.toHaveBeenCalled();
+  });
+});

--- a/src/extra/dom-utils.ts
+++ b/src/extra/dom-utils.ts
@@ -22,6 +22,7 @@ export function makeDroppable(previewInstance: GCodePreview): void {
     element.classList.remove('dragging');
     const files: FileList | [] = evt.dataTransfer?.files ?? [];
     const file = files[0];
+    if (!file) return;
 
     previewInstance.clear(); // TODO: remove?
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,13 +35,12 @@ export default defineConfig({
       reporter: ['text', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['src/__tests__/**'],
-      // 100% coverage is the default for every file under src/. Files listed
-      // below are grandfathered at their current coverage and fail CI if they
-      // regress. Raise (and eventually remove) an entry as coverage improves.
+      // 100% coverage is required for every file under src/. To grandfather a
+      // file at lower coverage, add an entry after the spread pinning its
+      // current numbers, and raise (then remove) it as coverage improves.
       thresholds: {
         perFile: true,
-        ...Object.fromEntries(sourceFiles.map((file) => [file, fullCoverage])),
-        'src/extra/dom-utils.ts': { statements: 0, branches: 0, functions: 0, lines: 0 }
+        ...Object.fromEntries(sourceFiles.map((file) => [file, fullCoverage]))
       }
     }
   }


### PR DESCRIPTION
## Summary

The final step of the one-file-at-a-time march to 100% coverage (#390, #397, #399, #403, #409, #412, #413): `src/extra/dom-utils.ts` goes from 0% (no test file at all) to **100%**, the last grandfathered pin is deleted from `vitest.config.mts`, and the repo now sits at **100% statements / branches / functions / lines with every file under `src/` failing CI below 100%**.

## Bug fix: empty drop crashed the handler and wiped the scene

In `makeDroppable`'s drop handler, `files[0]` is `undefined` when the drop carries no file (dropped text selection, empty dataTransfer). The handler still called `previewInstance.clear()` — destroying the user's loaded scene — and then `readFile` hit `undefined.stream()`, producing an unhandled `TypeError` rejection. Fixed with an early return *before* `clear()`, since wiping the scene on a fileless drop is part of the bug. Pinned by a regression test covering both the empty-`FileList` and missing-`dataTransfer` (`?? []`) paths.

## Tests

New `src/__tests__/dom-utils.ts` (5 tests), using the stub-preview style from the dev-gui suite:

- dragover with dataTransfer: preventDefault, `dropEffect = 'copy'`, `dragging` class added; and without dataTransfer (the guard branch)
- dragleave removes the class
- drop happy path with a **real** `File` flowing through **real** `file.stream().pipeThrough(new TextDecoderStream())` — the spy consumes the stream and the decoded G-code round-trips exactly; asserts `clear()`, `endLayer` from `job.layers.length`, and the `'update'` CustomEvent detail (`filename`/`size`/`layers`/`paths`)
- the no-file regression above

No polyfills needed — happy-dom plus Node's `File`/`TextDecoderStream` interoperate; the only quirk is happy-dom lacking `DragEvent`, so tests dispatch plain `Event`s with a `dataTransfer` property attached.

## Test plan

- [x] `src/extra/dom-utils.ts` at 100/100/100/100
- [x] Repo-wide coverage: 100% statements (1432/1432), branches (618/618), functions (305/305), lines (1337/1337)
- [x] Full suite: 24 files, 642 tests, all passing
- [x] `npm run lint` and `npm run typeCheck` clean

Assisted by Claude Code - Fable 5