### PR TITLE
Stop the streaming pipeline losing and corrupting data at chunk boundaries

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -486,6 +486,8 @@ describe('GCodePreview', () => {
 
     it('should handle empty stream chunks', async () => {
       preview = new GCodePreview({ canvas: mockCanvas });
+      const onStreamEnd = vi.fn();
+      preview.onStreamEnd = onStreamEnd;
 
       const stream = new ReadableStream({
         start(controller) {
@@ -496,8 +498,35 @@ describe('GCodePreview', () => {
 
       await preview.readStream(stream);
 
-      // Should handle empty chunk gracefully
+      // An empty chunk is skipped, not treated as end-of-stream: there is
+      // nothing to parse, but the stream still finishes normally
       expect(preview.parser.parseGCode).not.toHaveBeenCalled();
+      expect(onStreamEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should process every chunk after an empty mid-stream chunk', async () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+      const onStreamEnd = vi.fn();
+      preview.onStreamEnd = onStreamEnd;
+
+      const stream = new ReadableStream({
+        start(controller) {
+          // TextDecoderStream can emit '' for a chunk holding only a partial
+          // multi-byte sequence; it must not truncate the rest of the stream
+          controller.enqueue('G1 X0 Y0\n');
+          controller.enqueue('');
+          controller.enqueue('G1 X10 Y10\n');
+          controller.close();
+        }
+      });
+
+      await preview.readStream(stream);
+
+      expect(preview.parser.parseGCode).toHaveBeenCalledTimes(2);
+      expect(preview.parser.parseGCode).toHaveBeenNthCalledWith(1, 'G1 X0 Y0');
+      expect(preview.parser.parseGCode).toHaveBeenNthCalledWith(2, 'G1 X10 Y10');
+      expect(mockInterpreter.execute).toHaveBeenCalledTimes(2);
+      expect(onStreamEnd).toHaveBeenCalledTimes(1);
     });
 
     it('should handle stream with tail data', async () => {
@@ -517,6 +546,27 @@ describe('GCodePreview', () => {
       // Should process all complete lines
       expect(preview.parser.parseGCode).toHaveBeenCalledTimes(2);
       expect(mockInterpreter.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('should flush and parse the tail when the last chunk has no trailing newline', async () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue('G0 X0 Y0\n');
+          controller.enqueue('G1 X10 Y10');
+          controller.close();
+        }
+      });
+
+      await preview.readStream(stream);
+
+      // chunk 1 completes 'G0 X0 Y0', chunk 2 has no newline so it completes
+      // nothing (''), and the leftover tail is flushed after the stream ends
+      expect(preview.parser.parseGCode).toHaveBeenCalledTimes(3);
+      expect(preview.parser.parseGCode).toHaveBeenNthCalledWith(1, 'G0 X0 Y0');
+      expect(preview.parser.parseGCode).toHaveBeenLastCalledWith('G1 X10 Y10');
+      expect(mockInterpreter.execute).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/src/__tests__/split-chunk.ts
+++ b/src/__tests__/split-chunk.ts
@@ -25,13 +25,13 @@ describe('splitChunk', () => {
     expect(tail).toEqual('');
   });
 
-  test('a chunk with no newline is split before its last character', () => {
-    // Documented legacy quirk: without a newline, the split falls just
-    // before the last character of the chunk.
+  test('a chunk with no newline carries fully into the tail', () => {
+    // Without a newline nothing is complete yet: the whole chunk joins the
+    // tail so no line is ever handed to the parser truncated.
     const { complete, tail } = splitChunk('G1 ', 'X42');
 
-    expect(complete).toEqual('G1 X4');
-    expect(tail).toEqual('2');
+    expect(complete).toEqual('');
+    expect(tail).toEqual('G1 X42');
   });
 });
 
@@ -54,5 +54,23 @@ describe('streaming across a chunk boundary', () => {
     expect(parser.lines).toEqual(['G1 X0', 'G1 X1', 'G1 X2', 'G1 X3', 'G1 X4']);
     expect(parser.lines).not.toContain('');
     expect(parser.lineCount).toEqual(5);
+  });
+
+  test('1-character chunks plus a final flush reconstruct every line intact', () => {
+    // Worst-case chunking: every read delivers a single character. Each line
+    // must still reach the parser whole, never split mid-line.
+    const source = 'G1 X0\nG1 X1\nG1 X42';
+
+    const parser = new Parser({ keepLines: true });
+    let tail = '';
+    for (const chunk of source) {
+      const split = splitChunk(tail, chunk);
+      tail = split.tail;
+      if (split.complete !== '') parser.parseGCode(split.complete);
+    }
+    parser.parseGCode(tail);
+
+    expect(parser.lines).toEqual(['G1 X0', 'G1 X1', 'G1 X42']);
+    expect(parser.lineCount).toEqual(3);
   });
 });

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -227,7 +227,10 @@ export class GCodePreview {
       result = await reader.read();
       const length = result.value?.length ?? 0;
       if (length === 0) {
-        break;
+        // TextDecoderStream can legitimately emit an empty chunk (e.g. one
+        // holding only a partial multi-byte sequence). Skip it and keep
+        // reading; the loop only ends when the stream reports done.
+        continue;
       }
       console.debug('reading from stream', Math.floor(length / 1024), 'kB');
       size += length;
@@ -251,6 +254,13 @@ export class GCodePreview {
         lastDrawnAt = performance.now();
       }
     } while (!result.done);
+
+    // flush the leftover tail: a file whose last line has no trailing newline
+    // still needs that final command parsed and executed
+    if (tail !== '') {
+      const { commands } = this.parser.parseGCode(tail);
+      this.executeCommands(commands);
+    }
 
     console.debug('total read from stream', Math.floor(size / 1024), 'kB');
     this.onStreamEnd?.();

--- a/src/helpers/split-chunk.ts
+++ b/src/helpers/split-chunk.ts
@@ -10,15 +10,15 @@
  * The returned `tail` excludes the newline itself, so prepending it to the
  * next chunk never fabricates an empty line at a chunk boundary.
  *
- * A chunk containing no newline at all keeps its historical behaviour: it is
- * split before its last character. That is a known quirk, preserved here so
- * this helper changes nothing but the boundary newline.
+ * A chunk containing no newline at all completes nothing: the whole chunk is
+ * carried into the tail, so a line is only ever parsed once its terminating
+ * newline (or the end of the stream) has arrived.
  */
 export function splitChunk(tail: string, chunk: string): { complete: string; tail: string } {
   const idxNewLine = chunk.lastIndexOf('\n');
 
   if (idxNewLine < 0) {
-    return { complete: tail + chunk.slice(0, -1), tail: chunk.slice(-1) };
+    return { complete: '', tail: tail + chunk };
   }
 
   return { complete: tail + chunk.slice(0, idxNewLine), tail: chunk.slice(idxNewLine + 1) };


### PR DESCRIPTION
Fixes three related bugs where the G-code streaming pipeline silently lost or corrupted data at chunk boundaries.

## Bug 1 — no-newline chunks were split before their last character

`src/helpers/split-chunk.ts:20-22`: when a chunk contained no `\n`, `splitChunk` returned `complete: tail + chunk.slice(0, -1), tail: chunk.slice(-1)` — so `splitChunk('G1 ', 'X42')` handed the parser the truncated line `G1 X4` and carried only `2` forward. With small chunks (e.g. a 1-byte chunker) this corrupted nearly every line.

This behavior was documented in the code as a "known quirk, preserved", and pinned by a test. That legacy quirk pin has now been **deliberately removed**: a no-newline chunk completes nothing and carries fully into the tail, so a line only reaches the parser once its terminating newline (or the end of the stream) has arrived.

## Bug 2 — `readStream` never flushed the final tail

`src/gcode-preview.ts:219-257`: after the `do...while (!result.done)` read loop, the leftover `tail` was never parsed, so a file whose last line lacks a trailing newline lost its final command. The tail is now flushed after the loop — parsed and executed exactly like a complete chunk — before `onStreamEnd` fires.

## Bug 3 — a zero-length chunk aborted the whole stream

`src/gcode-preview.ts:228-231`: `if (length === 0) break;` treated an empty chunk as end-of-stream, truncating everything after it — even though `TextDecoderStream` can legitimately emit `''` for a chunk holding only a partial multi-byte sequence — and `onStreamEnd` still fired as if the read had succeeded. Empty chunks are now skipped; the loop exits only when the stream reports `done`.

## Tests

- Updated the split-chunk quirk pin to the new correct behavior (`complete: ''`, tail carries the whole chunk).
- New worst-case test: 1-character chunks plus a final flush reconstruct every line intact.
- New `readStream` tests: a stream whose last chunk has no trailing newline still parses the final command; an empty mid-stream chunk doesn't truncate the rest and `onStreamEnd` fires exactly once.
- Adjusted existing empty-chunk pinning test to the new skip semantics.

All gates pass: `npm run test:coverage` (100% statements/branches/functions/lines, 645 tests), `npm run typeCheck`, `npm run lint`.

This unblocks a follow-up streaming-vs-oneshot equivalence test harness, since streamed parsing now produces the same commands as one-shot parsing regardless of chunking.

Assisted by Claude Code - Fable 5