### PR TITLE
Run ingestion tests through both oneshot and streaming pipelines

### DIFF
--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -1,0 +1,235 @@
+/**
+ * Streaming-vs-oneshot ingestion equivalence harness.
+ *
+ * Every test added inside the describe.each block below automatically runs
+ * once per ingestion mode: oneshot `processGCode`, plus `processGCodeStream`
+ * fed through chunkers of several sizes. Chunk size 1 is the worst case for
+ * the stream splitter (every character is its own chunk), size 7 lands chunk
+ * boundaries mid-word, mid-number and mid-comment, and 64k delivers the whole
+ * file in a single chunk. This equivalence only holds because splitChunk
+ * carries a no-newline chunk into its tail, readStream flushes the leftover
+ * tail after the read loop, and empty chunks no longer end the stream early.
+ *
+ * Keep expected values CONCRETE (exact counts, coordinates and states derived
+ * from the fixture line by line) so every mode must independently reproduce
+ * them — comparing modes against each other would let a shared bug slip by.
+ *
+ * Streaming-only behaviors (render throttling, onJobUpdated cadence, …)
+ * belong in the gcode-preview.ts tests, not here.
+ *
+ * All helpers live in this file on purpose: the vitest config collects every
+ * .ts file under src/__tests__ as a test suite, so a separate helper module
+ * would be picked up as an empty suite and fail the run.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { GCodePreview } from '../gcode-preview';
+import { PathType } from '../path';
+
+const { MockWebGLRenderer } = vi.hoisted(() => {
+  class MockWebGLRenderer {
+    domElement: HTMLElement;
+    info = {
+      render: { triangles: 0, calls: 0, lines: 0, points: 0 },
+      memory: { geometries: 0, textures: 0 }
+    };
+    localClippingEnabled = false;
+    setPixelRatio = vi.fn();
+    setSize = vi.fn();
+    render = vi.fn();
+    dispose = vi.fn();
+
+    constructor(opts: { canvas?: HTMLElement } = {}) {
+      this.domElement = opts.canvas ?? document.createElement('canvas');
+    }
+  }
+
+  return { MockWebGLRenderer };
+});
+
+// Only the WebGLRenderer is replaced so the tests can run without a GPU.
+// Everything else — Parser, Interpreter, Job, SceneManager and the actual
+// three.js geometry — is real, which is the point of this harness.
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('three')>();
+  return { ...actual, WebGLRenderer: MockWebGLRenderer };
+});
+
+type Ingest = (preview: GCodePreview, gcode: string) => Promise<void>;
+
+/** Wraps pre-cut string chunks in a ReadableStream, delivered in order. */
+const makeStream = (chunks: string[]) =>
+  new ReadableStream({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    }
+  });
+
+/** Deterministically cuts the input into fixed-size chunks, in order. */
+const chunksOf = (gcode: string, size: number): string[] => {
+  const chunks: string[] = [];
+  for (let i = 0; i < gcode.length; i += size) {
+    chunks.push(gcode.slice(i, i + size));
+  }
+  return chunks;
+};
+
+/** Streams the gcode in fixed-size chunks, skipping progressive draws. */
+const streamIngest =
+  (size: number): Ingest =>
+  async (preview, gcode) => {
+    await preview.processGCodeStream(makeStream(chunksOf(gcode, size)), { render: false });
+  };
+
+const MODES: [name: string, ingest: Ingest][] = [
+  [
+    'oneshot',
+    async (preview, gcode) => {
+      await preview.processGCode(gcode);
+    }
+  ],
+  ['stream chunk=1', streamIngest(1)],
+  ['stream chunk=7', streamIngest(7)],
+  // 64k delivers the whole file in a single chunk (65536 > every fixture here)
+  ['stream chunk=64k', streamIngest(64 * 1024)]
+];
+
+function createPreview(): GCodePreview {
+  const canvas = document.createElement('canvas');
+  Object.defineProperty(canvas, 'offsetWidth', { value: 800, configurable: true });
+  Object.defineProperty(canvas, 'offsetHeight', { value: 600, configurable: true });
+  return new GCodePreview({ canvas, buildVolume: { x: 200, y: 200, z: 200 } });
+}
+
+describe.each(MODES)('ingestion via %s', (_name, ingest) => {
+  let preview: GCodePreview;
+
+  beforeEach(() => {
+    preview = createPreview();
+    // readStream logs a debug line per chunk; chunk=1 would emit one per byte
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // the SceneManager constructor starts a rAF loop; dispose cancels it
+    preview.dispose();
+    vi.restoreAllMocks();
+  });
+
+  test('a multi-move file yields the exact same paths and vertices', async () => {
+    // G28 homes to (0,0,0). The G0 opens a travel path from the origin; the
+    // first G1 with E>0 breaks it and opens an extrusion path that starts at
+    // the travel's endpoint and collects one vertex per move.
+    const gcode = ['G28', 'G0 X10 Y10 Z0.2', 'G1 X20 Y10 E1', 'G1 X20 Y20 E1', 'G1 X10 Y20 E1'].join('\n');
+
+    await ingest(preview, gcode);
+
+    expect(preview.job.paths.length).toEqual(2);
+    expect(preview.job.paths[0].travelType).toEqual(PathType.Travel);
+    expect(preview.job.paths[0].vertices).toEqual([0, 0, 0, 10, 10, 0.2]);
+    expect(preview.job.paths[1].travelType).toEqual(PathType.Extrusion);
+    expect(preview.job.paths[1].vertices).toEqual([10, 10, 0.2, 20, 10, 0.2, 20, 20, 0.2, 10, 20, 0.2]);
+  });
+
+  test('a file without a trailing newline keeps its final command', async () => {
+    // No '\n' after the last G1: streaming modes only see this command when
+    // readStream flushes the leftover tail after the read loop.
+    const gcode = 'G28\nG0 X5 Y5 Z0.2\nG1 X15 Y5 E1';
+
+    await ingest(preview, gcode);
+
+    expect(preview.job.paths.length).toEqual(2);
+    expect(preview.job.paths[1].vertices).toEqual([5, 5, 0.2, 15, 5, 0.2]);
+    expect(preview.job.state.x).toEqual(15);
+    expect(preview.job.state.y).toEqual(5);
+  });
+
+  test('a two-layer print indexes the same layers and paths per layer', async () => {
+    const gcode = [
+      'G28',
+      'G0 X10 Y10 Z0.2', // travel; no layer exists yet, so it lands in none
+      'G1 X20 Y10 E1', // extrusion at Z0.2 creates layer 1
+      'G1 X20 Y20 E1',
+      'G0 X20 Y20 Z0.4', // travel up; still indexed into layer 1
+      'G1 X10 Y20 E1' // extrusion at Z0.4 creates layer 2
+    ].join('\n');
+
+    await ingest(preview, gcode);
+
+    expect(preview.countLayers).toEqual(2);
+    expect(preview.job.layers[0].z).toEqual(0.2);
+    expect(preview.job.layers[1].z).toEqual(0.4);
+    // layer 1 holds the first extrusion and the travel up to the next layer
+    expect(preview.job.layers[0].paths.length).toEqual(2);
+    expect(preview.job.layers[1].paths.length).toEqual(1);
+    expect(preview.job.layers[1].paths[0].travelType).toEqual(PathType.Extrusion);
+    expect(preview.job.layers[1].paths[0].vertices).toEqual([20, 20, 0.4, 10, 20, 0.4]);
+  });
+
+  test('tool changes land on the same paths', async () => {
+    const gcode = [
+      'G28',
+      'T0',
+      'G0 X10 Y10 Z0.2',
+      'G1 X20 Y10 E1', // extruded with tool 0
+      'G0 X20 Y15', // travel so the tool change starts a fresh path
+      'T1',
+      'G1 X30 Y15 E1' // extruded with tool 1
+    ].join('\n');
+
+    await ingest(preview, gcode);
+
+    expect(preview.job.state.tool).toEqual(1);
+    expect(preview.job.paths.length).toEqual(4);
+    expect(preview.job.paths[1].tool).toEqual(0);
+    expect(preview.job.paths[3].tool).toEqual(1);
+    expect(preview.job.toolPaths[0]).toEqual([preview.job.paths[1]]);
+    expect(preview.job.toolPaths[1]).toEqual([preview.job.paths[3]]);
+    expect(preview.job.paths[3].vertices).toEqual([20, 15, 0.2, 30, 15, 0.2]);
+  });
+
+  test('comments and blank lines leave the command stream untouched', async () => {
+    // The long standalone comment guarantees the 7-byte chunker cuts inside
+    // comment text; the blank lines exercise empty-line handling per chunk.
+    const gcode = [
+      '; header comment long enough that a seven-byte chunker slices it mid-sentence',
+      'G28',
+      '',
+      'G0 X10 Y10 Z0.5',
+      '; standalone comment between two moves',
+      'G1 X20 Y10 E1 ; inline comment',
+      '',
+      'G1 X20 Y20 E1'
+    ].join('\n');
+
+    await ingest(preview, gcode);
+
+    expect(preview.job.paths.length).toEqual(2);
+    expect(preview.job.paths[0].vertices).toEqual([0, 0, 0, 10, 10, 0.5]);
+    expect(preview.job.paths[1].vertices).toEqual([10, 10, 0.5, 20, 10, 0.5, 20, 20, 0.5]);
+    expect(preview.job.state.x).toEqual(20);
+    expect(preview.job.state.y).toEqual(20);
+    expect(preview.job.state.z).toEqual(0.5);
+  });
+
+  // NOTE: a thumbnail-equivalence test deliberately does NOT live here yet.
+  // Parser.parseMetadata keeps its in-progress thumbnail in a local variable,
+  // so a multi-line thumbnail block that spans more than one parseGCode call
+  // (i.e. more than one stream chunk) is silently dropped in streaming mode
+  // while oneshot parses it fine. Add the test once that is fixed.
+
+  test('known extrusion coordinates produce the exact same bounding box', async () => {
+    // The bounding box only tracks extrusion endpoints, so the corners come
+    // straight from the three G1 targets below.
+    const gcode = ['G28', 'G0 X10 Y10 Z1', 'G1 X30 Y10 E1', 'G1 X30 Y25 E1', 'G1 X10 Y10 E1'].join('\n');
+
+    await ingest(preview, gcode);
+
+    expect(preview.job.boundingBox.isValid).toBe(true);
+    expect(preview.job.boundingBox.corners).toEqual({
+      min: expect.objectContaining({ x: 10, y: 10, z: 1 }),
+      max: expect.objectContaining({ x: 30, y: 25, z: 1 })
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `src/__tests__/ingestion-equivalence.ts`, a test harness where every test automatically runs under multiple ingestion modes via `describe.each`. Any test written inside the block covers both `processGCode` (oneshot) and `processGCodeStream` (streaming) for free, and must reproduce concrete expected values (exact path counts, vertex coordinates, layer/tool indexes, bounding-box corners) independently in every mode — modes are never just diffed against each other, so a bug shared by both pipelines can't hide.

## The chunk-size matrix

| Mode | Why |
| --- | --- |
| `oneshot` | the reference path: one `parseGCode` call |
| `stream chunk=1` | worst case for the splitter — every character is its own chunk |
| `stream chunk=7` | boundaries land mid-word, mid-number and mid-comment |
| `stream chunk=64k` | the whole file arrives as a single chunk |

Chunking is deterministic (fixed-size slices, no randomness) so failures reproduce exactly. Stream modes run with `{ render: false }` to skip progressive draws; the suite builds a real `GCodePreview` under happy-dom with only `THREE.WebGLRenderer` mocked, so the real Parser, Interpreter, Job, SceneManager and three.js geometry are exercised end to end.

## Why this builds on #415

The equivalence only holds because #415 fixed the streaming pipeline: `splitChunk` now carries a no-newline chunk into its tail instead of splitting before the last character, `readStream` flushes the leftover tail after the read loop, and empty chunks no longer end the stream early. On the previous behavior, the chunk=1 mode would corrupt or lose data and most of these tests would fail. (This was authored as a stacked PR on `fix-stream-data-loss`, which merged while it was in flight, so it now targets develop directly.)

## Tests that landed

- multi-move file → exact paths, travel types and vertices
- file without a trailing newline → final command still lands (direct regression companion to #415's tail flush)
- two-layer print → layer count, layer Z heights, paths per layer
- multi-tool (`T0`/`T1`) → `state.tool` and per-path tools
- comments and blank lines interleaved (including comments split mid-way by the chunkers) → command-derived state untouched
- known extrusion coordinates → exact bounding-box corners

## Known gap: thumbnails

A thumbnail-equivalence test was written and deliberately dropped: it exposed a genuine pre-existing discrepancy not covered by #415. `Parser.parseMetadata` keeps its in-progress thumbnail in a local variable, so a multi-line thumbnail block spanning more than one `parseGCode` call (i.e. more than one stream chunk) is silently dropped in streaming mode while oneshot parses it fine. A note in the file marks where the test belongs once that is fixed.

## Adding equivalence tests

Write a `test(...)` inside the `describe.each(MODES)` block, call `await ingest(preview, gcode)`, and assert concrete values derived line-by-line from the fixture. All helpers (chunkers, `makeStream`, the preview factory) live in this file on purpose — the vitest config collects every `.ts` under `src/__tests__` as a suite, so a helper module would fail the run as an empty suite. Streaming-only behaviors (render throttling, `onJobUpdated` cadence) belong in the `gcode-preview.ts` tests instead.

Assisted by Claude Code - Fable 5