### PR TITLE
Keep in-progress thumbnails across streamed chunks

### DIFF
--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -82,6 +82,20 @@ const streamIngest =
     await preview.processGCodeStream(makeStream(chunksOf(gcode, size)), { render: false });
   };
 
+// 856 base64 chars of a 16x16 PNG, same fixture as parse-thumbnail.ts. Copied
+// rather than imported: importing another test file would re-register its
+// tests inside this suite.
+const thumbnailPng =
+  `iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACSElEQVR4AXVSW08TURDuHyHSG9vunS21LaX0okiRQq1tipegwSAQQdNoG1ZBGogBJUo0GIiisIlN2sSEB+KDJvgiMSY+uIn8kf0Hw5mT7LIt9GHOmTnnzPfNd2YcHMcN8DyfFgQhw7Js0vTNOBeVyh9uBY/zMVk9796BDoLgbl6aoPPDinY4E4I/j6LUno4EasW4olZzIbrjG0c75umUoO3fVeBgImABoP0txUBNuaBxJwAUABdRFK+ZibgvjAbr+Hhl0AvVK94mgO08D3s3JNifCEKvyJQc9pLNKiaTvHZwrwfWrjKwdZ2niUezEdgY9cNUuAP+z6fgXzkOfbJfPRegX/aV1KQLdsdEi3V5sAumSfJyuosCfJ+JnEqwa8c4obBqOeGEJ3EnrJIqkHU9w8Dzyx4LYDUr6VYX0LG3c6cowlaOgx/3L8Lj/k542HcB3mVZqBDQT2MS6JUkRCVf2eqCvX0beeUYmV5nfLA2xFgALwgzAjTGFVgk9+Z7hzkDaOs5Wd8tCvCesO8R/egjAAJ+uSmRf/DCIdGe7vbUmgYJHdT0mSSgLZGESsprfCzwUB3wUIBvkyHj51zMeDbSUzP/CttPP3ElI+jI+OtBGN5keePVMEOrmAp1wMsMZ7wl+jdJnJbdmr1bVAIG+Pj3XC/Ub8uUaYcwL1xyw9fxbnIeAQRIie4m5iYJYdG/uF0QaRJWgXY0GyZDxMGQ4qm1TuoZADwI` +
+  `8oxaCHTqDcK6mWNhiWhP8E6tNaEtgHkQF1z1hOCut0tojU8AXkBuxgoBg+8AAAAASUVORK5CYII=`;
+
+/** The fixture PNG as a slicer would embed it: begin marker, data lines, end. */
+const thumbnailBlock = [
+  '; thumbnail begin 16x16 856',
+  ...chunksOf(thumbnailPng, 78).map((part) => `; ${part}`),
+  '; thumbnail end'
+].join('\n');
+
 const MODES: [name: string, ingest: Ingest][] = [
   [
     'oneshot',
@@ -213,11 +227,23 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
     expect(preview.job.state.z).toEqual(0.5);
   });
 
-  // NOTE: a thumbnail-equivalence test deliberately does NOT live here yet.
-  // Parser.parseMetadata keeps its in-progress thumbnail in a local variable,
-  // so a multi-line thumbnail block that spans more than one parseGCode call
-  // (i.e. more than one stream chunk) is silently dropped in streaming mode
-  // while oneshot parses it fine. Add the test once that is fixed.
+  test('an embedded multi-line thumbnail parses identically', async () => {
+    // The 13-line thumbnail block guarantees the streaming modes deliver it
+    // across many parseGCode calls, so the parser must carry its in-progress
+    // thumbnail between calls. Regression test: it used to keep that state in
+    // a local variable, so streaming silently yielded no thumbnail at all
+    // while oneshot parsed it fine.
+    const gcode = [thumbnailBlock, 'G28', 'G0 X10 Y10 Z0.2', 'G1 X20 Y10 E1'].join('\n');
+
+    await ingest(preview, gcode);
+
+    const thumbnails = preview.parser.metadata.thumbnails;
+    expect(Object.keys(thumbnails)).toEqual(['16x16']);
+    expect(thumbnails['16x16'].chars.length).toEqual(856);
+    expect(thumbnails['16x16'].isValid).toBe(true);
+    // the surrounding commands still parse as usual
+    expect(preview.job.paths.length).toEqual(2);
+  });
 
   test('known extrusion coordinates produce the exact same bounding box', async () => {
     // The bounding box only tracks extrusion endpoints, so the corners come

--- a/src/__tests__/parse-thumbnail.ts
+++ b/src/__tests__/parse-thumbnail.ts
@@ -95,6 +95,34 @@ test('only 1 thumbnail should be parsed if "end thumbnail" is missing for the fi
   expect(secondThumb.charLength).toEqual(secondThumb.chars.length);
 });
 
+test('thumbnail split mid-base64 across parseGCode calls should be parsed', () => {
+  // Streaming feeds each chunk to parseGCode separately, so the in-progress
+  // thumbnail must survive between calls on the same Parser instance.
+  const parser = new Parser(0);
+  const lines = gcodeCommentsWithThumbnail.trim().split('\n');
+
+  parser.parseGCode(lines.slice(0, 5).join('\n')); // begin + first data lines
+  parser.parseGCode(lines.slice(5, 9).join('\n')); // more base64, no markers
+  parser.parseGCode(lines.slice(9).join('\n')); // rest of the data + end
+
+  expect(Object.keys(parser.metadata.thumbnails).length).toEqual(1);
+  const thumb = Object.values(parser.metadata.thumbnails)[0] as Thumbnail;
+  expect(thumb.chars).toEqual(encodedImg);
+  expect(thumb.isValid).toBeTruthy();
+});
+
+test('thumbnail split between "thumbnail begin" and the data should be parsed', () => {
+  const parser = new Parser(0);
+  const lines = gcodeCommentsWithThumbnail.trim().split('\n');
+
+  parser.parseGCode(lines[0]); // only '; thumbnail begin 16x16 856'
+  parser.parseGCode(lines.slice(1).join('\n')); // all data lines + end
+
+  expect(Object.keys(parser.metadata.thumbnails).length).toEqual(1);
+  const thumb = Object.values(parser.metadata.thumbnails)[0] as Thumbnail;
+  expect(thumb.isValid).toBeTruthy();
+});
+
 test('skip thumb if not base64', () => {
   const parser = new Parser(0);
   const gcodeWithIllegalBase64 =

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -162,6 +162,15 @@ export class Parser {
   private metadataParser: SlicerMetadataParser | null = null;
 
   /**
+   * Thumbnail currently being accumulated, between a 'thumbnail begin' comment
+   * and its 'thumbnail end'. Kept on the instance (not local to a single
+   * parseMetadata call) so a block that spans multiple parseGCode calls -- as
+   * happens when streaming cuts the file mid-thumbnail -- keeps accumulating
+   * instead of being silently dropped.
+   */
+  private inProgressThumb?: Thumbnail;
+
+  /**
    * How many lines have been parsed, counting every call.
    * @remarks
    * Tracked whether or not the lines themselves are kept. Counts exactly what
@@ -360,6 +369,12 @@ export class Parser {
    * until it encounters the end marker. Once complete, it validates the
    * thumbnail data before storing it in the thumbnails record.
    *
+   * The in-progress thumbnail lives on the parser instance, so a block that
+   * spans multiple calls (a streaming parse hands each chunk to parseGCode
+   * separately) accumulates across them. Each call returns only the
+   * thumbnails completed during that call; a block still open at the end of
+   * a call carries into the next one.
+   *
    * @example
    * ```typescript
    * const commands = parser.parseGCode(gcode).commands;
@@ -369,8 +384,6 @@ export class Parser {
   parseMetadata(metadata: GCodeCommand[]): Metadata {
     const thumbnails: Record<string, Thumbnail> = {};
 
-    let thumb: Thumbnail | undefined;
-
     for (const cmd of metadata) {
       const comment = cmd.comment;
       if (!comment) continue;
@@ -378,15 +391,15 @@ export class Parser {
       const idxThumbEnd = comment.indexOf('thumbnail end');
 
       if (idxThumbBegin > -1) {
-        thumb = Thumbnail.parse(comment.slice(idxThumbBegin + 15).trim());
-      } else if (thumb) {
+        this.inProgressThumb = Thumbnail.parse(comment.slice(idxThumbBegin + 15).trim());
+      } else if (this.inProgressThumb) {
         if (idxThumbEnd == -1) {
-          thumb.chars += comment.trim();
+          this.inProgressThumb.chars += comment.trim();
         } else {
-          if (thumb.isValid) {
-            thumbnails[thumb.size] = thumb;
+          if (this.inProgressThumb.isValid) {
+            thumbnails[this.inProgressThumb.size] = this.inProgressThumb;
           }
-          thumb = undefined;
+          this.inProgressThumb = undefined;
         }
       }
     }

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -168,7 +168,7 @@ export class Parser {
    * happens when streaming cuts the file mid-thumbnail -- keeps accumulating
    * instead of being silently dropped.
    */
-  private inProgressThumb?: Thumbnail;
+  private thumb?: Thumbnail;
 
   /**
    * How many lines have been parsed, counting every call.
@@ -391,15 +391,15 @@ export class Parser {
       const idxThumbEnd = comment.indexOf('thumbnail end');
 
       if (idxThumbBegin > -1) {
-        this.inProgressThumb = Thumbnail.parse(comment.slice(idxThumbBegin + 15).trim());
-      } else if (this.inProgressThumb) {
+        this.thumb = Thumbnail.parse(comment.slice(idxThumbBegin + 15).trim());
+      } else if (this.thumb) {
         if (idxThumbEnd == -1) {
-          this.inProgressThumb.chars += comment.trim();
+          this.thumb.chars += comment.trim();
         } else {
-          if (this.inProgressThumb.isValid) {
-            thumbnails[this.inProgressThumb.size] = this.inProgressThumb;
+          if (this.thumb.isValid) {
+            thumbnails[this.thumb.size] = this.thumb;
           }
-          this.inProgressThumb = undefined;
+          this.thumb = undefined;
         }
       }
     }


### PR DESCRIPTION
## The bug

`Parser.parseMetadata` kept its in-progress thumbnail in a local variable (`let thumb`). Streaming hands each chunk to `parseGCode` separately, so a multi-line `; thumbnail begin ... ; thumbnail end` block that spans a chunk boundary lost its half-built accumulator between calls: streaming silently yielded no thumbnail at all while oneshot parsed the very same file fine. The layer-metadata accumulation right below even had a comment claiming it accumulates "like thumbnails above" — thumbnails didn't actually accumulate.

The ingestion-equivalence harness in #416 caught this empirically: its thumbnail test passed under oneshot and chunk=64k but failed under chunk=1 and chunk=7, so the test had to be dropped with a NOTE pointing here.

## The fix

The in-progress thumbnail now lives on the parser instance (`private inProgressThumb`), mirroring the layer-metadata accumulation pattern, so a block spanning multiple `parseGCode`/`parseMetadata` calls keeps accumulating. Semantics are otherwise unchanged: each `parseMetadata` call returns only the thumbnails completed during that call, a block left open carries into the next call, and a `thumbnail end` without a valid accumulated thumb behaves as before. No reset needed — `GCodePreview` constructs a fresh `Parser` per job.

## Tests

- Re-enabled the previously dropped thumbnail equivalence test: a 13-line thumbnail block embedded in a larger file must parse identically (same size key, chars length 856, `isValid`) in **all** ingestion modes, including chunk=1 and chunk=7.
- Added focused unit regressions in `parse-thumbnail.ts`: a block split mid-base64 across three `parseGCode` calls, and one split between `thumbnail begin` and the first data line, both end up as a valid thumbnail on `parser.metadata.thumbnails`.

Coverage stays at 100% across the repo (`npm run test:coverage`, 789 tests), `typeCheck` and `lint` clean.

Assisted by Claude Code - Fable 5