### PR TITLE
Add a G31 straight probe handler

### DIFF
--- a/src/__tests__/interpreter/commands/probe.ts
+++ b/src/__tests__/interpreter/commands/probe.ts
@@ -108,6 +108,16 @@ describe('probe (G31)', () => {
     expect(job.paths[0].vertices).toEqual([0, 0, 0, 5, 0, 0, 5, 0, -2]);
   });
 
+  test('a repeated probe without a lift stays at the trigger plane', () => {
+    // fast-probe-then-slow-probe without an intervening retract: the head is
+    // already sitting on the trigger, so the second probe must not dive
+    // through the plane
+    const job = run(['G0 Z0.5', 'G31 Z-10', 'G31 Z-2'].join('\n'));
+
+    expect(job.state.z).toEqual(0);
+    expect(job.paths[0].vertices.slice(-1)[0]).toEqual(0);
+  });
+
   test('a touch-off cycle converges instead of drifting upward', () => {
     // The mach3.gcode idiom: probe, re-zero, lift, re-zero — twice. Without the
     // assumed Z0 trigger the position shift would grow every cycle (#437).

--- a/src/__tests__/interpreter/commands/probe.ts
+++ b/src/__tests__/interpreter/commands/probe.ts
@@ -1,0 +1,125 @@
+import { test, expect, describe } from 'vitest';
+import { Parser, GCodeCommand } from '../../../parser/gcode-parser';
+import { Interpreter } from '../../../interpreter';
+import { probe } from '../../../interpreter/commands';
+import { Job } from '../../../job';
+import { PathType } from '../../../path';
+
+describe('probe (G31)', () => {
+  const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
+
+  test('a downward Z probe crossing the origin plane is assumed to trigger at Z0', () => {
+    const command = new GCodeCommand('G31 Z-11.8', 'g31', { z: -11.8 });
+    const job = new Job();
+    job.state.z = 0.2;
+
+    probe(command, job);
+
+    expect(job.state.z).toEqual(0);
+    expect(job.stats.points).toEqual(1);
+  });
+
+  test('a probe to a target above the origin plane travels to the commanded target', () => {
+    const command = new GCodeCommand('G31 Z2', 'g31', { z: 2 });
+    const job = new Job();
+    job.state.z = 5;
+
+    probe(command, job);
+
+    expect(job.state.z).toEqual(2);
+  });
+
+  test('a probe starting at or below the origin plane travels to the commanded target', () => {
+    const command = new GCodeCommand('G31 Z-5', 'g31', { z: -5 });
+    const job = new Job();
+    job.state.z = -1;
+
+    probe(command, job);
+
+    expect(job.state.z).toEqual(-5);
+  });
+
+  test('X/Y targets are kept as commanded while Z is clamped', () => {
+    const command = new GCodeCommand('G31 X1 Y2 Z-3', 'g31', { x: 1, y: 2, z: -3 });
+    const job = new Job();
+    job.state.z = 1;
+
+    probe(command, job);
+
+    expect(job.state.x).toEqual(1);
+    expect(job.state.y).toEqual(2);
+    expect(job.state.z).toEqual(0);
+  });
+
+  test('an X-only probe travels to the target without touching Z', () => {
+    const command = new GCodeCommand('G31 X5', 'g31', { x: 5 });
+    const job = new Job();
+    job.state.z = 3;
+
+    probe(command, job);
+
+    expect(job.state.x).toEqual(5);
+    expect(job.state.z).toEqual(3);
+  });
+
+  test('a G31 without axis words is ignored (Marlin dock-sled form)', () => {
+    const command = new GCodeCommand('G31', 'g31', {});
+    const job = new Job();
+
+    probe(command, job);
+
+    expect(job.paths.length).toEqual(0);
+    expect(job.inprogressPath).toBeUndefined();
+    expect(job.stats.points).toEqual(0);
+  });
+
+  test('a G31 with a P word is ignored (RepRapFirmware set-trigger form)', () => {
+    const command = new GCodeCommand('G31 P500 X0 Y0 Z2.6', 'g31', { p: 500, x: 0, y: 0, z: 2.6 });
+    const job = new Job();
+    job.state.z = 5;
+
+    probe(command, job);
+
+    expect(job.state.z).toEqual(5);
+    expect(job.inprogressPath).toBeUndefined();
+  });
+
+  test('probe targets are translated by the position shift', () => {
+    const job = run(['G0 X10', 'G92 X0', 'G31 X5'].join('\n'));
+
+    expect(job.state.x).toEqual(15);
+  });
+
+  test('renders as a travel move, breaking an in-progress extrusion', () => {
+    const job = run(['G1 X10 E1', 'G31 X20'].join('\n'));
+
+    expect(job.paths.length).toEqual(2);
+    expect(job.paths[0].travelType).toEqual(PathType.Extrusion);
+    expect(job.paths[1].travelType).toEqual(PathType.Travel);
+    expect(job.paths[1].vertices).toEqual([10, 0, 0, 20, 0, 0]);
+  });
+
+  test('continues an in-progress travel path', () => {
+    const job = run(['G0 X5', 'G31 Z-2'].join('\n'));
+
+    // starting at the assumed origin (un-homed), the probe cannot cross the
+    // origin plane, so it travels to the commanded depth
+    expect(job.paths.length).toEqual(1);
+    expect(job.paths[0].vertices).toEqual([0, 0, 0, 5, 0, 0, 5, 0, -2]);
+  });
+
+  test('a touch-off cycle converges instead of drifting upward', () => {
+    // The mach3.gcode idiom: probe, re-zero, lift, re-zero — twice. Without the
+    // assumed Z0 trigger the position shift would grow every cycle (#437).
+    const cycle = ['G0 Z0.2', 'G31 Z-11.8', 'G92 Z0', 'G0 Z0.039', 'G92 Z0'];
+    const job = run([...cycle, ...cycle].join('\n'));
+
+    expect(job.state.positionShift.z).toEqual(0.039);
+    expect(job.state.z).toEqual(0.039);
+    const { vertices } = job.paths[0];
+    // Both probes bottom out at physical Z0 (3rd and 6th points)
+    expect(vertices[8]).toEqual(0);
+    expect(vertices[17]).toEqual(0);
+    expect(vertices.slice(-1)[0]).toEqual(0.039);
+  });
+});

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8,6 +8,7 @@ import {
   setMillimeterUnits,
   home,
   setPosition,
+  probe,
   selectTool
 } from './interpreter/commands';
 
@@ -48,6 +49,7 @@ export const handlers: ReadonlyMap<string, CommandHandler> = new Map<string, Com
   ['g20', setInchUnits],
   ['g21', setMillimeterUnits],
   ['g28', home],
+  ['g31', probe],
   ['g92', setPosition],
   ['t0', selectTool],
   ['t1', selectTool],

--- a/src/interpreter/commands/index.ts
+++ b/src/interpreter/commands/index.ts
@@ -3,4 +3,5 @@ export { arcMove, makeArcMove } from './arc-move';
 export { setInchUnits, setMillimeterUnits } from './set-units';
 export { home } from './home';
 export { setPosition } from './set-position';
+export { probe } from './probe';
 export { selectTool } from './select-tool';

--- a/src/interpreter/commands/probe.ts
+++ b/src/interpreter/commands/probe.ts
@@ -7,11 +7,13 @@ import type { CommandHandler } from '../../interpreter';
  * @param job - Job instance to update
  * @remarks
  * A probe moves toward its target and stops on contact, at a point a previewer
- * cannot know. For a downward Z probe crossing the origin plane, the trigger
- * is assumed at physical Z0 (the material top on the origin plane), which
- * makes the G92 re-zeroes that follow a touch-off converge each cycle exactly
- * like on a real machine (see #437). Other probes render as a plain travel to
- * the commanded target. The trigger is assumed on the Z axis only; X/Y targets
+ * cannot know. A probe below the origin plane from a known Z at or above it is
+ * assumed to trigger at physical Z0 (the material top on the origin plane),
+ * which makes the G92 re-zeroes that follow a touch-off converge each cycle
+ * exactly like on a real machine, and keeps a repeated probe without a lift
+ * sitting on the plane instead of diving through it (see #437). Other probes —
+ * including from an un-homed Z, whose real position is unknown — render as a
+ * plain travel to the commanded target. The trigger is assumed on the Z axis only; X/Y targets
  * are kept as commanded. A G31 carrying a P word is RepRapFirmware's
  * set-trigger-values form, not a move, and is ignored; one without any axis
  * words (e.g. Marlin's dock-sled G31) is also ignored.
@@ -33,8 +35,7 @@ export const probe: CommandHandler = (command, job) => {
     return;
   }
 
-  const from = job.resolvePosition();
-  if (z !== undefined && z < 0 && from.z > 0) {
+  if (z !== undefined && z < 0 && state.z !== undefined && state.z >= 0) {
     z = 0;
   }
 

--- a/src/interpreter/commands/probe.ts
+++ b/src/interpreter/commands/probe.ts
@@ -1,0 +1,54 @@
+import { PathType } from '../../path';
+import type { CommandHandler } from '../../interpreter';
+
+/**
+ * Executes a straight probe command (G31, G38.2-G38.5)
+ * @param command - GCodeCommand containing the probe target
+ * @param job - Job instance to update
+ * @remarks
+ * A probe moves toward its target and stops on contact, at a point a previewer
+ * cannot know. For a downward Z probe crossing the origin plane, the trigger
+ * is assumed at physical Z0 (the material top on the origin plane), which
+ * makes the G92 re-zeroes that follow a touch-off converge each cycle exactly
+ * like on a real machine (see #437). Other probes render as a plain travel to
+ * the commanded target. The trigger is assumed on the Z axis only; X/Y targets
+ * are kept as commanded. A G31 carrying a P word is RepRapFirmware's
+ * set-trigger-values form, not a move, and is ignored; one without any axis
+ * words (e.g. Marlin's dock-sled G31) is also ignored.
+ */
+export const probe: CommandHandler = (command, job) => {
+  const { state } = job;
+  const { params } = command;
+
+  if (params.p !== undefined) {
+    return;
+  }
+
+  const { positionShift } = state;
+  const x = params.x === undefined ? undefined : params.x + positionShift.x;
+  const y = params.y === undefined ? undefined : params.y + positionShift.y;
+  let z = params.z === undefined ? undefined : params.z + positionShift.z;
+
+  if (x === undefined && y === undefined && z === undefined) {
+    return;
+  }
+
+  const from = job.resolvePosition();
+  if (z !== undefined && z < 0 && from.z > 0) {
+    z = 0;
+  }
+
+  job.stats.points++;
+
+  let currentPath = job.inprogressPath;
+  if (currentPath === undefined || currentPath.travelType !== PathType.Travel) {
+    currentPath = job.breakPath(PathType.Travel);
+  }
+
+  state.x = x ?? state.x;
+  state.y = y ?? state.y;
+  state.z = z ?? state.z;
+
+  const pos = job.resolvePosition();
+  currentPath.addPoint(pos.x, pos.y, pos.z);
+};


### PR DESCRIPTION
Part of #437 — implements G31 only; the G38.x family lands in the follow-up PR stacked on this one. Stacked on #436 (`positionShift`), which this PR's heuristic depends on.

## What this does

Adds a `probe` handler (`src/interpreter/commands/probe.ts`) registered for `g31` (Mach3's straight probe, the core of CNC touch-off cycles).

A probe moves toward its target and stops on contact — at a point a previewer cannot know. The handler resolves that with the heuristic from #437:

- A **probe below the origin plane from a known Z at or above it** is assumed to trigger at **physical Z0** — the material top on the origin plane. This makes the `G92 Z0` re-zeroes that follow every touch-off converge each cycle exactly like on a real machine, instead of accumulating +0.239 of position shift per pierce (the upward drift visible on mach3.gcode with #436 alone). It also keeps a repeated probe without an intervening lift (the fast-probe-then-slow-probe pattern) sitting on the plane instead of diving through it — the clamp keys on the *known* `state.z`, so an un-homed Z (merely assumed at 0) still falls through to the commanded target.
- Any other probe (upward, starting at/below the plane, or X/Y probes) renders as a plain **travel to the commanded target**. The trigger is only assumed on the Z axis; X/Y targets are kept as commanded.
- Probe targets are translated through `positionShift` like every other move, and the probe renders as a travel move (breaking an in-progress extrusion path, continuing an in-progress travel).

## Dialect guards

- `G31` with a **P word** is RepRapFirmware's set-trigger-values configuration form, not a move — ignored.
- `G31` without any axis words (e.g. Marlin's dock-sled G31) is ignored.

## Testing

Unit + full `Parser` → `Interpreter` pipeline tests cover the clamp matrix (downward-crossing, above-plane target, starting below the plane, X/Y-only), both dialect guards, shift translation, travel path behavior, and a two-cycle mach3-style touch-off asserting the position shift converges to 0.039 instead of growing. 792 tests pass with 100% per-file coverage.

## Screenshots

Captured from the demo at identical viewports and scripted cameras, this branch vs its base (`g92-command-support`, i.e. #436 without probe support). Images live on the throwaway [`pr438-assets`](https://github.com/xyz-tools/gcode-preview/tree/pr438-assets) branch — delete it after merge.

### mach3.gcode (the #437 repro)

With G92 alone the touch-off cycles accumulate +0.239 of position shift per pierce and the later cut passes hover above the plate (max Z 1.978). With G31, each probe renders its descent to the assumed Z0 trigger and the re-zeroes converge (max Z 1.539, cuts hugging the plate).

| this PR (G31) | base (#436, G31 ignored) |
|---|---|
| ![mach3 with G31](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr438-assets/pr438-mach3-g31.png) | ![mach3 without G31](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr438-assets/pr438-mach3-base.png) |

### Synthetic touch-off

```gcode
G28
G0 X60 Y60 Z5
G31 Z-10
G92 Z0
G0 Z0.2
G1 X120 Y60 E1
G1 X120 Y120 E1
G1 X60 Y120 E1
G1 X60 Y60 E1
```

With G31 the probe descends from Z5 to the assumed trigger at Z0, so the `G92 Z0` anchors to the plate and the square is cut at Z0.2 (probe descent visible in red at the near corner). Without it, `G92 Z0` fires at Z5 and the whole square floats at Z5.2.

| this PR (G31) | base (#436, G31 ignored) |
|---|---|
| ![touch-off with G31](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr438-assets/pr438-probe-demo-g31.png) | ![touch-off without G31](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr438-assets/pr438-probe-demo-base.png) |

Assisted by Claude Code - Fable 5
