### PR TITLE
Render on demand instead of every frame

### DIFF
--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -95,6 +95,7 @@ describe('public API surface', () => {
 
     const methods: Record<string, number> = {
       updateClippingPlanes: 0,
+      animate: 0,
       requestRender: 0,
       render: 0,
       renderAnimated: 0,

--- a/src/__tests__/public-api.ts
+++ b/src/__tests__/public-api.ts
@@ -95,7 +95,7 @@ describe('public API surface', () => {
 
     const methods: Record<string, number> = {
       updateClippingPlanes: 0,
-      animate: 0,
+      requestRender: 0,
       render: 0,
       renderAnimated: 0,
       clear: 0,

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -1348,6 +1348,19 @@ describe('SceneManager properties', () => {
       expect(renderCount()).toBe(drawn + 1);
     });
 
+    test('the deprecated animate() alias schedules a single on-demand frame', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      sceneManager.animate();
+      await flushFrame();
+
+      // one frame, and no self-rearming loop afterwards
+      expect(renderCount()).toBe(drawn + 1);
+      await flushFrame();
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
     test('the orthographic swap replaces the controls in the disposables', () => {
       const oldControls = sceneManager.controls;
 

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -34,6 +34,15 @@ vi.mock('three/examples/jsm/controls/OrbitControls.js', () => {
       screenSpacePanning = false;
       update = vi.fn();
       dispose = vi.fn();
+      // enough of an EventDispatcher for the on-demand rendering wiring: the
+      // SceneManager listens for 'change' and the tests fire it
+      private listeners: Record<string, Array<() => void>> = {};
+      addEventListener(type: string, listener: () => void) {
+        (this.listeners[type] ??= []).push(listener);
+      }
+      dispatchEvent({ type }: { type: string }) {
+        (this.listeners[type] ?? []).forEach((listener) => listener());
+      }
     }
   };
 });
@@ -79,7 +88,7 @@ describe('SceneManager properties', () => {
   });
 
   afterEach(() => {
-    // stops the requestAnimationFrame loop started by the constructor
+    // cancels any on-demand frame still pending from the constructor or a setter
     sceneManager.dispose();
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -1226,13 +1235,130 @@ describe('SceneManager properties', () => {
       fresh.dispose();
     });
 
-    test('reports each rendered frame through onFrameRendered', () => {
+    test('reports each rendered frame through onFrameRendered', async () => {
       const onFrameRendered = vi.fn();
       sceneManager.onFrameRendered = onFrameRendered;
 
-      sceneManager.animate();
+      sceneManager.requestRender();
+      await flushFrame();
 
       expect(onFrameRendered).toHaveBeenCalled();
+    });
+  });
+
+  describe('on-demand rendering', () => {
+    const renderCount = () => vi.mocked(sceneManager.renderer.render).mock.calls.length;
+
+    test('the constructor schedules the first frame instead of drawing synchronously', async () => {
+      expect(renderCount()).toBe(0);
+
+      await flushFrame();
+
+      expect(renderCount()).toBe(1);
+    });
+
+    test('an idle scene draws no further frames', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      await flushFrame();
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn);
+    });
+
+    test('camera movement reported by the controls requests a frame', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      sceneManager.controls.dispatchEvent({ type: 'change' });
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
+    test('a burst of changes coalesces into a single frame', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      sceneManager.backgroundColor = '#123456';
+      sceneManager.travelColor = '#654321';
+      sceneManager.ambientLight = 0.5;
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
+    test('every visual property change requests a frame', () => {
+      const requested = vi.spyOn(sceneManager, 'requestRender');
+
+      const mutations: Array<() => void> = [
+        () => (sceneManager.backgroundColor = '#111111'),
+        () => (sceneManager.extrusionColor = '#222222'),
+        () => (sceneManager.travelColor = '#333333'),
+        () => (sceneManager.boundingBoxColor = '#444444'),
+        () => (sceneManager.buildVolume = { x: 100, y: 100, z: 100 }),
+        () => (sceneManager.startLayer = 1),
+        () => (sceneManager.endLayer = 2),
+        () => (sceneManager.singleLayerMode = true),
+        () => (sceneManager.renderExtrusion = false),
+        () => (sceneManager.renderTravel = true),
+        () => (sceneManager.ambientLight = 0.6),
+        () => (sceneManager.directionalLight = 1.1),
+        () => (sceneManager.brightness = 1.0),
+        () => sceneManager.resize()
+      ];
+
+      mutations.forEach((mutate, index) => {
+        mutate();
+        // strictly monotonic: each mutation added at least one request of its own
+        expect(requested.mock.calls.length).toBeGreaterThan(index);
+      });
+    });
+
+    test('the orthographic swap keeps camera movement requesting frames', async () => {
+      sceneManager.orthographic = true;
+      await flushFrame();
+      const drawn = renderCount();
+
+      // the swap replaced the controls; the listener must be bound to the new ones
+      sceneManager.controls.dispatchEvent({ type: 'change' });
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
+    test('renderProgressive requests a frame to present the new paths', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      sceneManager.renderProgressive();
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
+    test('clear requests a frame to present the emptied scene', async () => {
+      await flushFrame();
+      const drawn = renderCount();
+
+      sceneManager.clear();
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn + 1);
+    });
+
+    test('a geometry rebuild with no job presents the emptied scene without a rebuild', () => {
+      vi.useFakeTimers();
+      sceneManager.clear(); // leaves the manager without a job
+      const requested = vi.spyOn(sceneManager, 'requestRender');
+      const rendered = vi.spyOn(sceneManager, 'render');
+
+      sceneManager.lineWidth = 5;
+      vi.advanceTimersByTime(ObjectsManager.rebuildDebounce);
+
+      expect(requested).toHaveBeenCalled();
+      expect(rendered).not.toHaveBeenCalled();
     });
   });
 
@@ -1329,6 +1455,11 @@ describe('SceneManager properties', () => {
     });
   });
 });
+
+/** Waits for the animation frame an on-demand render is scheduled on. */
+function flushFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
 
 /** Reaches the private ObjectsManager the SceneManager delegates to. */
 function objectsManager(sceneManager: SceneManager): ObjectsManager {

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -1348,6 +1348,35 @@ describe('SceneManager properties', () => {
       expect(renderCount()).toBe(drawn + 1);
     });
 
+    test('the orthographic swap replaces the controls in the disposables', () => {
+      const oldControls = sceneManager.controls;
+
+      sceneManager.orthographic = true;
+      const newControls = sceneManager.controls;
+      sceneManager.dispose();
+
+      // the swap disposed the old controls once by hand; dispose() must tear
+      // down the replacement instead of revisiting the dead ones
+      expect(vi.mocked(oldControls.dispose)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(newControls.dispose)).toHaveBeenCalledTimes(1);
+    });
+
+    test('a change event after dispose draws nothing on the disposed renderer', async () => {
+      const oldControls = sceneManager.controls;
+      sceneManager.orthographic = true;
+      await flushFrame(); // drain the frame the toggle itself requested
+      const drawn = renderCount();
+
+      sceneManager.dispose();
+      // neither the swap's undead controls nor the live ones may schedule a
+      // draw once the manager is disposed
+      oldControls.dispatchEvent({ type: 'change' });
+      sceneManager.controls.dispatchEvent({ type: 'change' });
+      await flushFrame();
+
+      expect(renderCount()).toBe(drawn);
+    });
+
     test('a geometry rebuild with no job presents the emptied scene without a rebuild', () => {
       vi.useFakeTimers();
       sceneManager.clear(); // leaves the manager without a job

--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -1,19 +1,14 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { test, expect, vi, assert } from 'vitest';
+import { test, expect, vi } from 'vitest';
 
 import { SceneManager } from '../scene-manager';
 import { GCodeCommand } from '../parser/gcode-parser';
 
-// add a test for destroying the scene manager which should cancel the render loop.
-test('destroying the scene manager should dispose renderer and controls', async () => {
+test('destroying the scene manager should dispose renderer and controls', () => {
   const mock = createMockSceneManager();
   // dispose() empties the array, so keep a reference to assert against afterwards
   const disposables = [...mock.disposables];
-
-  SceneManager.prototype.animate.call(mock);
-  // wait 50ms
-  await new Promise((resolve) => setTimeout(resolve, 50));
 
   // destroy the scene manager
   SceneManager.prototype.dispose.call(mock);
@@ -27,44 +22,50 @@ test('destroying the scene manager should dispose renderer and controls', async 
   disposables.forEach((d) => {
     expect(d.dispose).toHaveBeenCalledTimes(1);
   });
-});
-
-// add a test for destroying the scene manager which should cancel the render loop.
-test('destroying the scene manager should call cancelAnimation', async () => {
-  const mock = createMockSceneManager();
-
-  SceneManager.prototype.animate.call(mock);
-
-  // wait 50ms
-  await new Promise((resolve) => setTimeout(resolve, 50));
-  let callCount = mock.renderer.render.mock.calls.length;
-  assert(callCount > 2, 'callCount > 2');
-  callCount = mock.controls.update.mock.calls.length;
-  assert(callCount > 2, 'callCount > 2');
-
-  // destroy the renderer
-  SceneManager.prototype.dispose.call(mock);
+  // no frame was pending, so there was nothing to cancel — but the id is cleared
   expect(mock.cancelAnimation).toHaveBeenCalledTimes(1);
 });
 
-test('cancelAnimation should cancel the render loop', async () => {
+test('requestRender draws exactly one frame, then goes idle', async () => {
   const mock = createMockSceneManager();
 
-  SceneManager.prototype.animate.call(mock);
-
-  // wait 50ms
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  mock.cancelAnimation();
+  SceneManager.prototype.requestRender.call(mock);
 
   await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(mock.renderer.render).toHaveBeenCalledTimes(1);
 
-  const callCountAfterDestroy = mock.renderer.render.mock.calls.length;
+  // no self-rearming loop: with nothing else requested, no further frames draw
   await new Promise((resolve) => setTimeout(resolve, 50));
-  const callCountAfterDestroy2 = mock.renderer.render.mock.calls.length;
+  expect(mock.renderer.render).toHaveBeenCalledTimes(1);
+});
 
-  // expect no more calls to render
-  expect(callCountAfterDestroy).toBe(callCountAfterDestroy2);
+test('a burst of requestRender calls coalesces into a single frame', async () => {
+  const mock = createMockSceneManager();
+
+  SceneManager.prototype.requestRender.call(mock);
+  SceneManager.prototype.requestRender.call(mock);
+  SceneManager.prototype.requestRender.call(mock);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(mock.renderer.render).toHaveBeenCalledTimes(1);
+
+  // the pending flag was cleared, so a new request draws a new frame
+  SceneManager.prototype.requestRender.call(mock);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(mock.renderer.render).toHaveBeenCalledTimes(2);
+});
+
+test('destroying the scene manager should cancel a pending frame', async () => {
+  const mock = createMockSceneManager();
+
+  SceneManager.prototype.requestRender.call(mock);
+
+  // destroy the scene manager before the frame fires
+  SceneManager.prototype.dispose.call(mock);
+  expect(mock.cancelAnimation).toHaveBeenCalledTimes(1);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(mock.renderer.render).not.toHaveBeenCalled();
 });
 
 test('renderProgressive draws the paths parsed so far, holding back the still-growing last one', () => {
@@ -146,7 +147,7 @@ function createMockSceneManager() {
     addLineSegment: () => {},
     doRenderExtrusion: () => {},
     render: vi.fn(() => {}),
-    animate: vi.fn(SceneManager.prototype.animate),
+    requestRender: vi.fn(SceneManager.prototype.requestRender),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     cancelAnimation: vi.fn(SceneManager.prototype.cancelAnimation)

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -106,7 +106,12 @@ export class GCodePreview {
     return this._sceneManager;
   }
 
-  /** Builds a SceneManager wired to feed the stats display. */
+  /**
+   * Builds a SceneManager wired to feed the stats display.
+   * @remarks
+   * Frames are rendered on demand, so the stats FPS panel counts renders per
+   * second: it reads 0 while the scene is idle, not the display's refresh rate.
+   */
   private createSceneManager(): SceneManager {
     const sceneManager = new SceneManager(this.opts, this.job);
     sceneManager.onFrameRendered = () => this.stats?.update();

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -675,6 +675,17 @@ export class SceneManager {
   }
 
   /**
+   * Schedules a coalesced on-demand frame, exactly like {@link requestRender}.
+   * @deprecated Use requestRender() instead.
+   * @remarks
+   * Kept for external callers of the old continuous loop's entry point. It no
+   * longer re-arms itself: one call draws (at most) one frame.
+   */
+  animate(): void {
+    this.requestRender();
+  }
+
+  /**
    * Requests a frame whenever the controls move the camera.
    * @remarks
    * Also called by the orthographic swap: listeners do not carry over to the

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -115,7 +115,7 @@ export class SceneManager {
   private disposables: Disposable[] = [];
   /** Default extrusion color */
   static readonly defaultExtrusionColor = ObjectsManager.defaultExtrusionColor;
-  /** Animation frame ID */
+  /** Handle of the frame scheduled by requestRender, if one is pending */
   private animationFrameId?: number;
   /** Previous start layer before single layer mode */
   private prevStartLayer = 0;
@@ -139,7 +139,9 @@ export class SceneManager {
   /**
    * Called after every rendered frame, for consumers that track render stats.
    * @remarks
-   * Holds a single callback: assigning it replaces any previous one.
+   * Holds a single callback: assigning it replaces any previous one. Frames
+   * are drawn on demand rather than continuously, so this reports renders
+   * per second — an idle scene reports nothing.
    */
   onFrameRendered?: () => void;
   private objectsManager: ObjectsManager;
@@ -214,10 +216,14 @@ export class SceneManager {
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.controls.target.set(this.buildVolume.x / 2, 0, -this.buildVolume.y / 2);
     this.disposables.push(this.controls);
+    this.bindControls();
     this.loadCamera();
+    // aim the camera at the target once: frames are drawn on demand, so there
+    // is no per-frame update() loop to do it (damping and auto-rotate are off)
+    this.controls.update();
 
     this.initScene();
-    this.animate();
+    this.requestRender();
   }
 
   /**
@@ -228,7 +234,12 @@ export class SceneManager {
    */
   private createObjectsManager(lineWidth: number, lineHeight?: number, extrusionWidth?: number): ObjectsManager {
     const manager = new ObjectsManager(this.scene, lineWidth, lineHeight, extrusionWidth, () => {
-      if (this.job) this.render();
+      if (this.job) {
+        this.render();
+      } else {
+        // no job to rebuild from, but the reset emptied the scene, so present that
+        this.requestRender();
+      }
     });
     this.disposables.push(manager);
 
@@ -249,6 +260,7 @@ export class SceneManager {
    */
   set buildVolume(value: BuildVolumeDef | undefined) {
     this.objectsManager.setBuildVolume(value);
+    this.requestRender();
   }
 
   /**
@@ -267,6 +279,7 @@ export class SceneManager {
     this.objectsManager.setExtrusionColor(
       Array.isArray(value) ? value.map((color) => new Color(color)) : new Color(value)
     );
+    this.requestRender();
   }
 
   /**
@@ -284,6 +297,7 @@ export class SceneManager {
   set backgroundColor(value: number | string | Color) {
     this._backgroundColor = new Color(value);
     this.scene.background = this._backgroundColor;
+    this.requestRender();
   }
 
   /**
@@ -300,6 +314,7 @@ export class SceneManager {
    */
   set travelColor(value: number | string | Color) {
     this.objectsManager.setTravelColor(new Color(value));
+    this.requestRender();
   }
 
   /**
@@ -368,6 +383,7 @@ export class SceneManager {
     this.objectsManager.setBoundingBoxColor(value !== undefined ? new Color(value) : undefined);
 
     this.renderBoundingBox();
+    this.requestRender();
   }
 
   /**
@@ -390,6 +406,7 @@ export class SceneManager {
     }
 
     this.updateClippingPlanes();
+    this.requestRender();
   }
 
   get renderExtrusion(): boolean {
@@ -399,6 +416,7 @@ export class SceneManager {
     this._renderExtrusion = value;
     this.objectsManager.setExtrusionsVisible(value);
     if (value) this.renderMissingPaths();
+    this.requestRender();
   }
 
   get renderTravel(): boolean {
@@ -408,6 +426,7 @@ export class SceneManager {
     this._renderTravel = value;
     this.objectsManager.setTravelsVisible(value);
     if (value) this.renderMissingPaths();
+    this.requestRender();
   }
 
   get renderTubes(): boolean {
@@ -511,6 +530,7 @@ export class SceneManager {
     }
 
     this.updateClippingPlanes();
+    this.requestRender();
   }
 
   /**
@@ -541,6 +561,7 @@ export class SceneManager {
 
     // the visible range moved, so the clipping planes have to follow
     this.updateClippingPlanes();
+    this.requestRender();
 
     // entering or leaving single-layer mode flips whether the gradient applies, so
     // rebuild the lines to avoid leaving the lone visible layer dimmed by the ramp
@@ -554,6 +575,7 @@ export class SceneManager {
   }
   set ambientLight(value: number) {
     this.objectsManager.setAmbientLight(value);
+    this.requestRender();
   }
 
   get directionalLight(): number {
@@ -561,6 +583,7 @@ export class SceneManager {
   }
   set directionalLight(value: number) {
     this.objectsManager.setDirectionalLight(value);
+    this.requestRender();
   }
 
   get brightness(): number {
@@ -568,6 +591,7 @@ export class SceneManager {
   }
   set brightness(value: number) {
     this.objectsManager.setBrightness(value);
+    this.requestRender();
   }
 
   get orthographic(): boolean {
@@ -586,6 +610,9 @@ export class SceneManager {
     this.controls.dispose();
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.controls.target.copy(oldTarget);
+    // the fresh controls have no listeners yet, so camera movement would stop
+    // requesting frames without this
+    this.bindControls();
     if (value) {
       this.controls.screenSpacePanning = true;
     }
@@ -616,16 +643,35 @@ export class SceneManager {
     return DEFAULT_FRUSTUM_SIZE;
   }
 
-  /** @internal */
   /**
-   * Animation loop that continuously renders the scene
-   * @internal
+   * Schedules a frame to be drawn on the next animation frame.
+   * @remarks
+   * Frames are drawn on demand instead of in a continuous loop: a burst of
+   * changes coalesces into a single draw, and an idle scene draws nothing at
+   * all. Everything that changes the picture — camera movement, the property
+   * setters, resize — requests a frame this way; call it directly after
+   * mutating the scene graph from the outside.
    */
-  animate(): void {
-    this.animationFrameId = requestAnimationFrame(() => this.animate());
-    this.controls.update();
-    this.renderer.render(this.scene, this.camera);
-    this.onFrameRendered?.();
+  requestRender(): void {
+    // the layer-range setters run in the constructor before the renderer
+    // exists; construction ends with a request of its own, so these can skip
+    if (!this.renderer) return;
+    if (this.animationFrameId !== undefined) return;
+    this.animationFrameId = requestAnimationFrame(() => {
+      this.animationFrameId = undefined;
+      this.renderer.render(this.scene, this.camera);
+      this.onFrameRendered?.();
+    });
+  }
+
+  /**
+   * Requests a frame whenever the controls move the camera.
+   * @remarks
+   * Also called by the orthographic swap: listeners do not carry over to the
+   * controls instance it creates, so each new instance is bound again.
+   */
+  private bindControls(): void {
+    this.controls.addEventListener('change', () => this.requestRender());
   }
 
   /**
@@ -690,13 +736,14 @@ export class SceneManager {
    * than calling this directly. Only paths that have not been drawn yet are
    * built, and the last path is held back: it may still be growing, and a
    * path is only ever built once. The top-layer/last-segment highlight, if
-   * configured, moves onto whatever has most recently arrived. The continuous
-   * animation loop presents the new geometry on the next frame.
+   * configured, moves onto whatever has most recently arrived. A frame is
+   * requested to present the new geometry.
    */
   renderProgressive(): void {
     if (!this.job) return;
 
     this.renderPaths(Math.max(0, this.job.paths.length - 1));
+    this.requestRender();
   }
 
   /**
@@ -774,6 +821,8 @@ export class SceneManager {
     this.objectsManager.extrusionColor = extrusionColor;
     this.objectsManager.travelColor = travelColor;
     if (buildVolumeDef) this.objectsManager.setBuildVolume(buildVolumeDef);
+    // present the emptied scene rather than leaving the old job's pixels up
+    this.requestRender();
   }
 
   resize(): void {
@@ -794,6 +843,7 @@ export class SceneManager {
     this.camera.updateProjectionMatrix();
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.renderer.setSize(w, h, false);
+    this.requestRender();
   }
 
   dispose(): void {
@@ -803,10 +853,9 @@ export class SceneManager {
   }
 
   /**
-   * Cancels the current animation frame request
+   * Cancels a frame scheduled by requestRender, if one is still pending
    * @remarks
-   * Stops the animation loop and clears the animation frame ID.
-   * Called during cleanup to prevent memory leaks.
+   * Called during cleanup so a disposed renderer is never asked to draw.
    */
   private cancelAnimation(): void {
     if (this.animationFrameId !== undefined) cancelAnimationFrame(this.animationFrameId);

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -117,6 +117,8 @@ export class SceneManager {
   static readonly defaultExtrusionColor = ObjectsManager.defaultExtrusionColor;
   /** Handle of the frame scheduled by requestRender, if one is pending */
   private animationFrameId?: number;
+  /** Set by dispose(); a disposed renderer must never be asked to draw again */
+  private disposed = false;
   /** Previous start layer before single layer mode */
   private prevStartLayer = 0;
   // colors
@@ -608,7 +610,12 @@ export class SceneManager {
     this.camera.position.copy(oldPosition);
 
     this.controls.dispose();
+    // the old controls were just disposed by hand, so swap their entry out of
+    // the disposables for the replacement — otherwise dispose() would revisit
+    // the dead ones and never tear down the live ones
+    this.disposables = this.disposables.filter((d) => d !== this.controls);
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.disposables.push(this.controls);
     this.controls.target.copy(oldTarget);
     // the fresh controls have no listeners yet, so camera movement would stop
     // requesting frames without this
@@ -653,6 +660,9 @@ export class SceneManager {
    * mutating the scene graph from the outside.
    */
   requestRender(): void {
+    // a stray call after dispose() — a leftover listener, a late setter — must
+    // not schedule a draw on the disposed renderer
+    if (this.disposed) return;
     // the layer-range setters run in the constructor before the renderer
     // exists; construction ends with a request of its own, so these can skip
     if (!this.renderer) return;
@@ -847,6 +857,7 @@ export class SceneManager {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.cancelAnimation();
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];


### PR DESCRIPTION
Closes #354

## What

`SceneManager` used to re-arm a `requestAnimationFrame` loop from its constructor and redraw the scene on every display frame, whether or not anything changed. On the 3.5&nbsp;MB 3DBenchy that cost ~0.9&nbsp;ms CPU per frame, 804k triangles and 34 draw calls — roughly **54&nbsp;ms/second of main-thread time and ~48M triangles/second to redraw a still image** for as long as the tab stayed open.

This replaces the perpetual loop with on-demand rendering:

- A public `requestRender()` schedules a single frame on the next animation frame and coalesces any burst of changes into one draw. **An idle scene now draws zero frames.**
- Camera movement requests frames through the OrbitControls `change` event, so dragging still renders at full rate. The listener is re-bound when the orthographic swap replaces the controls instance.
- Every code path that changes the picture in place now requests a frame: background / extrusion / travel / bounding-box colors, build volume, start/end layer, single-layer mode, extrusion/travel visibility, ambient/directional light, brightness, `resize()`, `clear()`, and `renderProgressive()` while a stream is being read.
- Changes that rebuild geometry (line width/height, extrusion width, tubes/lines swap, top-layer and last-segment highlights, gradient toggle) keep drawing synchronously through the existing `render()` path, unchanged.
- The camera is aimed at its target with a single `controls.update()` at construction. `enableDamping` and `autoRotate` are both off in this project, so nothing needs a per-frame `update()` and nothing self-animates.
- `renderAnimated()` / `renderFrameLoop` keep their own legitimate frame loop while geometry streams in; it still terminates when the last path is drawn.

## Behavior notes

- `requestRender()` is the new supported way to present externally-made scene changes. The public `animate()` stays for compatibility as a `@deprecated` alias: it delegates to `requestRender()`, so one call schedules (at most) one coalesced frame and it no longer re-arms a continuous loop.
- `onFrameRendered` — and the dev-mode stats FPS panel it feeds — now counts renders per second: it reads 0 while the scene is idle instead of the display refresh rate. Documented on both hooks.

## Tests

- New `on-demand rendering` suite: constructor schedules exactly one initial frame, idle draws nothing, controls `change` triggers a frame, bursts coalesce into a single draw, every visual setter requests a frame, the orthographic swap keeps camera movement rendering, `renderProgressive`/`clear` present their results, and a geometry rebuild with no job presents the emptied scene.
- Mock-based tests cover coalescing, going idle after one frame, and `dispose()` cancelling a pending frame.
- Full suite: 825 tests passing, 100% statements/branches/functions/lines coverage, typecheck and lint clean.

## Measurements

Demo app with 3DBenchy.gcode (3.7&nbsp;MB), fresh rollup builds of both branches, Chrome 152 on Apple Silicon. DevTools performance traces over a strictly idle 10&nbsp;s window after the load fully settled, with the dev GUI panels hidden.

| Metric (10&nbsp;s idle) | develop @ 91a063a | PR @ 43598fc |
| --- | --- | --- |
| renderer frames | 596–600 (~60 fps) | **0** |
| main-thread busy | 908 ms (9.1%) | 190 ms (1.9%) |
| — of which FireAnimationFrame | 797 ms | 147 ms |
| triangles per rendered frame | 753,448 | 753,448 |
| draw calls per rendered frame | 38–48 | 38 |
| total frames, load → steady state | 1,249+ | 69–71 |

Caveats, in the interest of honesty:

- The residual 190&nbsp;ms on the PR build is the demo's devMode lil-gui rAF polling, which is identical in both versions — the renderer itself contributes 0 frames.
- Draw calls varied 38↔48 across develop loads at a constant triangle count because streamed progressive loading batches meshes nondeterministically. Triangles per frame are bit-identical, so *what* is drawn is unchanged — only how often.

Sanity checks: a 30-event orbit drag rendered exactly 30 coalesced frames and then returned to 0 idle; a forced `requestRender()` advanced the frame counter by exactly 1; before/after screenshots are visually identical.

## Out of scope

The draw-call consolidation noted under "Related" in #354 (progressive rendering fragmenting the scene into ~61 chunk groups) is deliberately not part of this PR.

Assisted by Claude Code - Fable 5
