### PR TITLE
Sync docs with the current state of develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,12 @@ newest supported version; after merge, a matrix job re-runs the suite against
 every supported three.js release. Avoid APIs that aren't available across that
 whole range.
 
+## AI usage
+
+AI-assisted contributions are welcome, but usage of AI tools (Copilot, Claude,
+ChatGPT, etc.) must be disclosed in the PR description. You remain responsible
+for understanding and verifying everything you submit.
+
 ## Review standards
 
 Every change, **intended or not**, must be:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Other things that are always helpful:
 
 ## Development setup
 
+Use Node 22 (`.nvmrc` pins `v22.12.0`, so `nvm use` picks it up). CI builds and tests on Node 22.
+
 Run the dev setup:
 
 ```sh
@@ -24,20 +26,33 @@ npm run dev
 This runs the demo app which is fairly complete in using the library's features.
 If you don't need the demo app, just run `npm run dev:watch`.
 
+## Branches
+
+`develop` is the default and integration branch. Open your PR against `develop` —
+the unit-test CI and the Firebase preview deploy only trigger for PRs targeting it.
+Merges to `develop` auto-deploy the demo to https://gcode-preview.web.app.
+
 ## Before submitting a PR
 
 Run the full check suite:
 
-- `npm run test` for unit tests
+- `npm run test` for unit tests, or `npm run test:coverage` for the coverage-gated run CI uses
 - `npm run typeCheck` for typescript typings
 - `npm run lint` for code style and formatting
 - `npm run build` for a production build
-- or all together: `npm run check` (test + typeCheck + lint)
+- or most of it together: `npm run check` (test + typeCheck + lint — note it does **not** run `build` or coverage)
 
 To auto-fix simple issues: `npm run lint:fix` or `npm run prettier:fix`.
 
-CI runs the same checks (`build`, `test`, `typeCheck`, `lint`) on Ubuntu with Node 22,
-so make sure everything passes locally first.
+CI runs `build`, `test:coverage`, `typeCheck` and `lint` on Ubuntu with Node 22.
+Note that CI uses `npm run test:coverage`, not `npm run test`: **every file under
+`src/` must be at 100% statement/branch/function/line coverage** (see
+`vitest.config.mts`), so run it locally before pushing.
+
+The library supports `three` `>=0.166.0 <0.186.0`. PRs are checked against the
+newest supported version; after merge, a matrix job re-runs the suite against
+every supported three.js release. Avoid APIs that aren't available across that
+whole range.
 
 ## Review standards
 
@@ -51,12 +66,20 @@ Every change, **intended or not**, must be:
 3. **Tested end-to-end where applicable.** Supporting a new or updated gcode
    command requires at least one test that feeds a gcode snippet through the
    whole pipeline:
-   `Parser.parseGCode` → `Interpreter.execute` (or the library's process entry point).
+   `Parser.parseGCode` → `Interpreter.execute`, or the top-level entry points
+   `GCodePreview.processGCode` / `processGCodeStream` (`src/gcode-preview.ts`).
    Hand-instantiated `GCodeCommand` objects only prove the handler logic; they don't
    prove the parser maps the command word to the handler.
 
 General test expectations:
 
+- Tests run on **vitest** (`vitest.config.mts`) in a `happy-dom` environment with
+  globals enabled — no need to import `describe`/`test`/`expect`.
+- Runtime tests live in `src/__tests__/`, mirroring the `src/` layout, as plain
+  `.ts` files (e.g. `src/__tests__/interpreter.ts`) — they are **not** named
+  `*.test.ts`, and files named that way won't be picked up.
+- `src/__tests__/**/*.test-d.ts` files are compile-time type assertions; they run
+  in the typecheck pass, not as runtime tests.
 - Tests should exercise dispatch through `Interpreter.execute()` whenever the
   behavior depends on it (e.g. mode-flipping sequences like `G91` → move → `G90` →
   move), not just call individual handler methods directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,6 @@ Other things that are always helpful:
 
 ## Development setup
 
-Use Node 22 (`.nvmrc` pins `v22.12.0`, so `nvm use` picks it up). CI builds and tests on Node 22.
-
 Run the dev setup:
 
 ```sh

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,10 +6,15 @@ the version number, so there is a single path for both stable and alpha builds.
 ## 1. Bump the version (on `develop`)
 
 ```bash
-npm run version:minor   # stable    -> 3.1.0          (npm tag: latest)
-npm run version:patch   # stable    -> 3.0.1          (npm tag: latest)
-npm run version:alpha   # prerelease -> 3.1.0-alpha.1 (npm tag: alpha)
+npm run version:minor   # stable minor       (npm tag: latest)
+npm run version:patch   # stable patch       (npm tag: latest)
+npm run version:alpha   # prerelease -alpha.N (npm tag: alpha)
 ```
+
+The resulting number follows normal semver rules — note that from a prerelease
+(e.g. `3.0.0-alpha.5`) both `minor` and `patch` resolve to `3.0.0`, not
+`3.1.0`/`3.0.1`. There is no `version:major` script; run `npm version major`
+directly (it still runs the `preversion` gate).
 
 Each runs the `preversion` gate (`typeCheck` + `test:coverage` + `lint`), bumps
 `package.json`, commits, and creates a git tag.
@@ -21,18 +26,40 @@ git push
 git push --tags
 ```
 
-Pushing `develop` auto-deploys the demo to https://gcode-preview.web.app — verify
-it works.
+Pushing `develop` auto-deploys the demo (and the typedoc API docs) to
+https://gcode-preview.web.app — verify it works.
 
-## 3. Create the GitHub Release
+## 3. Draft the release notes
 
-- Stable: publish the release from the tag, marked **latest**.
-- Alpha: publish it marked **pre-release**.
+```bash
+gh release create <tag> --generate-notes --draft --verify-tag
+```
+
+Curate the auto-generated notes into the themed sections from the template in
+`.agents/release-and-publish/SKILL.md`. **A stable release broadcasts this body
+to Discord `@everyone` — get sign-off on the title and full body before
+publishing.**
+
+## 4. Publish the GitHub Release
+
+```bash
+# Stable — marked latest, pings Discord:
+gh release create <tag> --title "<title>" --notes-file <notes.md> --latest --verify-tag
+
+# Alpha — marked pre-release, Discord stays quiet:
+gh release create <tag> --title "<title>" --notes-file <notes.md> --prerelease --verify-tag
+```
 
 Publishing the release triggers `npm-publish.yml`, which builds, tests, and runs
 `npm publish` with the dist-tag taken from the version (`latest` for a plain
 version, `alpha`/`beta`/`rc` for a prerelease). Stable releases also announce to
 Discord; prereleases publish silently.
+
+## 5. Verify
+
+- The **Node.js Package** workflow (`npm-publish.yml`) is green.
+- `npm view gcode-preview dist-tags` shows the new version under the expected tag.
+- For a stable release, the Discord announcement posted.
 
 See `.agents/release-and-publish/SKILL.md` for the full walkthrough and the
 release-notes template.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ Join us on <a href="https://discord.gg/w2bsGRE6S4">discord</a>
 - multi-color
 - tube geometry
 - g2/g3 arcs
+- streaming (progressive rendering from a `ReadableStream`)
 - thumbnail preview
 - build volume
+- orthographic camera
+- slicer detection (PrusaSlicer family, Cura, Simplify3D, Slic3r)
+- drag & drop
 - examples for various frameworks
 
 ## Demo 
@@ -28,11 +32,13 @@ Click to see the [full-fledged demo](https://gcode-preview.web.app/):
 
 ## Installation
 
- `npm install gcode-preview`
+`npm install gcode-preview`
+
+GCode Preview depends on [three.js](https://threejs.org/) and supports `three` `>=0.166.0 <0.186.0`.
 
 ### Quick start
 
-```  
+```js
   import { GCodePreview } from 'gcode-preview';
 
   const preview = new GCodePreview({
@@ -44,6 +50,33 @@ Click to see the [full-fledged demo](https://gcode-preview.web.app/):
   const gcode = 'G0 X0 Y0 Z0.2\nG1 X42 Y42 E10';
   preview.processGCode(gcode);
 ```
+
+G-code can also be streamed in and rendered progressively:
+
+```js
+  const response = await fetch('benchy.gcode');
+  await preview.processGCodeStream(response.body);
+```
+
+### Constructor options
+
+The main options accepted by `new GCodePreview({ ... })` (see the
+[API docs](https://gcode-preview.web.app/docs) for the full reference):
+
+- `canvas` — the canvas element to render to
+- `buildVolume` — renders the build volume (see below)
+- colors: `backgroundColor`, `extrusionColor`, `travelColor`, `topLayerColor`, `lastSegmentColor`, `boundingBoxColor`
+- render toggles: `renderExtrusion`, `renderTravel`, `renderTubes`, `disableGradient`
+- geometry: `lineWidth`, `lineHeight`, `extrusionWidth`
+- layer range: `startLayer`, `endLayer`
+- camera: `orthographic`, `initialCameraPosition`
+- streaming: `liveRenderInterval` (throttles progressive rendering)
+- arcs: `arcChordTolerance` (tessellation precision for G2/G3)
+- misc: `droppable` (drag & drop g-code files onto the canvas), `devMode` (debug GUI + stats), `keepLines`, `minLayerThreshold`
+
+After construction, most rendering properties live on the scene manager and can
+be changed at runtime, e.g. `preview.sceneManager.renderTubes = true`, followed
+by a re-render.
 
 ### API Docs
 Check the full API documentation at https://gcode-preview.web.app/docs
@@ -63,12 +96,29 @@ Check the full API documentation at https://gcode-preview.web.app/docs
 
 ## Feature description
 
+### Supported G-code commands
+
+The interpreter currently handles:
+
+| Command | Meaning |
+| --- | --- |
+| `G0` / `G1` | linear move |
+| `G2` / `G3` | clockwise / counter-clockwise arc |
+| `G20` / `G21` | set units to inches / millimeters |
+| `G28` | home |
+| `G31` | straight probe |
+| `G38.2`–`G38.5` | probe family |
+| `G92` | set position |
+| `T0`–`T7` | tool selection |
+
+Commands without a handler are parsed but ignored by the interpreter.
+
 ### Multi-color support
 
-GCode files that were sliced for a multi-tool system can be previewed as such. Assign an array of colors to the `extrusionColor` property, where the index in the array corresponds to the index of the tool: T0..T7. 
+GCode files that were sliced for a multi-tool system can be previewed as such. Pass an array of colors as the `extrusionColor` constructor option (or assign `preview.sceneManager.extrusionColor` at runtime), where the index in the array corresponds to the index of the tool: T0..T7. 
 
 example: 
-```
+```js
 extrusionColor: ['hotpink', 'indigo', 'lime']
 ```
 Here, T0 is hotpink, T1 is indigo and T2 is lime.
@@ -86,8 +136,11 @@ Supported systems include:
  - and possibly more
 
 ### Render extrusion as tubes
-```
-renderTubes : true
+Extrusions are rendered as flat lines by default; pass the `renderTubes`
+constructor option to get true tube geometry (it can also be toggled at runtime
+via `preview.sceneManager.renderTubes`):
+```js
+new GCodePreview({ canvas, renderTubes: true });
 ```
 
 ### G2/G3 arc support
@@ -103,17 +156,19 @@ The thumbnails can be accessed like this:
 
 Thumbnails have a `.src` property that will create a usable data url from the base64 string.
 
-See an [example in the demo source](https://github.com/remcoder/gcode-preview/blob/v2.5.0/demo/demo.js#L190-L204).
+See an [example in the demo source](https://github.com/xyz-tools/gcode-preview/blob/develop/demo/js/app.js#L43-L50).
 
 ### Build volume
 The build volume will be rendered if the `buildVolume` parameter is passed. It has the following type: 
-```
+```ts
 buildVolume: { 
   x: number; 
   y: number; 
-  z: number
+  z: number;
+  smallGrid?: boolean;
 }
 ```
+Negative dimensions are clamped to 0.
 
 example:
 
@@ -134,12 +189,10 @@ Note the dev bundle:
  - has no type defs (.d.ts)
 
 ### Submitting a PR
-Before submitting a PR run:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guidelines. In short, before submitting a PR run:
+- `npm run check` (test + typeCheck + lint)
 - `npm run build` for a production build
-- `npm run test` for unit tests
-- `npm run typeCheck` for typescript typings
-- `npm run lint` for code style and formatting
-- or all together: `npm run build && npm run test && npm run typeCheck && npm run lint`
+- `npm run test:coverage` — CI requires 100% coverage for every file under `src/`
 
 To auto-fix simple issues:
 - `npm run lint:fix` or `npm run prettier:fix`
@@ -150,7 +203,7 @@ For working on production builds you can use:
 - or just `npm run build` or `npm run build:watch`
 
 ## Feedback
-If you have found a bug or if have an idea for a feature, don't hesitate to [create an issue on GitHub](https://github.com/remcoder/gcode-preview/issues/new) or [talk to us on Discord](https://discord.gg/w2bsGRE6S4).
+If you have found a bug or if have an idea for a feature, don't hesitate to [create an issue on GitHub](https://github.com/xyz-tools/gcode-preview/issues/new) or [talk to us on Discord](https://discord.gg/w2bsGRE6S4).
 
 ## Contributing
 Want to help out? We are open to your ideas and always willing to get you started! [talk to us on Discord](https://discord.gg/w2bsGRE6S4).


### PR DESCRIPTION
Ref #402

An audit of README.md, CONTRIBUTING.md and PUBLISHING.md against the current code found the docs had drifted. This PR brings them back in line, following a few principles:

- **Docs should match what the code actually does** — every claim (commands, options, CI checks, release steps) was verified against the source and workflows, and corrected where stale.
- **Document the traps** — anything where following the old docs would fail (coverage gate, test file naming, PR base branch) is now called out explicitly.
- **Write for the 3.0 release** — the README describes the current API as *the* API, with no prerelease framing.
- **Don't duplicate** — the README defers to CONTRIBUTING.md and the API docs instead of restating them.

Assisted by Claude Code - Fable 5