### PR TITLE
Fix blank render when switching to the Mach3 preset in the demo

### DIFF
--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -92,6 +92,15 @@ export const app = (window.app = createApp({
       if (options.initialCameraPosition) {
         preview.sceneManager.camera.position.fromArray(options.initialCameraPosition);
       }
+      // re-aim the camera at the preset's plate center; the preview instance is
+      // reused across presets, so the constructor's centering never re-runs
+      const buildVolume = options.buildVolume;
+      if (buildVolume) {
+        preview.sceneManager.controls.target.set(buildVolume.x / 2, 0, -buildVolume.y / 2);
+      } else {
+        preview.sceneManager.controls.target.set(100, 0, -100);
+      }
+      preview.sceneManager.controls.update();
 
       console.debug('Applying preset', presetName, options);
 


### PR DESCRIPTION
## Problem

Selecting the **Mach3 tool path (cnc)** preset in the demo showed a completely blank canvas — no tool path, no grid, no axes — while every other preset rendered fine. No console errors.

## Cause

The tool path was actually being parsed and built correctly (46 travel verts in the scene). The camera just wasn't looking at it:

- Since the demo stopped recreating the `GCodePreview` instance on preset switches, the orbit-controls target keeps whatever it was set to at construction time — the center of the default 180×180 plate, `(90, 0, -90)`. Previously, `preview.dispose(); new GCodePreview(options)` re-ran the constructor's centering logic for each preset.
- The Mach3 job is a small plasma-cutter file in inches on a 10×10 build volume; its entire path fits within ~4×6 units of the origin. With the preset's close-up camera position `(-20, 20, 1.8)` aimed at `(90, 0, -90)`, everything fell outside the frustum.

All other presets survived by accident: their mm-scale content is large enough to still land in frame even with the stale target.

## Fix

In `selectPreset`, re-aim `controls.target` at the preset's plate center using the same formula as the `SceneManager` constructor (`x/2, 0, -y/2`, falling back to `(100, 0, -100)` without a build volume), then `controls.update()`.

The fix lives in the demo rather than the library's `buildVolume` setter because the demo mutates the existing volume's `x`/`y`/`z` directly (the setter never fires on preset switches), and auto-recentering the camera on every build-volume tweak from the dev GUI sliders would be disruptive.

## Before / After

| Before | After |
|---|---|
| ![Mach3 preset before the fix: blank canvas](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-457-assets/before-mach3.png) | ![Mach3 preset after the fix: tool path visible on the 10×10 plate](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-457-assets/after-mach3.png) |

(Screenshots live on the orphan branch `pr-457-assets`, which can be deleted after merge.)

## Verified in the browser

- **Mach3**: renders the cut path (square, triangle, circle) on its 10×10 plate ✅
- **Easel**: still renders, now properly centered on its 300×180 plate ✅
- **3DBenchy**: pixel-identical to before ✅
- Console clean (only the expected `Job is non-planar` warning for CNC files); prettier + eslint pass.

Assisted by Claude Code - Fable 5