### PR TITLE
Derive per-path line height and extrusion width for Cura gcode

### DIFF
--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -282,6 +282,51 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
     expect(paths[3].vertices).toEqual([10, 20, 0.16, 10, 10, 0.16]);
   });
 
+  test('a Cura file derives the same per-path dimensions and breaks', async () => {
+    // Cura announces no dimension comments, so widths and heights are derived
+    // from the moves: E values below deposit 0.4mm (E steps of 0.33260 per
+    // 10mm at 0.2mm height, computed from the volumetric model for 1.75mm
+    // filament) then 0.6mm (step 0.49890) wide lines. The layer change and
+    // the width shift land mid-file, so the 1- and 7-byte chunkers cut right
+    // through the derivation state: the extruder position, the last extrusion
+    // Z and the derived dimensions must all carry across chunk boundaries for
+    // every mode to break the same paths with the same dimensions.
+    const gcode = [
+      ';FLAVOR:Marlin',
+      ';Generated with Cura_SteamEngine 5.7.0',
+      'M82',
+      'G28',
+      ';LAYER:0',
+      'G0 X10 Y10 Z0.2',
+      'G1 X20 Y10 E0.33260',
+      'G1 X20 Y20 E0.66520',
+      ';TYPE:FILL',
+      'G1 X10 Y20 E1.16410',
+      ';LAYER:1',
+      'G0 Z0.4',
+      'G1 X10 Y10 E1.49670'
+    ].join('\n');
+
+    await ingest(preview, gcode);
+
+    const paths = preview.job.paths;
+    expect(paths.length).toEqual(5);
+    // the leading travel predates any extrusion, so it carries no dimensions;
+    // every later path carries the derived values in effect when it started
+    expect(paths.map((path) => [path.extrusionWidth, path.lineHeight])).toEqual([
+      [undefined, undefined],
+      [0.4, 0.2],
+      [0.6, 0.2],
+      [0.6, 0.2],
+      [0.4, 0.2]
+    ]);
+    // the width shift broke the extrusion exactly at the FILL move
+    expect(paths[1].vertices).toEqual([10, 10, 0.2, 20, 10, 0.2, 20, 20, 0.2]);
+    expect(paths[2].vertices).toEqual([20, 20, 0.2, 10, 20, 0.2]);
+    // and the second layer continues from the travel's endpoint
+    expect(paths[4].vertices).toEqual([10, 20, 0.4, 10, 10, 0.4]);
+  });
+
   test('known extrusion coordinates produce the exact same bounding box', async () => {
     // The bounding box only tracks extrusion endpoints, so the corners come
     // straight from the three G1 targets below.

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -187,6 +187,166 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
   });
 });
 
+describe('derived extrusion dimensions (Cura)', () => {
+  const FILAMENT_AREA = Math.PI * (1.75 / 2) ** 2;
+
+  /** The E increment depositing a width×height×length box of 1.75mm filament */
+  const eFor = (width: number, height: number, length: number) => (width * height * length) / FILAMENT_AREA;
+
+  /** Accumulates absolute E positions the way Cura emits them (5 decimals) */
+  const absoluteE = () => {
+    let e = 0;
+    return (width: number, height: number, length: number) => {
+      e += eFor(width, height, length);
+      return e.toFixed(5);
+    };
+  };
+
+  /** Parses and executes a Cura-style file: real header, then the given body */
+  const run = (lines: string[]) => {
+    const { commands, metadata } = new Parser().parseGCode(
+      [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', 'M82', 'G28', ...lines].join('\n')
+    );
+    const job = new Job();
+    job.metadata = metadata;
+    return new Interpreter().execute(commands, job);
+  };
+
+  const dimensions = (job: Job) => job.extrusions.map((path) => [path.extrusionWidth, path.lineHeight]);
+
+  test('round-trips programmed widths and heights through the volumetric model', () => {
+    // The E values are computed from the exact widths and heights the
+    // derivation should recover; a width change mid-layer must break the path.
+    const E = absoluteE();
+    const job = run([
+      ';LAYER:0',
+      'G0 X10 Y10 Z0.2',
+      `G1 X20 Y10 E${E(0.4, 0.2, 10)}`,
+      `G1 X20 Y20 E${E(0.4, 0.2, 10)}`,
+      ';TYPE:FILL',
+      `G1 X10 Y20 E${E(0.6, 0.2, 10)}`,
+      ';LAYER:1',
+      'G0 Z0.4',
+      `G1 X10 Y10 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.6, 0.2],
+      [0.4, 0.2]
+    ]);
+    // the width change broke the path exactly at the FILL move
+    expect(job.extrusions[0].vertices).toEqual([10, 10, 0.2, 20, 10, 0.2, 20, 20, 0.2]);
+    expect(job.extrusions[1].vertices).toEqual([20, 20, 0.2, 10, 20, 0.2]);
+  });
+
+  test('recovers an adaptive layer height sequence from the Z steps', () => {
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      'G0 Z0.36',
+      `G1 X0 Y0 E${E(0.4, 0.16, 10)}`,
+      'G0 Z0.66',
+      `G1 X10 Y0 E${E(0.4, 0.3, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.16],
+      [0.4, 0.3]
+    ]);
+  });
+
+  test('a z-hop travel between layers does not corrupt the derived height', () => {
+    // The hop raises Z to 0.7 mid-travel; the height must come from the
+    // extrusion Zs (0.2 then 0.4), not from the last-seen Z.
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      'G0 Z0.7',
+      'G0 X20 Y0',
+      'G0 Z0.4',
+      `G1 X30 Y0 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.2]
+    ]);
+  });
+
+  test('a G92 E reset between layers keeps the extruded lengths right', () => {
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`,
+      'G92 E0',
+      'G0 Z0.4',
+      `G1 X0 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.2]
+    ]);
+  });
+
+  test('relative extrusion mode (M83) derives the same dimensions', () => {
+    const job = run([
+      'M83',
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`,
+      `G1 X10 Y10 E${eFor(0.6, 0.2, 10).toFixed(5)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.6, 0.2]
+    ]);
+  });
+
+  test('ironing re-extrudes at the same Z without disturbing the dimensions', () => {
+    // The ironing pass deposits far too little material to be a real line
+    // (derived width 0.04); both its width and its zero Z step are discarded,
+    // so it continues the finished surface's path untouched.
+    const E = absoluteE();
+    const job = run(['G0 X0 Y0 Z0.2', `G1 X10 Y0 E${E(0.4, 0.2, 10)}`, `G1 X0 Y0 E${E(0.04, 0.2, 10)}`]);
+
+    expect(job.extrusions.length).toEqual(1);
+    expect(job.extrusions[0].vertices).toEqual([0, 0, 0.2, 10, 0, 0.2, 0, 0, 0.2]);
+    expect(dimensions(job)).toEqual([[0.4, 0.2]]);
+  });
+
+  test("spiralize's continuous micro-climb keeps the layer height it entered with", () => {
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      `G1 X10 Y10 Z0.205 E${E(0.4, 0.2, 10)}`,
+      `G1 X0 Y10 Z0.21 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    // each 0.005 step is below the plausible layer range and is skipped
+    expect(job.extrusions.length).toEqual(1);
+    expect(dimensions(job)).toEqual([[0.4, 0.2]]);
+  });
+
+  test('an UltiGCode-flavored file derives nothing', () => {
+    // UltiGCode E values are mm³, which the filament-length model would turn
+    // into confidently wrong widths; the parser leaves derivation off.
+    const { commands, metadata } = new Parser().parseGCode(
+      [';FLAVOR:UltiGCode', ';LAYER:0', 'G0 X0 Y0 Z0.2', 'G1 X10 Y0 E1.6'].join('\n')
+    );
+    const job = new Job();
+    job.metadata = metadata;
+    new Interpreter().execute(commands, job);
+
+    expect(job.extrusions[0].extrusionWidth).toBeUndefined();
+    expect(job.extrusions[0].lineHeight).toBeUndefined();
+  });
+});
+
 describe('malformed coordinates through the whole pipeline', () => {
   const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
   const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);

--- a/src/__tests__/interpreter/commands/arc-move.ts
+++ b/src/__tests__/interpreter/commands/arc-move.ts
@@ -31,6 +31,14 @@ describe('arcMove (G2/G3)', () => {
     expect(job.boundingBox.corners?.max.x).toEqual(20);
   });
 
+  test('keeps the extruder position in sync for the moves that follow', () => {
+    // The arc itself derives no dimensions, but a later linear move computes
+    // its extruded length against the position the arc left behind.
+    const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 Y10 I5 J0 E1.5'].join('\n'));
+
+    expect(job.state.e).toEqual(1.5);
+  });
+
   test('keeps the current Y when an arc omits it', () => {
     const job = run(['G1 X10 Y10 Z1 E1', 'G2 X20 I5 J0 E1'].join('\n'));
 

--- a/src/__tests__/interpreter/commands/linear-move.ts
+++ b/src/__tests__/interpreter/commands/linear-move.ts
@@ -124,6 +124,32 @@ describe('linearMove (G0/G1)', () => {
     expect(job.inprogressPath?.travelType).toEqual(PathType.Extrusion);
   });
 
+  test('tracks the extruder position of moves and of zero-length retractions', () => {
+    const job = new Job();
+
+    // absolute mode (the default): E parameters are positions
+    linearMove(new GCodeCommand('G1 X10 E2', 'g1', { x: 10, e: 2 }), job);
+    expect(job.state.e).toEqual(2);
+
+    // a zero-length prime still moves the extruder; losing it here would
+    // misattribute the difference to the next extruding move
+    linearMove(new GCodeCommand('G1 E3', 'g1', { e: 3 }), job);
+    expect(job.state.e).toEqual(3);
+
+    linearMove(new GCodeCommand('G1 X20 E4', 'g1', { x: 20, e: 4 }), job);
+    expect(job.state.e).toEqual(4);
+  });
+
+  test('accumulates the extruder position in relative mode', () => {
+    const job = new Job();
+    job.state.relativeExtrusion = true;
+
+    linearMove(new GCodeCommand('G1 X10 E2', 'g1', { x: 10, e: 2 }), job);
+    linearMove(new GCodeCommand('G1 X20 E3', 'g1', { x: 20, e: 3 }), job);
+
+    expect(job.state.e).toEqual(5);
+  });
+
   test('starts a new path if the travel type changes from Extrusion to Travel', () => {
     const command1 = new GCodeCommand('G1 X1 Y2 E3', 'g1', { x: 1, y: 2, e: 3 });
     const command2 = new GCodeCommand('G0 X3 Y4', 'g0', { x: 3, y: 4 });

--- a/src/__tests__/interpreter/commands/set-extrusion-mode.ts
+++ b/src/__tests__/interpreter/commands/set-extrusion-mode.ts
@@ -1,0 +1,39 @@
+import { test, expect } from 'vitest';
+import { GCodeCommand } from '../../../parser/gcode-parser';
+import { Parser } from '../../../parser/gcode-parser';
+import { Interpreter } from '../../../interpreter';
+import { setAbsoluteExtrusion, setRelativeExtrusion } from '../../../interpreter/commands';
+import { Job } from '../../../job';
+
+test('M83 switches E parameters to relative distances', () => {
+  const command = new GCodeCommand('M83', 'm83', {});
+  const job = new Job();
+
+  setRelativeExtrusion(command, job);
+
+  expect(job.state.relativeExtrusion).toBe(true);
+});
+
+test('M82 switches E parameters back to absolute positions', () => {
+  const command = new GCodeCommand('M82', 'm82', {});
+  const job = new Job();
+  job.state.relativeExtrusion = true;
+
+  setAbsoluteExtrusion(command, job);
+
+  expect(job.state.relativeExtrusion).toBe(false);
+});
+
+test('the mode defaults to absolute, matching the Marlin firmware default', () => {
+  expect(new Job().state.relativeExtrusion).toBe(false);
+});
+
+test('the extruder position follows the active mode through the registry', () => {
+  const run = (lines: string[]): Job =>
+    new Interpreter().execute(new Parser().parseGCode(lines.join('\n')).commands, new Job());
+
+  // absolute: E is a position, so the file ends at the last announced E
+  expect(run(['M82', 'G1 X10 E2', 'G1 X20 E5']).state.e).toEqual(5);
+  // relative: E is a distance, so the positions accumulate
+  expect(run(['M83', 'G1 X10 E2', 'G1 X20 E5']).state.e).toEqual(7);
+});

--- a/src/__tests__/interpreter/commands/set-position.ts
+++ b/src/__tests__/interpreter/commands/set-position.ts
@@ -114,7 +114,8 @@ describe('setPosition (G92)', () => {
 
     expect(job.paths.length).toEqual(1);
     expect(job.paths[0].vertices).toEqual([0, 0, 0, 10, 0, 0, 20, 0, 0]);
-    expect(job.state.e).toEqual(0);
+    // the reset took: the final move extrudes from 0 to its absolute E of 1
+    expect(job.state.e).toEqual(1);
   });
 
   test('a Z re-zero translates the following Z moves', () => {

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, vi, afterEach } from 'vitest';
 import { Job } from '../job';
+import { Metadata } from '../parser/gcode-parser';
 import { PathType, Path } from '../path';
 import { State } from '../state';
 import { LayersIndexer, NonApplicableIndexer, TravelTypeIndexer } from '../indexers';
@@ -687,6 +688,178 @@ describe('.beginCommand', () => {
 
     expect(job.state.extrusionWidth).toBeUndefined();
     expect(job.state.lineHeight).toBeUndefined();
+  });
+});
+
+describe('.deriveMoveDimensions', () => {
+  const FILAMENT_AREA = Math.PI * (1.75 / 2) ** 2;
+  /** Extruded filament length depositing a w×h×len box (the derivation's model, inverted) */
+  const eFor = (width: number, height: number, length: number, area = FILAMENT_AREA) =>
+    (width * height * length) / area;
+
+  /** A job with derivation enabled, positioned at (0, 0, z) */
+  const derivingJob = (metadata: Partial<Metadata> = {}, z = 0.2) => {
+    const job = new Job();
+    job.metadata = { thumbnails: {}, deriveExtrusionDimensions: true, ...metadata };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = z;
+    return job;
+  };
+
+  test('does nothing unless the metadata asked for derivation', () => {
+    const job = new Job();
+    job.metadata = { thumbnails: {} };
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.lineHeight).toBeUndefined();
+  });
+
+  test('does nothing for a move that extrudes nothing', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, 0);
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, -1);
+
+    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.lineHeight).toBeUndefined();
+  });
+
+  test('the first extrusion derives its height from Z itself and its width from the volume', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('a later extrusion derives its height from the Z step since the previous one', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.state.z = 0.36;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.36 }, eFor(0.4, 0.16, 10));
+
+    expect(job.state.lineHeight).toEqual(0.16);
+  });
+
+  test('extruding again at the same Z (ironing) keeps the current height', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+  });
+
+  test('an implausible Z step keeps the height but re-anchors the next step', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    // jumping to a second sequential object: the 2.8mm step is no layer height
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 3 }, eFor(0.4, 0.2, 10));
+    expect(job.state.lineHeight).toEqual(0.2);
+
+    // ...but the next layer measures from the new Z, not the stale one
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 3.25 }, eFor(0.4, 0.25, 10));
+    expect(job.state.lineHeight).toEqual(0.25);
+  });
+
+  test('moving down keeps the current height', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.4 }, eFor(0.4, 0.4, 10));
+
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.3 }, eFor(0.4, 0.4, 10));
+
+    expect(job.state.lineHeight).toEqual(0.4);
+  });
+
+  test('an unknown Z derives no height, and without a height no width either', () => {
+    const job = derivingJob();
+    job.state.z = undefined;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: undefined }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toBeUndefined();
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('a segment too short to measure derives no width', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 0.01, y: 0, z: 0.2 }, eFor(0.4, 0.2, 0.01));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('implausible widths are discarded instead of stamped on paths', () => {
+    const job = derivingJob();
+
+    // far too much material for the segment: a prime blob, not a 3mm line
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(3, 0.2, 10));
+    expect(job.state.extrusionWidth).toBeUndefined();
+
+    // far too little: a near-dry wipe
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.05, 0.2, 10));
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('the derived width is quantized to 0.01mm', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.3985, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('a width within 2% of the current one keeps the current value', () => {
+    // E-value rounding noise must not shatter the model into micro-paths.
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.6, 0.2, 10));
+
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.61, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.6);
+  });
+
+  test('a real width change beyond the tolerance is applied', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.42, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.42);
+  });
+
+  test('the metadata filament diameter scales the derived width', () => {
+    const area285 = Math.PI * (2.85 / 2) ** 2;
+    const job = derivingJob({ filamentDiameter: 2.85 });
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10, area285));
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('unknown axes are assumed at the origin, like the rendered geometry', () => {
+    const job = derivingJob();
+    job.state.x = undefined;
+
+    // X never homed: the segment runs from the assumed origin to (0,10)
+    job.deriveMoveDimensions({ x: undefined, y: 10, z: 0.2 }, eFor(0.4, 0.2, 10));
+    expect(job.state.extrusionWidth).toEqual(0.4);
+
+    // Y and Z unknown too; the height derived above still measures the width
+    job.state.y = undefined;
+    job.state.z = undefined;
+    job.deriveMoveDimensions({ x: 10, y: undefined, z: undefined }, eFor(0.42, 0.2, 10));
+    expect(job.state.extrusionWidth).toEqual(0.42);
   });
 });
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -847,6 +847,20 @@ describe('.deriveMoveDimensions', () => {
     expect(job.state.extrusionWidth).toEqual(0.4);
   });
 
+  test('overflowing coordinates and E values never latch NaN into the width', () => {
+    // Individually finite params survive the parser, but 1.7e308-scale
+    // values overflow the length (hypot -> Infinity) and the volume
+    // (deltaE x area -> Infinity), whose ratio is NaN — which a plain
+    // range check would wave through and stamp on every path after it.
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.deriveMoveDimensions({ x: 1.7e308, y: 1.7e308, z: 0.2 }, 1.7e308);
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(Number.isFinite(job.state.extrusionWidth)).toBe(true);
+  });
+
   test('unknown axes are assumed at the origin, like the rendered geometry', () => {
     const job = derivingJob();
     job.state.x = undefined;

--- a/src/__tests__/parser/cura-parser.ts
+++ b/src/__tests__/parser/cura-parser.ts
@@ -149,3 +149,41 @@ test('Cura parser returns empty array when no LAYER comments found', () => {
 
   expect(layers).toHaveLength(0);
 });
+
+test('Cura parser asks for derived extrusion dimensions', () => {
+  const parser = new CuraMetadataParser();
+
+  const commands = [
+    createCommand(';FLAVOR:Marlin', 'FLAVOR:Marlin'),
+    createCommand(';Generated with Cura_SteamEngine 5.7.0', 'Generated with Cura_SteamEngine 5.7.0')
+  ];
+
+  expect(parser.derivesExtrusionDimensions(commands)).toBe(true);
+});
+
+test('Cura parser does not derive dimensions for the volumetric UltiGCode flavor', () => {
+  // UltiGCode E values are mm³ of material, not mm of filament; deriving
+  // widths from them with the filament-length model would be confidently wrong.
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:UltiGCode', 'FLAVOR:UltiGCode')];
+
+  expect(parser.derivesExtrusionDimensions(commands)).toBe(false);
+});
+
+test('Cura parser reads a 2.85 filament diameter from the Griffin flavor', () => {
+  // Griffin is only generated for Ultimaker's own 2.85mm machines.
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:Griffin', 'FLAVOR:Griffin')];
+
+  expect(parser.parseFilamentDiameter(commands)).toEqual(2.85);
+});
+
+test('Cura parser leaves the filament diameter unknown for other flavors', () => {
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:Marlin', 'FLAVOR:Marlin')];
+
+  expect(parser.parseFilamentDiameter(commands)).toBeUndefined();
+});

--- a/src/__tests__/parser/layer-metadata-integration.ts
+++ b/src/__tests__/parser/layer-metadata-integration.ts
@@ -72,6 +72,42 @@ test('accumulates dimension events with whole-file line indices when parsing in 
   ]);
 });
 
+test('parser flags a Cura file for derived extrusion dimensions', () => {
+  const { metadata } = new Parser().parseGCode(
+    [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
+  );
+
+  expect(metadata.slicerName).toBe('Cura');
+  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  // Marlin flavor implies no particular machine, so no diameter is announced
+  expect(metadata.filamentDiameter).toBeUndefined();
+});
+
+test('parser reads the filament diameter from a Griffin-flavored Cura file', () => {
+  const { metadata } = new Parser().parseGCode(
+    [';FLAVOR:Griffin', ';GENERATOR.NAME:Cura_SteamEngine', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
+  );
+
+  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  expect(metadata.filamentDiameter).toEqual(2.85);
+});
+
+test('parser does not flag a Prusa-family file for derivation', () => {
+  // PrusaSlicer announces exact dimensions in comments; deriving would
+  // override them with approximations.
+  const { metadata } = new Parser().parseGCode(PRUSA_GCODE);
+
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
+  expect(metadata.filamentDiameter).toBeUndefined();
+});
+
+test('parser does not flag an UltiGCode-flavored Cura file for derivation', () => {
+  const { metadata } = new Parser().parseGCode([';FLAVOR:UltiGCode', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n'));
+
+  expect(metadata.slicerName).toBe('Cura');
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
+});
+
 test('slicer metadata drives job layer indexing end-to-end', () => {
   const { commands, metadata } = new Parser().parseGCode(PRUSA_GCODE);
 

--- a/src/__tests__/parser/metadata-parser-base.ts
+++ b/src/__tests__/parser/metadata-parser-base.ts
@@ -48,4 +48,17 @@ describe('SlicerMetadataParser base class', () => {
 
     expect(parser.parseExtrusionDimensions([comment('WIDTH:0.45')])).toEqual([]);
   });
+
+  it('derivesExtrusionDimensions defaults to false', () => {
+    // Only dialects without dimension comments (Cura) opt into deriving.
+    const parser = new StubMetadataParser();
+
+    expect(parser.derivesExtrusionDimensions([comment('STUB_MARKER v1')])).toBe(false);
+  });
+
+  it('parseFilamentDiameter defaults to unknown', () => {
+    const parser = new StubMetadataParser();
+
+    expect(parser.parseFilamentDiameter([comment('STUB_MARKER v1')])).toBeUndefined();
+  });
 });

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -226,7 +226,12 @@ describe('public API types', () => {
       expectTypeOf<Parser['lines']>().toEqualTypeOf<string[]>();
       expectTypeOf<Parser['lineCount']>().toEqualTypeOf<number>();
       expectTypeOf<keyof Parser['metadata']>().toEqualTypeOf<
-        'thumbnails' | 'layerMetadata' | 'extrusionDimensions' | 'slicerName'
+        | 'thumbnails'
+        | 'layerMetadata'
+        | 'extrusionDimensions'
+        | 'slicerName'
+        | 'deriveExtrusionDimensions'
+        | 'filamentDiameter'
       >();
       expectTypeOf<Parameters<Parser['parseGCode']>>().toEqualTypeOf<[string | string[]]>();
       expectTypeOf<keyof ReturnType<Parser['parseGCode']>>().toEqualTypeOf<'metadata' | 'commands'>();

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8,6 +8,8 @@ import {
   setMillimeterUnits,
   home,
   setPosition,
+  setAbsoluteExtrusion,
+  setRelativeExtrusion,
   probe,
   selectTool
 } from './interpreter/commands';
@@ -55,6 +57,8 @@ export const handlers: ReadonlyMap<string, CommandHandler> = new Map<string, Com
   ['g38.4', probe],
   ['g38.5', probe],
   ['g92', setPosition],
+  ['m82', setAbsoluteExtrusion],
+  ['m83', setRelativeExtrusion],
   ['t0', selectTool],
   ['t1', selectTool],
   ['t2', selectTool],

--- a/src/interpreter/commands/arc-move.ts
+++ b/src/interpreter/commands/arc-move.ts
@@ -28,6 +28,10 @@ export const makeArcMove = (options: ArcTessellatorOptions = {}): CommandHandler
     const from = job.resolvePosition();
 
     const cw = command.gcode === 'g2';
+    // Keep the extruder position in sync for the moves that follow; the arc
+    // itself derives no dimensions (Cura only emits arcs via plugins) and
+    // simply carries the state's current width and height like any move.
+    state.trackE(e);
     // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
     // material laid down. The looser `e ?` used to misclassify a retracting arc as
     // Extrusion, so it rendered as deposited filament and stretched the bounding box.

--- a/src/interpreter/commands/index.ts
+++ b/src/interpreter/commands/index.ts
@@ -3,5 +3,6 @@ export { arcMove, makeArcMove } from './arc-move';
 export { setInchUnits, setMillimeterUnits } from './set-units';
 export { home } from './home';
 export { setPosition } from './set-position';
+export { setAbsoluteExtrusion, setRelativeExtrusion } from './set-extrusion-mode';
 export { probe } from './probe';
 export { selectTool } from './select-tool';

--- a/src/interpreter/commands/linear-move.ts
+++ b/src/interpreter/commands/linear-move.ts
@@ -12,6 +12,7 @@ import type { CommandHandler } from '../../interpreter';
  */
 export const linearMove: CommandHandler = (command, job) => {
   const { x, y, z, e, f } = command.params;
+  const { state } = job;
 
   // discard zero length moves
   if (x === undefined && y === undefined && z === undefined) {
@@ -25,12 +26,25 @@ export const linearMove: CommandHandler = (command, job) => {
       job.stats.others++;
     }
 
+    // still account the E parameter: in absolute mode a retract/prime pair
+    // moves the extruder position, and losing it here would misattribute the
+    // difference to the next extruding move
+    state.trackE(e);
     return;
   }
 
   job.stats.points++;
 
-  const { state } = job;
+  // The move's physical endpoint; an omitted axis keeps its current
+  // (possibly unknown) position. Resolved before touching the state so the
+  // dimension derivation below still sees the segment's starting point.
+  const targetX = x === undefined ? state.x : x + state.positionShift.x;
+  const targetY = y === undefined ? state.y : y + state.positionShift.y;
+  const targetZ = z === undefined ? state.z : z + state.positionShift.z;
+
+  state.trackE(e);
+  // classified from the raw E parameter, in either extrusion mode
+  // see also https://github.com/xyz-tools/gcode-preview/issues/179
   const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
   const currentPath = job.continuePath(pathType);
 
@@ -38,11 +52,9 @@ export const linearMove: CommandHandler = (command, job) => {
     job.stats.extrusionDistance += e;
   }
 
-  // e is omitted bc currently we're assuming relative extrusion distances
-  // see also https://github.com/xyz-tools/gcode-preview/issues/179
-  state.x = x === undefined ? state.x : x + state.positionShift.x;
-  state.y = y === undefined ? state.y : y + state.positionShift.y;
-  state.z = z === undefined ? state.z : z + state.positionShift.z;
+  state.x = targetX;
+  state.y = targetY;
+  state.z = targetZ;
 
   const pos = job.resolvePosition();
   currentPath.addPoint(pos.x, pos.y, pos.z);

--- a/src/interpreter/commands/linear-move.ts
+++ b/src/interpreter/commands/linear-move.ts
@@ -42,10 +42,14 @@ export const linearMove: CommandHandler = (command, job) => {
   const targetY = y === undefined ? state.y : y + state.positionShift.y;
   const targetZ = z === undefined ? state.z : z + state.positionShift.z;
 
-  state.trackE(e);
+  const deltaE = state.trackE(e);
   // classified from the raw E parameter, in either extrusion mode
   // see also https://github.com/xyz-tools/gcode-preview/issues/179
   const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
+  if (pathType === PathType.Extrusion) {
+    // may change the state's dimensions, which continuePath breaks on
+    job.deriveMoveDimensions({ x: targetX, y: targetY, z: targetZ }, deltaE);
+  }
   const currentPath = job.continuePath(pathType);
 
   if (e > 0) {

--- a/src/interpreter/commands/set-extrusion-mode.ts
+++ b/src/interpreter/commands/set-extrusion-mode.ts
@@ -1,0 +1,24 @@
+import type { CommandHandler } from '../../interpreter';
+
+/**
+ * Executes an M82 command, switching E parameters to absolute positions
+ * @param _command - GCodeCommand (no parameters used)
+ * @param job - Job instance to update
+ * @remarks
+ * Only the E accounting (`State.trackE`) consults the mode; whether a move
+ * extrudes is still classified from the raw E parameter. Cura emits M82 or
+ * M83 right after its start gcode, which is what keeps the volumetric
+ * dimension derivation's extruded lengths correct in either mode.
+ */
+export const setAbsoluteExtrusion: CommandHandler = (_command, job) => {
+  job.state.relativeExtrusion = false;
+};
+
+/**
+ * Executes an M83 command, switching E parameters to relative distances
+ * @param _command - GCodeCommand (no parameters used)
+ * @param job - Job instance to update
+ */
+export const setRelativeExtrusion: CommandHandler = (_command, job) => {
+  job.state.relativeExtrusion = true;
+};

--- a/src/job.ts
+++ b/src/job.ts
@@ -14,6 +14,27 @@ import { Metadata } from './parser/gcode-parser';
 import { ExtrusionDimensionMetadata } from './parser/metadata-parser-base';
 import { JobStats } from './job-stats';
 
+/** Filament diameter assumed when the metadata announces none, in millimeters */
+const DEFAULT_FILAMENT_DIAMETER = 1.75;
+/** Derived layer heights outside this range are considered implausible */
+const MIN_DERIVED_HEIGHT = 0.01;
+const MAX_DERIVED_HEIGHT = 1.0;
+/** Derived extrusion widths outside this range are considered implausible */
+const MIN_DERIVED_WIDTH = 0.1;
+const MAX_DERIVED_WIDTH = 2.0;
+/**
+ * Segments shorter than this derive no width, in millimeters: the slicer
+ * rounds E to a few decimals, and over a near-zero length that quantization
+ * noise dominates the derived value.
+ */
+const MIN_DERIVED_SEGMENT_LENGTH = 0.05;
+/**
+ * A derived width within this relative tolerance of the current one keeps the
+ * current value, so residual noise cannot shatter the model into micro-paths.
+ * 2% separates real Cura width steps (0.4 vs 0.42 infill is 5%) from noise.
+ */
+const DERIVED_WIDTH_TOLERANCE = 0.02;
+
 /**
  * Represents a complete print job containing paths, layers, and state
  * @remarks
@@ -45,6 +66,12 @@ export class Job {
   private extrusionDimensions: ExtrusionDimensionMetadata[] = [];
   /** Position in extrusionDimensions up to which events have been applied */
   private dimensionCursor = 0;
+  /** Whether per-path dimensions are derived from the moves (see metadata) */
+  private deriveDimensions = false;
+  /** Filament cross-section area feeding the width derivation, in mm² */
+  private filamentCrossSection = Math.PI * (DEFAULT_FILAMENT_DIAMETER / 2) ** 2;
+  /** Z of the last extrusion move, from which derived layer heights are measured */
+  private lastExtrusionZ: number | undefined;
   /** How many commands have been executed on this job — one per parsed line */
   private executedCommandCount = 0;
 
@@ -87,6 +114,9 @@ export class Job {
     this._metadata = metadata;
     this.layersIndexer.setLayerMetadata(metadata?.layerMetadata ?? []);
     this.setExtrusionDimensions(metadata?.extrusionDimensions ?? []);
+    this.deriveDimensions = metadata?.deriveExtrusionDimensions === true;
+    const filamentDiameter = metadata?.filamentDiameter ?? DEFAULT_FILAMENT_DIAMETER;
+    this.filamentCrossSection = Math.PI * (filamentDiameter / 2) ** 2;
   }
 
   /**
@@ -126,6 +156,69 @@ export class Job {
       if (dimension.width !== undefined) this.state.extrusionWidth = dimension.width;
       if (dimension.height !== undefined) this.state.lineHeight = dimension.height;
     }
+  }
+
+  /**
+   * Derives the extrusion dimensions of the move about to be executed and
+   * folds them into the state, best-effort
+   * @param target - The move's physical endpoint; an axis the move leaves
+   * unchanged carries the current (possibly unknown) state value
+   * @param deltaE - The filament length the move extrudes (see `State.trackE`)
+   * @remarks
+   * Active only when the slicer metadata asked for it (Cura, whose files
+   * announce no dimension comments); paths then carry these derived values as
+   * their own, taking the same render-time precedence over the global
+   * fallback as comment-announced dimensions do. Move handlers call this for
+   * extruding moves before `continuePath`, so a change breaks the path
+   * exactly like a `;WIDTH:` / `;HEIGHT:` comment would.
+   *
+   * Layer height is the Z step between consecutive extrusion moves (the
+   * first one's Z stands in for the first layer). Only extrusion Zs are
+   * compared, so z-hop travels are invisible; a zero step (ironing, or
+   * printing on within the layer) and steps outside 0.01–1.0 mm (spiralize's
+   * continuous micro-climb, a probe artifact, moving down to a second
+   * sequential object) keep the current height.
+   *
+   * Width comes from conservation of volume with a rectangular deposit
+   * cross-section — width = (ΔE × filament cross-section) / (length ×
+   * height) — matching the box profile ExtrusionGeometry extrudes. The
+   * result is quantized to 0.01 mm and kept within 2% of the current width,
+   * so E-value rounding noise cannot break the model into micro-paths, and
+   * discarded entirely when implausible (outside 0.1–2.0 mm, or over a
+   * segment too short to measure).
+   */
+  deriveMoveDimensions(
+    target: { x: number | undefined; y: number | undefined; z: number | undefined },
+    deltaE: number
+  ): void {
+    if (!this.deriveDimensions || deltaE <= 0) return;
+
+    if (target.z !== undefined) {
+      const step = this.lastExtrusionZ === undefined ? target.z : target.z - this.lastExtrusionZ;
+      if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
+        // rounded so consecutive layers with equal heights compare equal
+        // despite floating-point Z subtraction noise
+        this.state.lineHeight = Math.round(step * 10000) / 10000;
+      }
+      this.lastExtrusionZ = target.z;
+    }
+
+    const height = this.state.lineHeight;
+    if (height === undefined) return;
+
+    // Resolved exactly like the rendered geometry: an unknown axis is assumed
+    // at the origin (see resolvePosition).
+    const from = this.resolvePosition();
+    const length = Math.hypot((target.x ?? 0) - from.x, (target.y ?? 0) - from.y, (target.z ?? 0) - from.z);
+    if (length < MIN_DERIVED_SEGMENT_LENGTH) return;
+
+    const width = (deltaE * this.filamentCrossSection) / (length * height);
+    if (width < MIN_DERIVED_WIDTH || width > MAX_DERIVED_WIDTH) return;
+
+    const quantized = Math.round(width * 100) / 100;
+    const current = this.state.extrusionWidth;
+    if (current !== undefined && Math.abs(quantized - current) <= current * DERIVED_WIDTH_TOLERANCE) return;
+    this.state.extrusionWidth = quantized;
   }
 
   /**

--- a/src/job.ts
+++ b/src/job.ts
@@ -210,10 +210,14 @@ export class Job {
     // at the origin (see resolvePosition).
     const from = this.resolvePosition();
     const length = Math.hypot((target.x ?? 0) - from.x, (target.y ?? 0) - from.y, (target.z ?? 0) - from.z);
-    if (length < MIN_DERIVED_SEGMENT_LENGTH) return;
+    // Number.isFinite: overflowing (yet individually finite) coordinates can
+    // make hypot Infinity — or NaN via Inf - Inf — and both pass a plain `<`
+    if (!Number.isFinite(length) || length < MIN_DERIVED_SEGMENT_LENGTH) return;
 
     const width = (deltaE * this.filamentCrossSection) / (length * height);
-    if (width < MIN_DERIVED_WIDTH || width > MAX_DERIVED_WIDTH) return;
+    // inclusive form so NaN (e.g. from an Infinity/Infinity overflow) is
+    // rejected rather than latched into the state and every path after it
+    if (!(width >= MIN_DERIVED_WIDTH && width <= MAX_DERIVED_WIDTH)) return;
 
     const quantized = Math.round(width * 100) / 100;
     const current = this.state.extrusionWidth;

--- a/src/parser/cura-parser.ts
+++ b/src/parser/cura-parser.ts
@@ -15,6 +15,45 @@ export class CuraMetadataParser extends SlicerMetadataParser {
   readonly identificationPatterns = [/^LAYER:\d+/, /Cura_SteamEngine/i, /Generated with Cura/i, /CURA_/i];
 
   /**
+   * How many header comments to sample for flavor detection. Cura puts the
+   * `;FLAVOR:` line first in the file, so a small sample is plenty.
+   */
+  private static readonly HEADER_SAMPLE = 200;
+
+  /**
+   * Whether per-path extrusion dimensions should be derived from the moves
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns True except for the volumetric UltiGCode flavor
+   * @remarks
+   * Cura emits no `;WIDTH:` / `;HEIGHT:` comments, so dimensions can only be
+   * reconstructed from extrusion amounts and Z changes. The UltiGCode flavor
+   * (Ultimaker 2 era) is excluded: its E values are cubic millimeters of
+   * material rather than millimeters of filament, which the derivation does
+   * not model — deriving from them would produce confidently wrong widths.
+   */
+  derivesExtrusionDimensions(commentCommands: GCodeCommand[]): boolean {
+    const sample = commentCommands.slice(0, CuraMetadataParser.HEADER_SAMPLE);
+    return !sample.some((cmd) => /^FLAVOR:UltiGCode/i.test(cmd.comment!));
+  }
+
+  /**
+   * Reads the filament diameter implied by the header flavor
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns 2.85 for the Griffin flavor, otherwise undefined
+   * @remarks
+   * Cura's own `material_diameter` setting only appears in the `;SETTING_3`
+   * blob at the very end of the file, too late to inform the derivation of
+   * the moves that precede it (see the base class remarks). The `;FLAVOR:`
+   * header line is emitted first instead, and Griffin is only ever generated
+   * for Ultimaker's own 2.85 mm machines (UM3 and S-line); every other
+   * flavor falls back to the 1.75 mm default downstream.
+   */
+  parseFilamentDiameter(commentCommands: GCodeCommand[]): number | undefined {
+    const sample = commentCommands.slice(0, CuraMetadataParser.HEADER_SAMPLE);
+    return sample.some((cmd) => /^FLAVOR:Griffin/i.test(cmd.comment!)) ? 2.85 : undefined;
+  }
+
+  /**
    * Parses layer metadata from Cura comments
    * @param commands - Array of gcode commands with comments
    * @returns Array of layer metadata

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -109,6 +109,14 @@ export type Metadata = {
   /** Extrusion dimension changes from `;WIDTH:` / `;HEIGHT:` comments, in line order */
   extrusionDimensions?: ExtrusionDimensionMetadata[];
   slicerName?: string;
+  /**
+   * Set when the detected slicer announces no dimension comments (Cura), so
+   * per-path width and height should be derived from the moves instead
+   * (see `Job.deriveMoveDimensions`)
+   */
+  deriveExtrusionDimensions?: boolean;
+  /** Filament diameter in millimeters announced by header comments, when known */
+  filamentDiameter?: number;
 };
 
 /**
@@ -236,9 +244,18 @@ export class Parser {
     if (!this.metadataParser) {
       this.metadataParser = detectSlicer(commands);
       // The slicer name comes from the chunk that identified the slicer -- a
-      // later chunk may contain layer comments but not the header.
+      // later chunk may contain layer comments but not the header. The same
+      // goes for the dimension derivation flag and the filament diameter:
+      // both read header comments, which sit in the identifying chunk.
       if (this.metadataParser) {
         this.metadata.slicerName = this.metadataParser.detectSlicerName(comments);
+        if (this.metadataParser.derivesExtrusionDimensions(comments)) {
+          this.metadata.deriveExtrusionDimensions = true;
+        }
+        const filamentDiameter = this.metadataParser.parseFilamentDiameter(comments);
+        if (filamentDiameter !== undefined) {
+          this.metadata.filamentDiameter = filamentDiameter;
+        }
       }
     }
     const slicerMetadata = parseSlicerMetadata(commands, this.metadataParser);

--- a/src/parser/metadata-parser-base.ts
+++ b/src/parser/metadata-parser-base.ts
@@ -100,4 +100,40 @@ export abstract class SlicerMetadataParser {
   parseExtrusionDimensions(commands: GCodeCommand[]): ExtrusionDimensionMetadata[] {
     return [];
   }
+
+  /**
+   * Whether per-path extrusion dimensions should be derived from the moves
+   * themselves for this gcode
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns True when the job should derive dimensions volumetrically
+   * @remarks
+   * Dialects that announce no dimension comments at all (Cura) opt in here,
+   * so the job can reconstruct per-path width and height from extrusion
+   * amounts and Z changes instead. Dialects with explicit `;WIDTH:` /
+   * `;HEIGHT:` comments keep the default `false`: their announced values are
+   * exact and must not be overridden by derived approximations. Evaluated on
+   * the chunk that identified the slicer (like `detectSlicerName`), so it can
+   * inspect header comments.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  derivesExtrusionDimensions(commentCommands: GCodeCommand[]): boolean {
+    return false;
+  }
+
+  /**
+   * Reads the filament diameter announced in header comments, when any
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns The filament diameter in millimeters, or undefined when unknown
+   * @remarks
+   * Feeds the volumetric dimension derivation (see
+   * `derivesExtrusionDimensions`), which converts extruded filament lengths
+   * into deposited volume. Only header-borne values may be reported here: a
+   * diameter that appears after moves (like Cura's end-of-file `;SETTING_3`
+   * blob) would reach a one-shot parse before any move executes but a
+   * streamed parse only after every move already ran, making the two disagree.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  parseFilamentDiameter(commentCommands: GCodeCommand[]): number | undefined {
+    return undefined;
+  }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,8 +12,17 @@ export class State {
   y: number | undefined = undefined;
   /** Current Z position, or `undefined` until the axis is homed (G28) */
   z: number | undefined = undefined;
-  /** Current extrusion amount */
+  /** Current extruder position, tracked by `trackE` and reset by G92 */
   e = 0;
+  /**
+   * Whether E parameters are relative distances (M83) rather than absolute
+   * extruder positions (M82).
+   * @remarks
+   * Defaults to absolute, matching the Marlin firmware default. Only the E
+   * accounting in `trackE` consults this; move classification (`e > 0` means
+   * extrusion) is deliberately unchanged in either mode.
+   */
+  relativeExtrusion = false;
   /**
    * Shift between the logical G-code coordinates and the physical position,
    * created by G92: `physical = logical + positionShift`.
@@ -60,6 +69,27 @@ export class State {
    * the job's decision (see `Job.resolvePosition`), not the state's.
    */
   isHomed = false;
+
+  /**
+   * Applies a move's E parameter to the extruder position
+   * @param e - The move's E parameter, or undefined when the move has none
+   * @returns The filament length this move extrudes (negative for retractions)
+   * @remarks
+   * In relative mode (M83) the parameter is the extruded length itself; in
+   * absolute mode (M82) the length is the difference with the tracked
+   * position. Both modes leave `e` at the move's resulting extruder position,
+   * so G92 E resets (which set `e` directly) compose naturally with either.
+   */
+  trackE(e: number | undefined): number {
+    if (e === undefined) return 0;
+    if (this.relativeExtrusion) {
+      this.e += e;
+      return e;
+    }
+    const delta = e - this.e;
+    this.e = e;
+    return delta;
+  }
 
   /**
    * Gets a new State instance with default initial values


### PR DESCRIPTION
Derives per-path line height and extrusion width for Cura-sliced files, which announce no `;WIDTH:`/`;HEIGHT:` comments — heights come from the Z steps between extrusion moves, widths from conservation of volume (ΔE × filament cross-section / (length × height), rectangular deposit matching what `ExtrusionGeometry` renders).

Stacked on #458.

Five first-layer lines printed at 1.2 / 0.9 / 0.6 / 0.4 / 0.25 mm, same camera in both shots:

| Before: every line the same 0.6 mm | After: derived widths |
| --- | --- |
| ![Five parallel first-layer lines, all rendered at an identical 0.6 mm width because the file announces no dimensions](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-459-assets/width-fan-before.png) | ![The same five lines with derived widths, tapering from a fat 1.2 mm bead at the bottom to a hairline 0.25 mm one at the top](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-459-assets/width-fan-after.png) |

Heights come out of the Z steps, so the tower's three tiers stack visibly differently — 0.3 mm at the bottom, 0.2 mm in the middle, 0.1 mm on top:

![Close-up of the tower wall: four fat beads in the bottom tier, eight medium ones in the middle, about twenty hairline beads in the top tier](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-459-assets/layer-height-tiers.png)

Design decisions:

- Derivation only activates when the detected slicer's dialect has no dimension comments (Cura, minus the volumetric UltiGCode flavor); Prusa-family files keep their exact comment values, unrecognized files render exactly as before.
- Derived values count as the path's own dimensions, so they beat the global fallback with the same precedence and path-breaking behavior as comment-announced ones.
- New M82/M83 handlers plus `State.trackE` give real absolute/relative E accounting (closes #419); z-hops, ironing, spiralize, G92 E resets and adaptive layer heights are all handled, with implausible results clamped away.
- Filament diameter comes from the header `;FLAVOR:` line (Griffin = Ultimaker 2.85 mm, else 1.75 mm). Cura's `material_diameter` sits in the end-of-file `;SETTING_3` blob — using it would make streamed and one-shot parses disagree, so it is deliberately not read.
- Derived widths are quantized to 0.01 mm with a 2% tolerance so E-rounding noise cannot shatter the model into micro-paths; streamed vs one-shot equivalence is covered by a new Cura fixture in the ingestion harness, and synthetic round-trip tests recover programmed dimensions through the inverted volumetric formula.

Assisted by Claude Code - Fable 5
