### PR TITLE
Derive per-path line height and extrusion width from the moves

### DIFF
--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -287,6 +287,51 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
     expect(paths[3].vertices).toEqual([10, 20, 0.16, 10, 10, 0.16]);
   });
 
+  test('a Cura file derives the same per-path dimensions and breaks', async () => {
+    // Cura announces no dimension comments, so widths and heights are derived
+    // from the moves: E values below deposit 0.4mm (E steps of 0.33260 per
+    // 10mm at 0.2mm height, computed from the volumetric model for 1.75mm
+    // filament) then 0.6mm (step 0.49890) wide lines. The layer change and
+    // the width shift land mid-file, so the 1- and 7-byte chunkers cut right
+    // through the derivation state: the extruder position, the last extrusion
+    // Z and the derived dimensions must all carry across chunk boundaries for
+    // every mode to break the same paths with the same dimensions.
+    const gcode = [
+      ';FLAVOR:Marlin',
+      ';Generated with Cura_SteamEngine 5.7.0',
+      'M82',
+      'G28',
+      ';LAYER:0',
+      'G0 X10 Y10 Z0.2',
+      'G1 X20 Y10 E0.33260',
+      'G1 X20 Y20 E0.66520',
+      ';TYPE:FILL',
+      'G1 X10 Y20 E1.16410',
+      ';LAYER:1',
+      'G0 Z0.4',
+      'G1 X10 Y10 E1.49670'
+    ].join('\n');
+
+    await ingest(preview, gcode);
+
+    const paths = preview.job.paths;
+    expect(paths.length).toEqual(5);
+    // the leading travel predates any extrusion, so it carries no dimensions;
+    // every later path carries the derived values in effect when it started
+    expect(paths.map((path) => [path.extrusionWidth, path.lineHeight])).toEqual([
+      [undefined, undefined],
+      [0.4, 0.2],
+      [0.6, 0.2],
+      [0.6, 0.2],
+      [0.4, 0.2]
+    ]);
+    // the width shift broke the extrusion exactly at the FILL move
+    expect(paths[1].vertices).toEqual([10, 10, 0.2, 20, 10, 0.2, 20, 20, 0.2]);
+    expect(paths[2].vertices).toEqual([20, 20, 0.2, 10, 20, 0.2]);
+    // and the second layer continues from the travel's endpoint
+    expect(paths[4].vertices).toEqual([10, 20, 0.4, 10, 10, 0.4]);
+  });
+
   test('known extrusion coordinates produce the exact same bounding box', async () => {
     // The bounding box only tracks extrusion endpoints, so the corners come
     // straight from the three G1 targets below.

--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -287,8 +287,8 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
     expect(paths[3].vertices).toEqual([10, 20, 0.16, 10, 10, 0.16]);
   });
 
-  test('a Cura file derives the same per-path dimensions and breaks', async () => {
-    // Cura announces no dimension comments, so widths and heights are derived
+  test('a file without dimension comments derives the same dimensions and breaks', async () => {
+    // Nothing announces width or height here, so both are derived
     // from the moves: E values below deposit 0.4mm (E steps of 0.33260 per
     // 10mm at 0.2mm height, computed from the volumetric model for 1.75mm
     // filament) then 0.6mm (step 0.49890) wide lines. The layer change and

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -191,6 +191,166 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
   });
 });
 
+describe('derived extrusion dimensions (Cura)', () => {
+  const FILAMENT_AREA = Math.PI * (1.75 / 2) ** 2;
+
+  /** The E increment depositing a width×height×length box of 1.75mm filament */
+  const eFor = (width: number, height: number, length: number) => (width * height * length) / FILAMENT_AREA;
+
+  /** Accumulates absolute E positions the way Cura emits them (5 decimals) */
+  const absoluteE = () => {
+    let e = 0;
+    return (width: number, height: number, length: number) => {
+      e += eFor(width, height, length);
+      return e.toFixed(5);
+    };
+  };
+
+  /** Parses and executes a Cura-style file: real header, then the given body */
+  const run = (lines: string[]) => {
+    const { commands, metadata } = new Parser().parseGCode(
+      [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', 'M82', 'G28', ...lines].join('\n')
+    );
+    const job = new Job();
+    job.metadata = metadata;
+    return new Interpreter().execute(commands, job);
+  };
+
+  const dimensions = (job: Job) => job.extrusions.map((path) => [path.extrusionWidth, path.lineHeight]);
+
+  test('round-trips programmed widths and heights through the volumetric model', () => {
+    // The E values are computed from the exact widths and heights the
+    // derivation should recover; a width change mid-layer must break the path.
+    const E = absoluteE();
+    const job = run([
+      ';LAYER:0',
+      'G0 X10 Y10 Z0.2',
+      `G1 X20 Y10 E${E(0.4, 0.2, 10)}`,
+      `G1 X20 Y20 E${E(0.4, 0.2, 10)}`,
+      ';TYPE:FILL',
+      `G1 X10 Y20 E${E(0.6, 0.2, 10)}`,
+      ';LAYER:1',
+      'G0 Z0.4',
+      `G1 X10 Y10 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.6, 0.2],
+      [0.4, 0.2]
+    ]);
+    // the width change broke the path exactly at the FILL move
+    expect(job.extrusions[0].vertices).toEqual([10, 10, 0.2, 20, 10, 0.2, 20, 20, 0.2]);
+    expect(job.extrusions[1].vertices).toEqual([20, 20, 0.2, 10, 20, 0.2]);
+  });
+
+  test('recovers an adaptive layer height sequence from the Z steps', () => {
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      'G0 Z0.36',
+      `G1 X0 Y0 E${E(0.4, 0.16, 10)}`,
+      'G0 Z0.66',
+      `G1 X10 Y0 E${E(0.4, 0.3, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.16],
+      [0.4, 0.3]
+    ]);
+  });
+
+  test('a z-hop travel between layers does not corrupt the derived height', () => {
+    // The hop raises Z to 0.7 mid-travel; the height must come from the
+    // extrusion Zs (0.2 then 0.4), not from the last-seen Z.
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      'G0 Z0.7',
+      'G0 X20 Y0',
+      'G0 Z0.4',
+      `G1 X30 Y0 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.2]
+    ]);
+  });
+
+  test('a G92 E reset between layers keeps the extruded lengths right', () => {
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`,
+      'G92 E0',
+      'G0 Z0.4',
+      `G1 X0 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.4, 0.2]
+    ]);
+  });
+
+  test('relative extrusion mode (M83) derives the same dimensions', () => {
+    const job = run([
+      'M83',
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${eFor(0.4, 0.2, 10).toFixed(5)}`,
+      `G1 X10 Y10 E${eFor(0.6, 0.2, 10).toFixed(5)}`
+    ]);
+
+    expect(dimensions(job)).toEqual([
+      [0.4, 0.2],
+      [0.6, 0.2]
+    ]);
+  });
+
+  test('ironing re-extrudes at the same Z without disturbing the dimensions', () => {
+    // The ironing pass deposits far too little material to be a real line
+    // (derived width 0.04); both its width and its zero Z step are discarded,
+    // so it continues the finished surface's path untouched.
+    const E = absoluteE();
+    const job = run(['G0 X0 Y0 Z0.2', `G1 X10 Y0 E${E(0.4, 0.2, 10)}`, `G1 X0 Y0 E${E(0.04, 0.2, 10)}`]);
+
+    expect(job.extrusions.length).toEqual(1);
+    expect(job.extrusions[0].vertices).toEqual([0, 0, 0.2, 10, 0, 0.2, 0, 0, 0.2]);
+    expect(dimensions(job)).toEqual([[0.4, 0.2]]);
+  });
+
+  test("spiralize's continuous micro-climb keeps the layer height it entered with", () => {
+    const E = absoluteE();
+    const job = run([
+      'G0 X0 Y0 Z0.2',
+      `G1 X10 Y0 E${E(0.4, 0.2, 10)}`,
+      `G1 X10 Y10 Z0.205 E${E(0.4, 0.2, 10)}`,
+      `G1 X0 Y10 Z0.21 E${E(0.4, 0.2, 10)}`
+    ]);
+
+    // each 0.005 step is below the plausible layer range and is skipped
+    expect(job.extrusions.length).toEqual(1);
+    expect(dimensions(job)).toEqual([[0.4, 0.2]]);
+  });
+
+  test('an UltiGCode-flavored file derives nothing', () => {
+    // UltiGCode E values are mm³, which the filament-length model would turn
+    // into confidently wrong widths; the parser leaves derivation off.
+    const { commands, metadata } = new Parser().parseGCode(
+      [';FLAVOR:UltiGCode', ';LAYER:0', 'G0 X0 Y0 Z0.2', 'G1 X10 Y0 E1.6'].join('\n')
+    );
+    const job = new Job();
+    job.metadata = metadata;
+    new Interpreter().execute(commands, job);
+
+    expect(job.extrusions[0].extrusionWidth).toBeUndefined();
+    expect(job.extrusions[0].lineHeight).toBeUndefined();
+  });
+});
+
 describe('malformed coordinates through the whole pipeline', () => {
   const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
   const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -140,7 +140,10 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
   });
 
   test('a HEIGHT change mid-path breaks the path, continuing from the same point', () => {
-    const job = run([';HEIGHT:0.2', 'G1 X10 Y10 E1', 'G1 X20 Y10 E1', ';HEIGHT:0.3', 'G1 X30 Y10 E1']);
+    // The announced WIDTH keeps the derivation out of it: these moves extrude
+    // the same E over different lengths, so a derived width would change and
+    // break the path on its own.
+    const job = run([';WIDTH:0.45', ';HEIGHT:0.2', 'G1 X10 Y10 E1', 'G1 X20 Y10 E1', ';HEIGHT:0.3', 'G1 X30 Y10 E1']);
 
     expect(job.paths.length).toEqual(2);
     expect(job.paths[0].lineHeight).toEqual(0.2);
@@ -188,6 +191,38 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
     expect(job.paths.length).toEqual(1);
     expect(job.paths[0].extrusionWidth).toBeUndefined();
     expect(job.paths[0].lineHeight).toBeUndefined();
+  });
+
+  test('an announced width outranks the width derived from the same move', () => {
+    // The move's volume implies ~1.2mm; the slicer says 0.45, and the slicer
+    // is stating what it asked for rather than inferring it.
+    const job = run([';WIDTH:0.45', ';HEIGHT:0.2', 'G0 X0 Y0 Z0.2', 'G1 X10 Y0 E1']);
+
+    expect(job.extrusions[0].extrusionWidth).toEqual(0.45);
+  });
+
+  test('a file no slicer parser recognises still derives its dimensions', () => {
+    // The point of deriving: it is the default for any gcode, not a Cura
+    // feature. This has no slicer fingerprint at all.
+    const { commands, metadata } = new Parser().parseGCode(
+      ['M83', 'G28', 'G0 X0 Y0 Z0.2', 'G1 X10 Y0 E0.48'].join('\n')
+    );
+    const job = new Job();
+    job.metadata = metadata;
+    new Interpreter().execute(commands, job);
+
+    expect(metadata.slicerName).toBeUndefined();
+    expect(job.extrusions[0].lineHeight).toEqual(0.2);
+    expect(job.extrusions[0].extrusionWidth).toBeGreaterThan(0);
+  });
+
+  test('a derived width change breaks the path, like an announced one', () => {
+    // Same E over half the distance means twice the bead width (0.6 -> 1.2),
+    // so the second move cannot share a path with the first.
+    const job = run(['M83', 'G0 X0 Y0 Z0.2', 'G1 X20 Y0 E1', 'G1 X30 Y0 E1']);
+
+    expect(job.extrusions.length).toEqual(2);
+    expect(job.extrusions[1].extrusionWidth).toBeGreaterThan(job.extrusions[0].extrusionWidth!);
   });
 });
 

--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -226,13 +226,13 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
   });
 });
 
-describe('derived extrusion dimensions (Cura)', () => {
+describe('extrusion dimensions derived from the moves', () => {
   const FILAMENT_AREA = Math.PI * (1.75 / 2) ** 2;
 
   /** The E increment depositing a width×height×length box of 1.75mm filament */
   const eFor = (width: number, height: number, length: number) => (width * height * length) / FILAMENT_AREA;
 
-  /** Accumulates absolute E positions the way Cura emits them (5 decimals) */
+  /** Accumulates absolute E positions the way a slicer emits them (5 decimals) */
   const absoluteE = () => {
     let e = 0;
     return (width: number, height: number, length: number) => {
@@ -241,7 +241,11 @@ describe('derived extrusion dimensions (Cura)', () => {
     };
   };
 
-  /** Parses and executes a Cura-style file: real header, then the given body */
+  /**
+   * Parses and executes a file that announces no dimensions: a Cura header
+   * stands in for one, since Cura is the slicer that never announces them,
+   * but nothing here depends on the dialect — deriving is the default.
+   */
   const run = (lines: string[]) => {
     const { commands, metadata } = new Parser().parseGCode(
       [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', 'M82', 'G28', ...lines].join('\n')

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, vi, afterEach } from 'vitest';
 import { Job } from '../job';
+import { Metadata } from '../parser/gcode-parser';
 import { PathType, Path } from '../path';
 import { State } from '../state';
 import { LayersIndexer, NonApplicableIndexer, TravelTypeIndexer } from '../indexers';
@@ -687,6 +688,178 @@ describe('.beginCommand', () => {
 
     expect(job.state.extrusionWidth).toBeUndefined();
     expect(job.state.lineHeight).toBeUndefined();
+  });
+});
+
+describe('.deriveMoveDimensions', () => {
+  const FILAMENT_AREA = Math.PI * (1.75 / 2) ** 2;
+  /** Extruded filament length depositing a w×h×len box (the derivation's model, inverted) */
+  const eFor = (width: number, height: number, length: number, area = FILAMENT_AREA) =>
+    (width * height * length) / area;
+
+  /** A job with derivation enabled, positioned at (0, 0, z) */
+  const derivingJob = (metadata: Partial<Metadata> = {}, z = 0.2) => {
+    const job = new Job();
+    job.metadata = { thumbnails: {}, deriveExtrusionDimensions: true, ...metadata };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = z;
+    return job;
+  };
+
+  test('does nothing unless the metadata asked for derivation', () => {
+    const job = new Job();
+    job.metadata = { thumbnails: {} };
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.lineHeight).toBeUndefined();
+  });
+
+  test('does nothing for a move that extrudes nothing', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, 0);
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, -1);
+
+    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.lineHeight).toBeUndefined();
+  });
+
+  test('the first extrusion derives its height from Z itself and its width from the volume', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('a later extrusion derives its height from the Z step since the previous one', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.state.z = 0.36;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.36 }, eFor(0.4, 0.16, 10));
+
+    expect(job.state.lineHeight).toEqual(0.16);
+  });
+
+  test('extruding again at the same Z (ironing) keeps the current height', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+  });
+
+  test('an implausible Z step keeps the height but re-anchors the next step', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    // jumping to a second sequential object: the 2.8mm step is no layer height
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 3 }, eFor(0.4, 0.2, 10));
+    expect(job.state.lineHeight).toEqual(0.2);
+
+    // ...but the next layer measures from the new Z, not the stale one
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 3.25 }, eFor(0.4, 0.25, 10));
+    expect(job.state.lineHeight).toEqual(0.25);
+  });
+
+  test('moving down keeps the current height', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.4 }, eFor(0.4, 0.4, 10));
+
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.3 }, eFor(0.4, 0.4, 10));
+
+    expect(job.state.lineHeight).toEqual(0.4);
+  });
+
+  test('an unknown Z derives no height, and without a height no width either', () => {
+    const job = derivingJob();
+    job.state.z = undefined;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: undefined }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.lineHeight).toBeUndefined();
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('a segment too short to measure derives no width', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 0.01, y: 0, z: 0.2 }, eFor(0.4, 0.2, 0.01));
+
+    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('implausible widths are discarded instead of stamped on paths', () => {
+    const job = derivingJob();
+
+    // far too much material for the segment: a prime blob, not a 3mm line
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(3, 0.2, 10));
+    expect(job.state.extrusionWidth).toBeUndefined();
+
+    // far too little: a near-dry wipe
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.05, 0.2, 10));
+    expect(job.state.extrusionWidth).toBeUndefined();
+  });
+
+  test('the derived width is quantized to 0.01mm', () => {
+    const job = derivingJob();
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.3985, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('a width within 2% of the current one keeps the current value', () => {
+    // E-value rounding noise must not shatter the model into micro-paths.
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.6, 0.2, 10));
+
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.61, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.6);
+  });
+
+  test('a real width change beyond the tolerance is applied', () => {
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.state.x = 10;
+    job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.42, 0.2, 10));
+
+    expect(job.state.extrusionWidth).toEqual(0.42);
+  });
+
+  test('the metadata filament diameter scales the derived width', () => {
+    const area285 = Math.PI * (2.85 / 2) ** 2;
+    const job = derivingJob({ filamentDiameter: 2.85 });
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10, area285));
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+  });
+
+  test('unknown axes are assumed at the origin, like the rendered geometry', () => {
+    const job = derivingJob();
+    job.state.x = undefined;
+
+    // X never homed: the segment runs from the assumed origin to (0,10)
+    job.deriveMoveDimensions({ x: undefined, y: 10, z: 0.2 }, eFor(0.4, 0.2, 10));
+    expect(job.state.extrusionWidth).toEqual(0.4);
+
+    // Y and Z unknown too; the height derived above still measures the width
+    job.state.y = undefined;
+    job.state.z = undefined;
+    job.deriveMoveDimensions({ x: 10, y: undefined, z: undefined }, eFor(0.42, 0.2, 10));
+    expect(job.state.extrusionWidth).toEqual(0.42);
   });
 });
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -850,7 +850,7 @@ describe('.deriveMoveDimensions', () => {
   test('overflowing coordinates and E values never latch NaN into the width', () => {
     // Individually finite params survive the parser, but 1.7e308-scale
     // values overflow the length (hypot -> Infinity) and the volume
-    // (deltaE x area -> Infinity), whose ratio is NaN — which a plain
+    // (extruded x area -> Infinity), whose ratio is NaN — which a plain
     // range check would wave through and stamp on every path after it.
     const job = derivingJob();
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -697,6 +697,15 @@ describe('.deriveMoveDimensions', () => {
   const eFor = (width: number, height: number, length: number, area = FILAMENT_AREA) =>
     (width * height * length) / area;
 
+  /**
+   * The dimensions a path started right now would carry. The derived values
+   * are the Job's own business, so these assert what reaches a path instead.
+   */
+  const dimsOf = (job: Job) => {
+    const path = job.breakPath(PathType.Extrusion);
+    return { width: path.extrusionWidth, height: path.lineHeight };
+  };
+
   /** A job with derivation enabled, positioned at (0, 0, z) */
   const derivingJob = (metadata: Partial<Metadata> = {}, z = 0.2) => {
     const job = new Job();
@@ -717,9 +726,11 @@ describe('.deriveMoveDimensions', () => {
     job.state.z = 0.2;
     job.deriveMoveDimensions({ x: 20, y: 0, z: 0.45 }, eFor(0.4, 0.25, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.25);
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
-    expect(job.state.resolvedExtrusionWidth).toEqual(0.45);
+    const dims = dimsOf(job);
+    // the height kept being derived across the Z step ...
+    expect(dims.height).toEqual(0.25);
+    // ... while the announced width is what the path carries
+    expect(dims.width).toEqual(0.45);
   });
 
   test('a width supplied through the public API is not derived over', () => {
@@ -732,8 +743,8 @@ describe('.deriveMoveDimensions', () => {
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
     // the height still derives; only the supplied dimension is left alone
-    expect(job.state.derivedLineHeight).toEqual(0.2);
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(dimsOf(job).height).toEqual(0.2);
+    expect(dimsOf(job).width).toBeUndefined();
   });
 
   test('a height supplied through the public API still feeds the width derivation', () => {
@@ -745,8 +756,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.3 }, eFor(0.5, 0.3, 10));
 
-    expect(job.state.derivedLineHeight).toBeUndefined();
-    expect(job.state.derivedExtrusionWidth).toEqual(0.5);
+    expect(dimsOf(job).height).toBeUndefined();
+    expect(dimsOf(job).width).toEqual(0.5);
   });
 
   test('derives by default, without the metadata asking for it', () => {
@@ -758,8 +769,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.2);
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(dimsOf(job).height).toEqual(0.2);
+    expect(dimsOf(job).width).toEqual(0.4);
   });
 
   test('does nothing once the metadata opts out', () => {
@@ -771,8 +782,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
-    expect(job.state.derivedLineHeight).toBeUndefined();
+    expect(dimsOf(job).width).toBeUndefined();
+    expect(dimsOf(job).height).toBeUndefined();
   });
 
   test('does nothing for a move that extrudes nothing', () => {
@@ -781,8 +792,8 @@ describe('.deriveMoveDimensions', () => {
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, 0);
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, -1);
 
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
-    expect(job.state.derivedLineHeight).toBeUndefined();
+    expect(dimsOf(job).width).toBeUndefined();
+    expect(dimsOf(job).height).toBeUndefined();
   });
 
   test('the first extrusion derives its height from Z itself and its width from the volume', () => {
@@ -790,8 +801,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.2);
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(dimsOf(job).height).toEqual(0.2);
+    expect(dimsOf(job).width).toEqual(0.4);
   });
 
   test('a later extrusion derives its height from the Z step since the previous one', () => {
@@ -801,7 +812,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.z = 0.36;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.36 }, eFor(0.4, 0.16, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.16);
+    expect(dimsOf(job).height).toEqual(0.16);
   });
 
   test('extruding again at the same Z (ironing) keeps the current height', () => {
@@ -810,7 +821,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(dimsOf(job).height).toEqual(0.2);
   });
 
   test('an implausible Z step keeps the height but re-anchors the next step', () => {
@@ -819,11 +830,11 @@ describe('.deriveMoveDimensions', () => {
 
     // jumping to a second sequential object: the 2.8mm step is no layer height
     job.deriveMoveDimensions({ x: 0, y: 0, z: 3 }, eFor(0.4, 0.2, 10));
-    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(dimsOf(job).height).toEqual(0.2);
 
     // ...but the next layer measures from the new Z, not the stale one
     job.deriveMoveDimensions({ x: 10, y: 0, z: 3.25 }, eFor(0.4, 0.25, 10));
-    expect(job.state.derivedLineHeight).toEqual(0.25);
+    expect(dimsOf(job).height).toEqual(0.25);
   });
 
   test('moving down keeps the current height', () => {
@@ -832,7 +843,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.3 }, eFor(0.4, 0.4, 10));
 
-    expect(job.state.derivedLineHeight).toEqual(0.4);
+    expect(dimsOf(job).height).toEqual(0.4);
   });
 
   test('an unknown Z derives no height, and without a height no width either', () => {
@@ -841,8 +852,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: undefined }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.derivedLineHeight).toBeUndefined();
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(dimsOf(job).height).toBeUndefined();
+    expect(dimsOf(job).width).toBeUndefined();
   });
 
   test('a segment too short to measure derives no width', () => {
@@ -850,8 +861,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0.01, y: 0, z: 0.2 }, eFor(0.4, 0.2, 0.01));
 
-    expect(job.state.derivedLineHeight).toEqual(0.2);
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(dimsOf(job).height).toEqual(0.2);
+    expect(dimsOf(job).width).toBeUndefined();
   });
 
   test('implausible widths are discarded instead of stamped on paths', () => {
@@ -859,12 +870,12 @@ describe('.deriveMoveDimensions', () => {
 
     // far too much material for the segment: a prime blob, not a 3mm line
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(3, 0.2, 10));
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(dimsOf(job).width).toBeUndefined();
 
     // far too little: a near-dry wipe
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.05, 0.2, 10));
-    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(dimsOf(job).width).toBeUndefined();
   });
 
   test('the derived width is quantized to 0.01mm', () => {
@@ -872,7 +883,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.3985, 0.2, 10));
 
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(dimsOf(job).width).toEqual(0.4);
   });
 
   test('a width within 2% of the current one keeps the current value', () => {
@@ -883,7 +894,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.61, 0.2, 10));
 
-    expect(job.state.derivedExtrusionWidth).toEqual(0.6);
+    expect(dimsOf(job).width).toEqual(0.6);
   });
 
   test('a real width change beyond the tolerance is applied', () => {
@@ -893,7 +904,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.42, 0.2, 10));
 
-    expect(job.state.derivedExtrusionWidth).toEqual(0.42);
+    expect(dimsOf(job).width).toEqual(0.42);
   });
 
   test('the metadata filament diameter scales the derived width', () => {
@@ -902,7 +913,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10, area285));
 
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(dimsOf(job).width).toEqual(0.4);
   });
 
   test('overflowing coordinates and E values never latch NaN into the width', () => {
@@ -915,8 +926,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 1.7e308, y: 1.7e308, z: 0.2 }, 1.7e308);
 
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
-    expect(Number.isFinite(job.state.derivedExtrusionWidth)).toBe(true);
+    expect(dimsOf(job).width).toEqual(0.4);
+    expect(Number.isFinite(dimsOf(job).width)).toBe(true);
   });
 
   test('unknown axes are assumed at the origin, like the rendered geometry', () => {
@@ -925,13 +936,13 @@ describe('.deriveMoveDimensions', () => {
 
     // X never homed: the segment runs from the assumed origin to (0,10)
     job.deriveMoveDimensions({ x: undefined, y: 10, z: 0.2 }, eFor(0.4, 0.2, 10));
-    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(dimsOf(job).width).toEqual(0.4);
 
     // Y and Z unknown too; the height derived above still measures the width
     job.state.y = undefined;
     job.state.z = undefined;
     job.deriveMoveDimensions({ x: 10, y: undefined, z: undefined }, eFor(0.42, 0.2, 10));
-    expect(job.state.derivedExtrusionWidth).toEqual(0.42);
+    expect(dimsOf(job).width).toEqual(0.42);
   });
 });
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -707,6 +707,48 @@ describe('.deriveMoveDimensions', () => {
     return job;
   };
 
+  test('keeps deriving the height while a width outranks the derived one', () => {
+    // The width shortcut must not skip the height block, or the Z anchor stops
+    // advancing and a file that announces only its width loses its heights.
+    const job = derivingJob();
+    job.state.extrusionWidth = 0.45;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+    job.state.z = 0.2;
+    job.deriveMoveDimensions({ x: 20, y: 0, z: 0.45 }, eFor(0.4, 0.25, 10));
+
+    expect(job.state.derivedLineHeight).toEqual(0.25);
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(job.state.resolvedExtrusionWidth).toEqual(0.45);
+  });
+
+  test('a width supplied through the public API is not derived over', () => {
+    const job = new Job({ extrusionWidth: 0.6 });
+    job.metadata = { thumbnails: {} };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = 0.2;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    // the height still derives; only the supplied dimension is left alone
+    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+  });
+
+  test('a height supplied through the public API still feeds the width derivation', () => {
+    const job = new Job({ lineHeight: 0.3 });
+    job.metadata = { thumbnails: {} };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = 0.3;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.3 }, eFor(0.5, 0.3, 10));
+
+    expect(job.state.derivedLineHeight).toBeUndefined();
+    expect(job.state.derivedExtrusionWidth).toEqual(0.5);
+  });
+
   test('derives by default, without the metadata asking for it', () => {
     const job = new Job();
     job.metadata = { thumbnails: {} };

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -707,14 +707,30 @@ describe('.deriveMoveDimensions', () => {
     return job;
   };
 
-  test('does nothing unless the metadata asked for derivation', () => {
+  test('derives by default, without the metadata asking for it', () => {
     const job = new Job();
     job.metadata = { thumbnails: {} };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = 0.2;
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.extrusionWidth).toBeUndefined();
-    expect(job.state.lineHeight).toBeUndefined();
+    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+  });
+
+  test('does nothing once the metadata opts out', () => {
+    const job = new Job();
+    job.metadata = { thumbnails: {}, deriveExtrusionDimensions: false };
+    job.state.x = 0;
+    job.state.y = 0;
+    job.state.z = 0.2;
+
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(job.state.derivedLineHeight).toBeUndefined();
   });
 
   test('does nothing for a move that extrudes nothing', () => {
@@ -723,8 +739,8 @@ describe('.deriveMoveDimensions', () => {
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, 0);
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, -1);
 
-    expect(job.state.extrusionWidth).toBeUndefined();
-    expect(job.state.lineHeight).toBeUndefined();
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
+    expect(job.state.derivedLineHeight).toBeUndefined();
   });
 
   test('the first extrusion derives its height from Z itself and its width from the volume', () => {
@@ -732,8 +748,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.lineHeight).toEqual(0.2);
-    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
   });
 
   test('a later extrusion derives its height from the Z step since the previous one', () => {
@@ -743,7 +759,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.z = 0.36;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.36 }, eFor(0.4, 0.16, 10));
 
-    expect(job.state.lineHeight).toEqual(0.16);
+    expect(job.state.derivedLineHeight).toEqual(0.16);
   });
 
   test('extruding again at the same Z (ironing) keeps the current height', () => {
@@ -752,7 +768,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.derivedLineHeight).toEqual(0.2);
   });
 
   test('an implausible Z step keeps the height but re-anchors the next step', () => {
@@ -761,11 +777,11 @@ describe('.deriveMoveDimensions', () => {
 
     // jumping to a second sequential object: the 2.8mm step is no layer height
     job.deriveMoveDimensions({ x: 0, y: 0, z: 3 }, eFor(0.4, 0.2, 10));
-    expect(job.state.lineHeight).toEqual(0.2);
+    expect(job.state.derivedLineHeight).toEqual(0.2);
 
     // ...but the next layer measures from the new Z, not the stale one
     job.deriveMoveDimensions({ x: 10, y: 0, z: 3.25 }, eFor(0.4, 0.25, 10));
-    expect(job.state.lineHeight).toEqual(0.25);
+    expect(job.state.derivedLineHeight).toEqual(0.25);
   });
 
   test('moving down keeps the current height', () => {
@@ -774,7 +790,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.3 }, eFor(0.4, 0.4, 10));
 
-    expect(job.state.lineHeight).toEqual(0.4);
+    expect(job.state.derivedLineHeight).toEqual(0.4);
   });
 
   test('an unknown Z derives no height, and without a height no width either', () => {
@@ -783,8 +799,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: undefined }, eFor(0.4, 0.2, 10));
 
-    expect(job.state.lineHeight).toBeUndefined();
-    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.derivedLineHeight).toBeUndefined();
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
   });
 
   test('a segment too short to measure derives no width', () => {
@@ -792,8 +808,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 0.01, y: 0, z: 0.2 }, eFor(0.4, 0.2, 0.01));
 
-    expect(job.state.lineHeight).toEqual(0.2);
-    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.derivedLineHeight).toEqual(0.2);
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
   });
 
   test('implausible widths are discarded instead of stamped on paths', () => {
@@ -801,12 +817,12 @@ describe('.deriveMoveDimensions', () => {
 
     // far too much material for the segment: a prime blob, not a 3mm line
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(3, 0.2, 10));
-    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
 
     // far too little: a near-dry wipe
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.05, 0.2, 10));
-    expect(job.state.extrusionWidth).toBeUndefined();
+    expect(job.state.derivedExtrusionWidth).toBeUndefined();
   });
 
   test('the derived width is quantized to 0.01mm', () => {
@@ -814,7 +830,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.3985, 0.2, 10));
 
-    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
   });
 
   test('a width within 2% of the current one keeps the current value', () => {
@@ -825,7 +841,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.61, 0.2, 10));
 
-    expect(job.state.extrusionWidth).toEqual(0.6);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.6);
   });
 
   test('a real width change beyond the tolerance is applied', () => {
@@ -835,7 +851,7 @@ describe('.deriveMoveDimensions', () => {
     job.state.x = 10;
     job.deriveMoveDimensions({ x: 0, y: 0, z: 0.2 }, eFor(0.42, 0.2, 10));
 
-    expect(job.state.extrusionWidth).toEqual(0.42);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.42);
   });
 
   test('the metadata filament diameter scales the derived width', () => {
@@ -844,7 +860,7 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10, area285));
 
-    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
   });
 
   test('overflowing coordinates and E values never latch NaN into the width', () => {
@@ -857,8 +873,8 @@ describe('.deriveMoveDimensions', () => {
 
     job.deriveMoveDimensions({ x: 1.7e308, y: 1.7e308, z: 0.2 }, 1.7e308);
 
-    expect(job.state.extrusionWidth).toEqual(0.4);
-    expect(Number.isFinite(job.state.extrusionWidth)).toBe(true);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
+    expect(Number.isFinite(job.state.derivedExtrusionWidth)).toBe(true);
   });
 
   test('unknown axes are assumed at the origin, like the rendered geometry', () => {
@@ -867,13 +883,13 @@ describe('.deriveMoveDimensions', () => {
 
     // X never homed: the segment runs from the assumed origin to (0,10)
     job.deriveMoveDimensions({ x: undefined, y: 10, z: 0.2 }, eFor(0.4, 0.2, 10));
-    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.4);
 
     // Y and Z unknown too; the height derived above still measures the width
     job.state.y = undefined;
     job.state.z = undefined;
     job.deriveMoveDimensions({ x: 10, y: undefined, z: undefined }, eFor(0.42, 0.2, 10));
-    expect(job.state.extrusionWidth).toEqual(0.42);
+    expect(job.state.derivedExtrusionWidth).toEqual(0.42);
   });
 });
 

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -847,6 +847,20 @@ describe('.deriveMoveDimensions', () => {
     expect(job.state.extrusionWidth).toEqual(0.4);
   });
 
+  test('overflowing coordinates and E values never latch NaN into the width', () => {
+    // Individually finite params survive the parser, but 1.7e308-scale
+    // values overflow the length (hypot -> Infinity) and the volume
+    // (deltaE x area -> Infinity), whose ratio is NaN — which a plain
+    // range check would wave through and stamp on every path after it.
+    const job = derivingJob();
+    job.deriveMoveDimensions({ x: 10, y: 0, z: 0.2 }, eFor(0.4, 0.2, 10));
+
+    job.deriveMoveDimensions({ x: 1.7e308, y: 1.7e308, z: 0.2 }, 1.7e308);
+
+    expect(job.state.extrusionWidth).toEqual(0.4);
+    expect(Number.isFinite(job.state.extrusionWidth)).toBe(true);
+  });
+
   test('unknown axes are assumed at the origin, like the rendered geometry', () => {
     const job = derivingJob();
     job.state.x = undefined;

--- a/src/__tests__/parser/cura-parser.ts
+++ b/src/__tests__/parser/cura-parser.ts
@@ -150,7 +150,7 @@ test('Cura parser returns empty array when no LAYER comments found', () => {
   expect(layers).toHaveLength(0);
 });
 
-test('Cura parser asks for derived extrusion dimensions', () => {
+test('Cura parser keeps the default of deriving dimensions', () => {
   const parser = new CuraMetadataParser();
 
   const commands = [

--- a/src/__tests__/parser/cura-parser.ts
+++ b/src/__tests__/parser/cura-parser.ts
@@ -149,3 +149,41 @@ test('Cura parser returns empty array when no LAYER comments found', () => {
 
   expect(layers).toHaveLength(0);
 });
+
+test('Cura parser asks for derived extrusion dimensions', () => {
+  const parser = new CuraMetadataParser();
+
+  const commands = [
+    createCommand(';FLAVOR:Marlin', 'FLAVOR:Marlin'),
+    createCommand(';Generated with Cura_SteamEngine 5.7.0', 'Generated with Cura_SteamEngine 5.7.0')
+  ];
+
+  expect(parser.derivesExtrusionDimensions(commands)).toBe(true);
+});
+
+test('Cura parser does not derive dimensions for the volumetric UltiGCode flavor', () => {
+  // UltiGCode E values are mm³ of material, not mm of filament; deriving
+  // widths from them with the filament-length model would be confidently wrong.
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:UltiGCode', 'FLAVOR:UltiGCode')];
+
+  expect(parser.derivesExtrusionDimensions(commands)).toBe(false);
+});
+
+test('Cura parser reads a 2.85 filament diameter from the Griffin flavor', () => {
+  // Griffin is only generated for Ultimaker's own 2.85mm machines.
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:Griffin', 'FLAVOR:Griffin')];
+
+  expect(parser.parseFilamentDiameter(commands)).toEqual(2.85);
+});
+
+test('Cura parser leaves the filament diameter unknown for other flavors', () => {
+  const parser = new CuraMetadataParser();
+
+  const commands = [createCommand(';FLAVOR:Marlin', 'FLAVOR:Marlin')];
+
+  expect(parser.parseFilamentDiameter(commands)).toBeUndefined();
+});

--- a/src/__tests__/parser/gcode-parser.ts
+++ b/src/__tests__/parser/gcode-parser.ts
@@ -344,7 +344,7 @@ describe('header metadata across chunk boundaries', () => {
     streamed.parseGCode(';FLAVOR:UltiGCode\n');
     streamed.parseGCode(identifying);
 
-    expect(oneshot.metadata.deriveExtrusionDimensions).toBeUndefined();
+    expect(oneshot.metadata.deriveExtrusionDimensions).toBe(false);
     expect(streamed.metadata.deriveExtrusionDimensions).toEqual(oneshot.metadata.deriveExtrusionDimensions);
   });
 

--- a/src/__tests__/parser/gcode-parser.ts
+++ b/src/__tests__/parser/gcode-parser.ts
@@ -315,3 +315,54 @@ test('parseGCode ignores a thumbnail with invalid data', () => {
   const parsed = parser.parseGCode(gcode);
   expect(parsed.metadata.thumbnails['8x8']).toBeUndefined();
 });
+
+describe('header metadata across chunk boundaries', () => {
+  // The ;FLAVOR: line the diameter and the derivation flag are read from can
+  // sit in an earlier chunk than the comment that identifies the slicer, so
+  // reading them from the identifying chunk alone made the answers depend on
+  // chunk size -- Griffin lost its 2.85mm diameter (widths off by 2.65x) and
+  // UltiGCode wrongly enabled the volumetric derivation.
+  const identifying = ';Generated with Cura_SteamEngine 5.7.0\n;LAYER:0\nG1 X1 E1\n';
+
+  test('the Griffin filament diameter survives a chunk split after the flavor', () => {
+    const oneshot = new Parser();
+    oneshot.parseGCode(';FLAVOR:Griffin\n' + identifying);
+
+    const streamed = new Parser();
+    streamed.parseGCode(';FLAVOR:Griffin\n');
+    streamed.parseGCode(identifying);
+
+    expect(oneshot.metadata.filamentDiameter).toEqual(2.85);
+    expect(streamed.metadata.filamentDiameter).toEqual(oneshot.metadata.filamentDiameter);
+  });
+
+  test('UltiGCode still opts out of derivation when split after the flavor', () => {
+    const oneshot = new Parser();
+    oneshot.parseGCode(';FLAVOR:UltiGCode\n' + identifying);
+
+    const streamed = new Parser();
+    streamed.parseGCode(';FLAVOR:UltiGCode\n');
+    streamed.parseGCode(identifying);
+
+    expect(oneshot.metadata.deriveExtrusionDimensions).toBeUndefined();
+    expect(streamed.metadata.deriveExtrusionDimensions).toEqual(oneshot.metadata.deriveExtrusionDimensions);
+  });
+
+  test('a flavor past the header sample is ignored the same way in both modes', () => {
+    // The sample is capped, so a ;FLAVOR: line buried behind 200+ comments is
+    // out of reach -- what matters is that it is out of reach identically
+    // whether the file arrives in one piece or in chunks.
+    const filler = Array.from({ length: 250 }, (_, i) => `;filler ${i}`).join('\n') + '\n';
+    const late = ';FLAVOR:Griffin\n' + identifying;
+
+    const oneshot = new Parser();
+    oneshot.parseGCode(filler + late);
+
+    const streamed = new Parser();
+    streamed.parseGCode(filler);
+    streamed.parseGCode(late);
+
+    expect(oneshot.metadata.filamentDiameter).toBeUndefined();
+    expect(streamed.metadata.filamentDiameter).toEqual(oneshot.metadata.filamentDiameter);
+  });
+});

--- a/src/__tests__/parser/layer-metadata-integration.ts
+++ b/src/__tests__/parser/layer-metadata-integration.ts
@@ -73,6 +73,42 @@ test('accumulates dimension events with whole-file line indices when parsing in 
   ]);
 });
 
+test('parser flags a Cura file for derived extrusion dimensions', () => {
+  const { metadata } = new Parser().parseGCode(
+    [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
+  );
+
+  expect(metadata.slicerName).toBe('Cura');
+  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  // Marlin flavor implies no particular machine, so no diameter is announced
+  expect(metadata.filamentDiameter).toBeUndefined();
+});
+
+test('parser reads the filament diameter from a Griffin-flavored Cura file', () => {
+  const { metadata } = new Parser().parseGCode(
+    [';FLAVOR:Griffin', ';GENERATOR.NAME:Cura_SteamEngine', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
+  );
+
+  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  expect(metadata.filamentDiameter).toEqual(2.85);
+});
+
+test('parser does not flag a Prusa-family file for derivation', () => {
+  // PrusaSlicer announces exact dimensions in comments; deriving would
+  // override them with approximations.
+  const { metadata } = new Parser().parseGCode(PRUSA_GCODE);
+
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
+  expect(metadata.filamentDiameter).toBeUndefined();
+});
+
+test('parser does not flag an UltiGCode-flavored Cura file for derivation', () => {
+  const { metadata } = new Parser().parseGCode([';FLAVOR:UltiGCode', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n'));
+
+  expect(metadata.slicerName).toBe('Cura');
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
+});
+
 test('slicer metadata drives job layer indexing end-to-end', () => {
   const { commands, metadata } = new Parser().parseGCode(PRUSA_GCODE);
 

--- a/src/__tests__/parser/layer-metadata-integration.ts
+++ b/src/__tests__/parser/layer-metadata-integration.ts
@@ -51,10 +51,12 @@ test('extrusion dimension metadata reaches the paths end-to-end', () => {
   job.metadata = metadata;
   new Interpreter().execute(commands, job);
 
-  // every extrusion follows a ;HEIGHT:0.2 comment; no ;WIDTH: was announced
+  // every extrusion follows a ;HEIGHT:0.2 comment, so the announced height is
+  // what the paths carry; no ;WIDTH: was announced, so the width is the one
+  // derived from the moves rather than nothing at all
   for (const path of job.extrusions) {
     expect(path.lineHeight).toBe(0.2);
-    expect(path.extrusionWidth).toBeUndefined();
+    expect(path.extrusionWidth).toBeGreaterThan(0);
   }
 });
 
@@ -73,13 +75,14 @@ test('accumulates dimension events with whole-file line indices when parsing in 
   ]);
 });
 
-test('parser flags a Cura file for derived extrusion dimensions', () => {
+test('parser leaves a Cura file deriving, which is the default', () => {
   const { metadata } = new Parser().parseGCode(
     [';FLAVOR:Marlin', ';Generated with Cura_SteamEngine 5.7.0', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
   );
 
   expect(metadata.slicerName).toBe('Cura');
-  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  // only the opt-out is ever recorded, so deriving reads as "not opted out"
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
   // Marlin flavor implies no particular machine, so no diameter is announced
   expect(metadata.filamentDiameter).toBeUndefined();
 });
@@ -89,24 +92,24 @@ test('parser reads the filament diameter from a Griffin-flavored Cura file', () 
     [';FLAVOR:Griffin', ';GENERATOR.NAME:Cura_SteamEngine', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n')
   );
 
-  expect(metadata.deriveExtrusionDimensions).toBe(true);
+  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
   expect(metadata.filamentDiameter).toEqual(2.85);
 });
 
-test('parser does not flag a Prusa-family file for derivation', () => {
-  // PrusaSlicer announces exact dimensions in comments; deriving would
-  // override them with approximations.
+test('a Prusa-family file derives too, its announced dimensions simply outrank it', () => {
   const { metadata } = new Parser().parseGCode(PRUSA_GCODE);
 
   expect(metadata.deriveExtrusionDimensions).toBeUndefined();
   expect(metadata.filamentDiameter).toBeUndefined();
 });
 
-test('parser does not flag an UltiGCode-flavored Cura file for derivation', () => {
+test('an UltiGCode-flavored Cura file opts out of derivation', () => {
+  // Its E values are cubic millimetres of material, not millimetres of
+  // filament, so the volumetric arithmetic does not hold.
   const { metadata } = new Parser().parseGCode([';FLAVOR:UltiGCode', ';LAYER:0', 'G1 X10 Y10 Z0.2 E1'].join('\n'));
 
   expect(metadata.slicerName).toBe('Cura');
-  expect(metadata.deriveExtrusionDimensions).toBeUndefined();
+  expect(metadata.deriveExtrusionDimensions).toBe(false);
 });
 
 test('slicer metadata drives job layer indexing end-to-end', () => {

--- a/src/__tests__/parser/metadata-parser-base.ts
+++ b/src/__tests__/parser/metadata-parser-base.ts
@@ -48,4 +48,17 @@ describe('SlicerMetadataParser base class', () => {
 
     expect(parser.parseExtrusionDimensions([comment('WIDTH:0.45')])).toEqual([]);
   });
+
+  it('derivesExtrusionDimensions defaults to false', () => {
+    // Only dialects without dimension comments (Cura) opt into deriving.
+    const parser = new StubMetadataParser();
+
+    expect(parser.derivesExtrusionDimensions([comment('STUB_MARKER v1')])).toBe(false);
+  });
+
+  it('parseFilamentDiameter defaults to unknown', () => {
+    const parser = new StubMetadataParser();
+
+    expect(parser.parseFilamentDiameter([comment('STUB_MARKER v1')])).toBeUndefined();
+  });
 });

--- a/src/__tests__/parser/metadata-parser-base.ts
+++ b/src/__tests__/parser/metadata-parser-base.ts
@@ -49,11 +49,12 @@ describe('SlicerMetadataParser base class', () => {
     expect(parser.parseExtrusionDimensions([comment('WIDTH:0.45')])).toEqual([]);
   });
 
-  it('derivesExtrusionDimensions defaults to false', () => {
-    // Only dialects without dimension comments (Cura) opt into deriving.
+  it('derivesExtrusionDimensions defaults to true', () => {
+    // Deriving is the default; announced dimensions outrank derived ones per
+    // path, so only a dialect whose E is not a filament length opts out.
     const parser = new StubMetadataParser();
 
-    expect(parser.derivesExtrusionDimensions([comment('STUB_MARKER v1')])).toBe(false);
+    expect(parser.derivesExtrusionDimensions([comment('STUB_MARKER v1')])).toBe(true);
   });
 
   it('parseFilamentDiameter defaults to unknown', () => {

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -226,7 +226,12 @@ describe('public API types', () => {
       expectTypeOf<Parser['lines']>().toEqualTypeOf<string[]>();
       expectTypeOf<Parser['lineCount']>().toEqualTypeOf<number>();
       expectTypeOf<keyof Parser['metadata']>().toEqualTypeOf<
-        'thumbnails' | 'layerMetadata' | 'extrusionDimensions' | 'slicerName'
+        | 'thumbnails'
+        | 'layerMetadata'
+        | 'extrusionDimensions'
+        | 'slicerName'
+        | 'deriveExtrusionDimensions'
+        | 'filamentDiameter'
       >();
       expectTypeOf<Parameters<Parser['parseGCode']>>().toEqualTypeOf<[string | string[]]>();
       expectTypeOf<keyof ReturnType<Parser['parseGCode']>>().toEqualTypeOf<'metadata' | 'commands'>();

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -267,9 +267,10 @@ describe('public API types', () => {
       >();
     });
 
-    it('exposes the print state, whose dimensions separate announced from derived', () => {
+    it('exposes the print state, carrying only the dimensions the slicer announced', () => {
       // Reachable as job.state, so these are public whether or not State is
-      // exported: renaming one of them breaks a consumer.
+      // exported. The derived dimensions are deliberately absent: they are the
+      // Job's own working values, not part of the surface.
       expectTypeOf<keyof Job['state']>().toEqualTypeOf<
         | 'x'
         | 'y'
@@ -280,16 +281,12 @@ describe('public API types', () => {
         | 'tool'
         | 'extrusionWidth'
         | 'lineHeight'
-        | 'derivedExtrusionWidth'
-        | 'derivedLineHeight'
-        | 'resolvedExtrusionWidth'
-        | 'resolvedLineHeight'
         | 'units'
         | 'isHomed'
         | 'applyExtrusion'
       >();
-      expectTypeOf<Job['state']['resolvedExtrusionWidth']>().toEqualTypeOf<number | undefined>();
-      expectTypeOf<Job['state']['resolvedLineHeight']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<Job['state']['extrusionWidth']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<Job['state']['lineHeight']>().toEqualTypeOf<number | undefined>();
     });
 
     it('keeps its public fields, getters and method signatures', () => {

--- a/src/__tests__/public-api.test-d.ts
+++ b/src/__tests__/public-api.test-d.ts
@@ -261,10 +261,35 @@ describe('public API types', () => {
   });
 
   describe('Job', () => {
-    it('is constructed from optional state and layer threshold', () => {
+    it('is constructed from optional state, layer threshold and supplied dimensions', () => {
       expectTypeOf<ConstructorParameters<typeof JobClass>>().toEqualTypeOf<
-        [{ state?: Job['state']; minLayerThreshold?: number }?]
+        [{ state?: Job['state']; minLayerThreshold?: number; extrusionWidth?: number; lineHeight?: number }?]
       >();
+    });
+
+    it('exposes the print state, whose dimensions separate announced from derived', () => {
+      // Reachable as job.state, so these are public whether or not State is
+      // exported: renaming one of them breaks a consumer.
+      expectTypeOf<keyof Job['state']>().toEqualTypeOf<
+        | 'x'
+        | 'y'
+        | 'z'
+        | 'e'
+        | 'relativeExtrusion'
+        | 'positionShift'
+        | 'tool'
+        | 'extrusionWidth'
+        | 'lineHeight'
+        | 'derivedExtrusionWidth'
+        | 'derivedLineHeight'
+        | 'resolvedExtrusionWidth'
+        | 'resolvedLineHeight'
+        | 'units'
+        | 'isHomed'
+        | 'applyExtrusion'
+      >();
+      expectTypeOf<Job['state']['resolvedExtrusionWidth']>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<Job['state']['resolvedLineHeight']>().toEqualTypeOf<number | undefined>();
     });
 
     it('keeps its public fields, getters and method signatures', () => {

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -157,7 +157,12 @@ export class GCodePreview {
     this.opts = opts;
     this.interpreter = new Interpreter({ arcChordTolerance: opts.arcChordTolerance });
     this._parser = this.createParser();
-    this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
+    this.job = new Job({
+      minLayerThreshold: this.opts.minLayerThreshold,
+      // a dimension the caller asked for is not derived from the moves
+      extrusionWidth: this.opts.extrusionWidth,
+      lineHeight: this.opts.lineHeight
+    });
     // note: reads opts.devMode because this.devMode is only assigned below,
     // once the scene manager needed by its setter exists
     this.stats = opts.devMode ? new Stats() : undefined;
@@ -174,7 +179,12 @@ export class GCodePreview {
    */
   clear(): void {
     this._parser = this.createParser();
-    this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
+    this.job = new Job({
+      minLayerThreshold: this.opts.minLayerThreshold,
+      // a dimension the caller asked for is not derived from the moves
+      extrusionWidth: this.opts.extrusionWidth,
+      lineHeight: this.opts.lineHeight
+    });
     this.sceneManager.clear();
     this.sceneManager.job = this.job;
     this.sceneManager.render();

--- a/src/interpreter/commands/linear-move.ts
+++ b/src/interpreter/commands/linear-move.ts
@@ -48,6 +48,10 @@ export const linearMove: CommandHandler = (command, job) => {
   // see also https://github.com/xyz-tools/gcode-preview/issues/179
   const extruded = state.applyExtrusion(e);
   const pathType = extruded > 0 ? PathType.Extrusion : PathType.Travel;
+  if (pathType === PathType.Extrusion) {
+    // may change the state's dimensions, which continuePath breaks on
+    job.deriveMoveDimensions({ x: targetX, y: targetY, z: targetZ }, extruded);
+  }
   const currentPath = job.continuePath(pathType);
 
   if (extruded > 0) {

--- a/src/job.ts
+++ b/src/job.ts
@@ -83,6 +83,10 @@ export class Job {
   private readonly suppliedExtrusionWidth: number | undefined;
   /** Line height the caller supplied through the public API; suppresses deriving one */
   private readonly suppliedLineHeight: number | undefined;
+  /** Width derived from the moves, used where nothing announced or supplied one */
+  private derivedExtrusionWidth: number | undefined;
+  /** Line height derived from the Z steps, used on the same terms */
+  private derivedLineHeight: number | undefined;
   /** How many commands have been executed on this job — one per parsed line */
   private executedCommandCount = 0;
 
@@ -206,6 +210,24 @@ export class Job {
    * discarded entirely when implausible (outside 0.1–2.0 mm, or over a
    * segment too short to measure).
    */
+  /**
+   * The width a path started now carries of its own: what the slicer
+   * announced, else what the moves imply, else `undefined`.
+   * @remarks
+   * A width the caller supplied is deliberately absent here. It suppresses
+   * the derivation, but baking it into the path would freeze it: the renderer
+   * applies it as a fallback, so leaving the path without one is what lets
+   * `SceneManager.extrusionWidth` still take effect after the file is loaded.
+   */
+  private get resolvedExtrusionWidth(): number | undefined {
+    return this.state.extrusionWidth ?? this.derivedExtrusionWidth;
+  }
+
+  /** The line height a path started now carries of its own, resolved likewise */
+  private get resolvedLineHeight(): number | undefined {
+    return this.state.lineHeight ?? this.derivedLineHeight;
+  }
+
   deriveMoveDimensions(
     target: { x: number | undefined; y: number | undefined; z: number | undefined },
     extruded: number
@@ -218,7 +240,7 @@ export class Job {
         if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
           // rounded so consecutive layers with equal heights compare equal
           // despite floating-point Z subtraction noise
-          this.state.derivedLineHeight = Math.round(step * 10000) / 10000;
+          this.derivedLineHeight = Math.round(step * 10000) / 10000;
         }
       }
       // Advanced even when the height is not being derived, so the anchor is
@@ -235,7 +257,7 @@ export class Job {
 
     // Whichever height the material was actually laid at, in the same order
     // the paths resolve it: announced, then the caller's, then derived.
-    const height = this.state.lineHeight ?? this.suppliedLineHeight ?? this.state.derivedLineHeight;
+    const height = this.state.lineHeight ?? this.suppliedLineHeight ?? this.derivedLineHeight;
     if (height === undefined) return;
 
     // Resolved exactly like the rendered geometry: an unknown axis is assumed
@@ -252,9 +274,9 @@ export class Job {
     if (!(width >= MIN_DERIVED_WIDTH && width <= MAX_DERIVED_WIDTH)) return;
 
     const quantized = Math.round(width * 100) / 100;
-    const current = this.state.derivedExtrusionWidth;
+    const current = this.derivedExtrusionWidth;
     if (current !== undefined && Math.abs(quantized - current) <= current * DERIVED_WIDTH_TOLERANCE) return;
-    this.state.derivedExtrusionWidth = quantized;
+    this.derivedExtrusionWidth = quantized;
   }
 
   /**
@@ -338,12 +360,7 @@ export class Job {
    */
   breakPath(newType: PathType): Path {
     this.finishPath();
-    const currentPath = new Path(
-      newType,
-      this.state.resolvedExtrusionWidth,
-      this.state.resolvedLineHeight,
-      this.state.tool
-    );
+    const currentPath = new Path(newType, this.resolvedExtrusionWidth, this.resolvedLineHeight, this.state.tool);
     const pos = this.resolvePosition();
     currentPath.addPoint(pos.x, pos.y, pos.z);
     this.inprogressPath = currentPath;
@@ -368,8 +385,8 @@ export class Job {
     if (
       currentPath !== undefined &&
       currentPath.travelType === pathType &&
-      currentPath.extrusionWidth === this.state.resolvedExtrusionWidth &&
-      currentPath.lineHeight === this.state.resolvedLineHeight
+      currentPath.extrusionWidth === this.resolvedExtrusionWidth &&
+      currentPath.lineHeight === this.resolvedLineHeight
     ) {
       return currentPath;
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -14,6 +14,27 @@ import { Metadata } from './parser/gcode-parser';
 import { ExtrusionDimensionMetadata } from './parser/metadata-parser-base';
 import { JobStats } from './job-stats';
 
+/** Filament diameter assumed when the metadata announces none, in millimeters */
+const DEFAULT_FILAMENT_DIAMETER = 1.75;
+/** Derived layer heights outside this range are considered implausible */
+const MIN_DERIVED_HEIGHT = 0.01;
+const MAX_DERIVED_HEIGHT = 1.0;
+/** Derived extrusion widths outside this range are considered implausible */
+const MIN_DERIVED_WIDTH = 0.1;
+const MAX_DERIVED_WIDTH = 2.0;
+/**
+ * Segments shorter than this derive no width, in millimeters: the slicer
+ * rounds E to a few decimals, and over a near-zero length that quantization
+ * noise dominates the derived value.
+ */
+const MIN_DERIVED_SEGMENT_LENGTH = 0.05;
+/**
+ * A derived width within this relative tolerance of the current one keeps the
+ * current value, so residual noise cannot shatter the model into micro-paths.
+ * 2% separates real Cura width steps (0.4 vs 0.42 infill is 5%) from noise.
+ */
+const DERIVED_WIDTH_TOLERANCE = 0.02;
+
 /**
  * Represents a complete print job containing paths, layers, and state
  * @remarks
@@ -45,6 +66,12 @@ export class Job {
   private extrusionDimensions: ExtrusionDimensionMetadata[] = [];
   /** Position in extrusionDimensions up to which events have been applied */
   private dimensionCursor = 0;
+  /** Whether per-path dimensions are derived from the moves (see metadata) */
+  private deriveDimensions = false;
+  /** Filament cross-section area feeding the width derivation, in mm² */
+  private filamentCrossSection = Math.PI * (DEFAULT_FILAMENT_DIAMETER / 2) ** 2;
+  /** Z of the last extrusion move, from which derived layer heights are measured */
+  private lastExtrusionZ: number | undefined;
   /** How many commands have been executed on this job — one per parsed line */
   private executedCommandCount = 0;
 
@@ -87,6 +114,9 @@ export class Job {
     this._metadata = metadata;
     this.layersIndexer.setLayerMetadata(metadata?.layerMetadata ?? []);
     this.setExtrusionDimensions(metadata?.extrusionDimensions ?? []);
+    this.deriveDimensions = metadata?.deriveExtrusionDimensions === true;
+    const filamentDiameter = metadata?.filamentDiameter ?? DEFAULT_FILAMENT_DIAMETER;
+    this.filamentCrossSection = Math.PI * (filamentDiameter / 2) ** 2;
   }
 
   /**
@@ -126,6 +156,69 @@ export class Job {
       if (dimension.width !== undefined) this.state.extrusionWidth = dimension.width;
       if (dimension.height !== undefined) this.state.lineHeight = dimension.height;
     }
+  }
+
+  /**
+   * Derives the extrusion dimensions of the move about to be executed and
+   * folds them into the state, best-effort
+   * @param target - The move's physical endpoint; an axis the move leaves
+   * unchanged carries the current (possibly unknown) state value
+   * @param deltaE - The filament length the move extrudes (see `State.trackE`)
+   * @remarks
+   * Active only when the slicer metadata asked for it (Cura, whose files
+   * announce no dimension comments); paths then carry these derived values as
+   * their own, taking the same render-time precedence over the global
+   * fallback as comment-announced dimensions do. Move handlers call this for
+   * extruding moves before `continuePath`, so a change breaks the path
+   * exactly like a `;WIDTH:` / `;HEIGHT:` comment would.
+   *
+   * Layer height is the Z step between consecutive extrusion moves (the
+   * first one's Z stands in for the first layer). Only extrusion Zs are
+   * compared, so z-hop travels are invisible; a zero step (ironing, or
+   * printing on within the layer) and steps outside 0.01–1.0 mm (spiralize's
+   * continuous micro-climb, a probe artifact, moving down to a second
+   * sequential object) keep the current height.
+   *
+   * Width comes from conservation of volume with a rectangular deposit
+   * cross-section — width = (ΔE × filament cross-section) / (length ×
+   * height) — matching the box profile ExtrusionGeometry extrudes. The
+   * result is quantized to 0.01 mm and kept within 2% of the current width,
+   * so E-value rounding noise cannot break the model into micro-paths, and
+   * discarded entirely when implausible (outside 0.1–2.0 mm, or over a
+   * segment too short to measure).
+   */
+  deriveMoveDimensions(
+    target: { x: number | undefined; y: number | undefined; z: number | undefined },
+    deltaE: number
+  ): void {
+    if (!this.deriveDimensions || deltaE <= 0) return;
+
+    if (target.z !== undefined) {
+      const step = this.lastExtrusionZ === undefined ? target.z : target.z - this.lastExtrusionZ;
+      if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
+        // rounded so consecutive layers with equal heights compare equal
+        // despite floating-point Z subtraction noise
+        this.state.lineHeight = Math.round(step * 10000) / 10000;
+      }
+      this.lastExtrusionZ = target.z;
+    }
+
+    const height = this.state.lineHeight;
+    if (height === undefined) return;
+
+    // Resolved exactly like the rendered geometry: an unknown axis is assumed
+    // at the origin (see resolvePosition).
+    const from = this.resolvePosition();
+    const length = Math.hypot((target.x ?? 0) - from.x, (target.y ?? 0) - from.y, (target.z ?? 0) - from.z);
+    if (length < MIN_DERIVED_SEGMENT_LENGTH) return;
+
+    const width = (deltaE * this.filamentCrossSection) / (length * height);
+    if (width < MIN_DERIVED_WIDTH || width > MAX_DERIVED_WIDTH) return;
+
+    const quantized = Math.round(width * 100) / 100;
+    const current = this.state.extrusionWidth;
+    if (current !== undefined && Math.abs(quantized - current) <= current * DERIVED_WIDTH_TOLERANCE) return;
+    this.state.extrusionWidth = quantized;
   }
 
   /**

--- a/src/job.ts
+++ b/src/job.ts
@@ -79,6 +79,10 @@ export class Job {
   private filamentCrossSection = Math.PI * (DEFAULT_FILAMENT_DIAMETER / 2) ** 2;
   /** Z of the last extrusion move, from which derived layer heights are measured */
   private lastExtrusionZ: number | undefined;
+  /** Width the caller supplied through the public API; suppresses deriving one */
+  private readonly suppliedExtrusionWidth: number | undefined;
+  /** Line height the caller supplied through the public API; suppresses deriving one */
+  private readonly suppliedLineHeight: number | undefined;
   /** How many commands have been executed on this job — one per parsed line */
   private executedCommandCount = 0;
 
@@ -90,9 +94,17 @@ export class Job {
    * @param opts - Job options
    * @param opts.state - Initial state (default: State.initial)
    * @param opts.minLayerThreshold - Minimum layer height threshold (default: LayersIndexer.DEFAULT_TOLERANCE)
+   * @param opts.extrusionWidth - Width the caller supplied through the public API, if any
+   * @param opts.lineHeight - Line height the caller supplied through the public API, if any
+   * @remarks
+   * A dimension the caller supplied is not derived: asking for a width is a
+   * decision, while deriving one is an inference, and the decision wins. The
+   * slicer's own `;WIDTH:` / `;HEIGHT:` comments still outrank both.
    */
-  constructor(opts: { state?: State; minLayerThreshold?: number } = {}) {
+  constructor(opts: { state?: State; minLayerThreshold?: number; extrusionWidth?: number; lineHeight?: number } = {}) {
     this.state = opts.state || State.initial;
+    this.suppliedExtrusionWidth = opts.extrusionWidth;
+    this.suppliedLineHeight = opts.lineHeight;
     this.layersIndexer = new LayersMetadataIndexer(this._layers, [], opts.minLayerThreshold);
     this.indexers = [
       new TravelTypeIndexer({ travel: this.travelPaths, extrusion: this.extrusionPaths }),
@@ -201,24 +213,29 @@ export class Job {
     if (!this.deriveDimensions || extruded <= 0) return;
 
     if (target.z !== undefined) {
-      const step = this.lastExtrusionZ === undefined ? target.z : target.z - this.lastExtrusionZ;
-      if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
-        // rounded so consecutive layers with equal heights compare equal
-        // despite floating-point Z subtraction noise
-        this.state.derivedLineHeight = Math.round(step * 10000) / 10000;
+      if (this.suppliedLineHeight === undefined) {
+        const step = this.lastExtrusionZ === undefined ? target.z : target.z - this.lastExtrusionZ;
+        if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
+          // rounded so consecutive layers with equal heights compare equal
+          // despite floating-point Z subtraction noise
+          this.state.derivedLineHeight = Math.round(step * 10000) / 10000;
+        }
       }
+      // Advanced even when the height is not being derived, so the anchor is
+      // still right if a later move does derive one.
       this.lastExtrusionZ = target.z;
     }
 
-    // Nothing below is needed while the slicer announces the width itself: it
-    // would outrank the derived one anyway. Worth skipping rather than
-    // discarding -- on a file that announces every width (3DBenchy) the
-    // segment length and volume arithmetic is a third of the interpret time.
-    if (this.state.extrusionWidth !== undefined) return;
+    // Nothing below is needed while a width already outranks the derived one,
+    // whether the slicer announced it or the caller supplied it. Worth
+    // skipping rather than discarding -- on a file that announces every width
+    // (3DBenchy) the segment length and volume arithmetic is a third of the
+    // interpret time.
+    if (this.suppliedExtrusionWidth !== undefined || this.state.extrusionWidth !== undefined) return;
 
-    // The announced height still feeds the width derivation, which needs the
-    // height the material was actually laid at, not the inferred one.
-    const height = this.state.resolvedLineHeight;
+    // Whichever height the material was actually laid at, in the same order
+    // the paths resolve it: announced, then the caller's, then derived.
+    const height = this.state.lineHeight ?? this.suppliedLineHeight ?? this.state.derivedLineHeight;
     if (height === undefined) return;
 
     // Resolved exactly like the rendered geometry: an unknown axis is assumed

--- a/src/job.ts
+++ b/src/job.ts
@@ -31,7 +31,8 @@ const MIN_DERIVED_SEGMENT_LENGTH = 0.05;
 /**
  * A derived width within this relative tolerance of the current one keeps the
  * current value, so residual noise cannot shatter the model into micro-paths.
- * 2% separates real Cura width steps (0.4 vs 0.42 infill is 5%) from noise.
+ * 2% separates a real width step (0.4 to 0.42 between wall and infill is 5%)
+ * from the noise.
  */
 const DERIVED_WIDTH_TOLERANCE = 0.02;
 
@@ -171,10 +172,10 @@ export class Job {
    * unchanged carries the current (possibly unknown) state value
    * @param extruded - The filament length the move extrudes (see `State.applyExtrusion`)
    * @remarks
-   * Active only when the slicer metadata asked for it (Cura, whose files
-   * announce no dimension comments); paths then carry these derived values as
-   * their own, taking the same render-time precedence over the global
-   * fallback as comment-announced dimensions do. Move handlers call this for
+   * Runs for every dialect, unless the slicer metadata opted out; a path
+   * carries the derived values as its own wherever the slicer announced
+   * none, taking the same render-time precedence over the global fallback as
+   * comment-announced dimensions do. Move handlers call this for
    * extruding moves before `continuePath`, so a change breaks the path
    * exactly like a `;WIDTH:` / `;HEIGHT:` comment would.
    *

--- a/src/job.ts
+++ b/src/job.ts
@@ -210,10 +210,14 @@ export class Job {
     // at the origin (see resolvePosition).
     const from = this.resolvePosition();
     const length = Math.hypot((target.x ?? 0) - from.x, (target.y ?? 0) - from.y, (target.z ?? 0) - from.z);
-    if (length < MIN_DERIVED_SEGMENT_LENGTH) return;
+    // Number.isFinite: overflowing (yet individually finite) coordinates can
+    // make hypot Infinity — or NaN via Inf - Inf — and both pass a plain `<`
+    if (!Number.isFinite(length) || length < MIN_DERIVED_SEGMENT_LENGTH) return;
 
     const width = (deltaE * this.filamentCrossSection) / (length * height);
-    if (width < MIN_DERIVED_WIDTH || width > MAX_DERIVED_WIDTH) return;
+    // inclusive form so NaN (e.g. from an Infinity/Infinity overflow) is
+    // rejected rather than latched into the state and every path after it
+    if (!(width >= MIN_DERIVED_WIDTH && width <= MAX_DERIVED_WIDTH)) return;
 
     const quantized = Math.round(width * 100) / 100;
     const current = this.state.extrusionWidth;

--- a/src/job.ts
+++ b/src/job.ts
@@ -163,7 +163,7 @@ export class Job {
    * folds them into the state, best-effort
    * @param target - The move's physical endpoint; an axis the move leaves
    * unchanged carries the current (possibly unknown) state value
-   * @param deltaE - The filament length the move extrudes (see `State.trackE`)
+   * @param extruded - The filament length the move extrudes (see `State.applyExtrusion`)
    * @remarks
    * Active only when the slicer metadata asked for it (Cura, whose files
    * announce no dimension comments); paths then carry these derived values as
@@ -189,9 +189,9 @@ export class Job {
    */
   deriveMoveDimensions(
     target: { x: number | undefined; y: number | undefined; z: number | undefined },
-    deltaE: number
+    extruded: number
   ): void {
-    if (!this.deriveDimensions || deltaE <= 0) return;
+    if (!this.deriveDimensions || extruded <= 0) return;
 
     if (target.z !== undefined) {
       const step = this.lastExtrusionZ === undefined ? target.z : target.z - this.lastExtrusionZ;
@@ -214,7 +214,7 @@ export class Job {
     // make hypot Infinity — or NaN via Inf - Inf — and both pass a plain `<`
     if (!Number.isFinite(length) || length < MIN_DERIVED_SEGMENT_LENGTH) return;
 
-    const width = (deltaE * this.filamentCrossSection) / (length * height);
+    const width = (extruded * this.filamentCrossSection) / (length * height);
     // inclusive form so NaN (e.g. from an Infinity/Infinity overflow) is
     // rejected rather than latched into the state and every path after it
     if (!(width >= MIN_DERIVED_WIDTH && width <= MAX_DERIVED_WIDTH)) return;

--- a/src/job.ts
+++ b/src/job.ts
@@ -66,8 +66,14 @@ export class Job {
   private extrusionDimensions: ExtrusionDimensionMetadata[] = [];
   /** Position in extrusionDimensions up to which events have been applied */
   private dimensionCursor = 0;
-  /** Whether per-path dimensions are derived from the moves (see metadata) */
-  private deriveDimensions = false;
+  /**
+   * Whether per-path dimensions are derived from the moves.
+   * @remarks
+   * On unless the slicer metadata opts out (see
+   * `SlicerMetadataParser.derivesExtrusionDimensions`); announced dimensions
+   * outrank derived ones per path rather than switching the derivation off.
+   */
+  private deriveDimensions = true;
   /** Filament cross-section area feeding the width derivation, in mm² */
   private filamentCrossSection = Math.PI * (DEFAULT_FILAMENT_DIAMETER / 2) ** 2;
   /** Z of the last extrusion move, from which derived layer heights are measured */
@@ -114,7 +120,7 @@ export class Job {
     this._metadata = metadata;
     this.layersIndexer.setLayerMetadata(metadata?.layerMetadata ?? []);
     this.setExtrusionDimensions(metadata?.extrusionDimensions ?? []);
-    this.deriveDimensions = metadata?.deriveExtrusionDimensions === true;
+    this.deriveDimensions = metadata?.deriveExtrusionDimensions !== false;
     const filamentDiameter = metadata?.filamentDiameter ?? DEFAULT_FILAMENT_DIAMETER;
     this.filamentCrossSection = Math.PI * (filamentDiameter / 2) ** 2;
   }
@@ -198,12 +204,20 @@ export class Job {
       if (step >= MIN_DERIVED_HEIGHT && step <= MAX_DERIVED_HEIGHT) {
         // rounded so consecutive layers with equal heights compare equal
         // despite floating-point Z subtraction noise
-        this.state.lineHeight = Math.round(step * 10000) / 10000;
+        this.state.derivedLineHeight = Math.round(step * 10000) / 10000;
       }
       this.lastExtrusionZ = target.z;
     }
 
-    const height = this.state.lineHeight;
+    // Nothing below is needed while the slicer announces the width itself: it
+    // would outrank the derived one anyway. Worth skipping rather than
+    // discarding -- on a file that announces every width (3DBenchy) the
+    // segment length and volume arithmetic is a third of the interpret time.
+    if (this.state.extrusionWidth !== undefined) return;
+
+    // The announced height still feeds the width derivation, which needs the
+    // height the material was actually laid at, not the inferred one.
+    const height = this.state.resolvedLineHeight;
     if (height === undefined) return;
 
     // Resolved exactly like the rendered geometry: an unknown axis is assumed
@@ -220,9 +234,9 @@ export class Job {
     if (!(width >= MIN_DERIVED_WIDTH && width <= MAX_DERIVED_WIDTH)) return;
 
     const quantized = Math.round(width * 100) / 100;
-    const current = this.state.extrusionWidth;
+    const current = this.state.derivedExtrusionWidth;
     if (current !== undefined && Math.abs(quantized - current) <= current * DERIVED_WIDTH_TOLERANCE) return;
-    this.state.extrusionWidth = quantized;
+    this.state.derivedExtrusionWidth = quantized;
   }
 
   /**
@@ -306,7 +320,12 @@ export class Job {
    */
   breakPath(newType: PathType): Path {
     this.finishPath();
-    const currentPath = new Path(newType, this.state.extrusionWidth, this.state.lineHeight, this.state.tool);
+    const currentPath = new Path(
+      newType,
+      this.state.resolvedExtrusionWidth,
+      this.state.resolvedLineHeight,
+      this.state.tool
+    );
     const pos = this.resolvePosition();
     currentPath.addPoint(pos.x, pos.y, pos.z);
     this.inprogressPath = currentPath;
@@ -331,8 +350,8 @@ export class Job {
     if (
       currentPath !== undefined &&
       currentPath.travelType === pathType &&
-      currentPath.extrusionWidth === this.state.extrusionWidth &&
-      currentPath.lineHeight === this.state.lineHeight
+      currentPath.extrusionWidth === this.state.resolvedExtrusionWidth &&
+      currentPath.lineHeight === this.state.resolvedLineHeight
     ) {
       return currentPath;
     }

--- a/src/parser/cura-parser.ts
+++ b/src/parser/cura-parser.ts
@@ -15,6 +15,45 @@ export class CuraMetadataParser extends SlicerMetadataParser {
   readonly identificationPatterns = [/^LAYER:\d+/, /Cura_SteamEngine/i, /Generated with Cura/i, /CURA_/i];
 
   /**
+   * How many header comments to sample for flavor detection. Cura puts the
+   * `;FLAVOR:` line first in the file, so a small sample is plenty.
+   */
+  private static readonly HEADER_SAMPLE = 200;
+
+  /**
+   * Whether per-path extrusion dimensions should be derived from the moves
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns True except for the volumetric UltiGCode flavor
+   * @remarks
+   * Cura emits no `;WIDTH:` / `;HEIGHT:` comments, so dimensions can only be
+   * reconstructed from extrusion amounts and Z changes. The UltiGCode flavor
+   * (Ultimaker 2 era) is excluded: its E values are cubic millimeters of
+   * material rather than millimeters of filament, which the derivation does
+   * not model — deriving from them would produce confidently wrong widths.
+   */
+  derivesExtrusionDimensions(commentCommands: GCodeCommand[]): boolean {
+    const sample = commentCommands.slice(0, CuraMetadataParser.HEADER_SAMPLE);
+    return !sample.some((cmd) => /^FLAVOR:UltiGCode/i.test(cmd.comment!));
+  }
+
+  /**
+   * Reads the filament diameter implied by the header flavor
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns 2.85 for the Griffin flavor, otherwise undefined
+   * @remarks
+   * Cura's own `material_diameter` setting only appears in the `;SETTING_3`
+   * blob at the very end of the file, too late to inform the derivation of
+   * the moves that precede it (see the base class remarks). The `;FLAVOR:`
+   * header line is emitted first instead, and Griffin is only ever generated
+   * for Ultimaker's own 2.85 mm machines (UM3 and S-line); every other
+   * flavor falls back to the 1.75 mm default downstream.
+   */
+  parseFilamentDiameter(commentCommands: GCodeCommand[]): number | undefined {
+    const sample = commentCommands.slice(0, CuraMetadataParser.HEADER_SAMPLE);
+    return sample.some((cmd) => /^FLAVOR:Griffin/i.test(cmd.comment!)) ? 2.85 : undefined;
+  }
+
+  /**
    * Parses layer metadata from Cura comments
    * @param commands - Array of gcode commands with comments
    * @returns Array of layer metadata

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -112,6 +112,14 @@ export type Metadata = {
   /** Extrusion dimension changes from `;WIDTH:` / `;HEIGHT:` comments, in line order */
   extrusionDimensions?: ExtrusionDimensionMetadata[];
   slicerName?: string;
+  /**
+   * Set when the detected slicer announces no dimension comments (Cura), so
+   * per-path width and height should be derived from the moves instead
+   * (see `Job.deriveMoveDimensions`)
+   */
+  deriveExtrusionDimensions?: boolean;
+  /** Filament diameter in millimeters announced by header comments, when known */
+  filamentDiameter?: number;
 };
 
 /**
@@ -239,9 +247,18 @@ export class Parser {
     if (!this.metadataParser) {
       this.metadataParser = detectSlicer(commands);
       // The slicer name comes from the chunk that identified the slicer -- a
-      // later chunk may contain layer comments but not the header.
+      // later chunk may contain layer comments but not the header. The same
+      // goes for the dimension derivation flag and the filament diameter:
+      // both read header comments, which sit in the identifying chunk.
       if (this.metadataParser) {
         this.metadata.slicerName = this.metadataParser.detectSlicerName(comments);
+        if (this.metadataParser.derivesExtrusionDimensions(comments)) {
+          this.metadata.deriveExtrusionDimensions = true;
+        }
+        const filamentDiameter = this.metadataParser.parseFilamentDiameter(comments);
+        if (filamentDiameter !== undefined) {
+          this.metadata.filamentDiameter = filamentDiameter;
+        }
       }
     }
     const slicerMetadata = parseSlicerMetadata(commands, this.metadataParser);

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -113,8 +113,9 @@ export type Metadata = {
   extrusionDimensions?: ExtrusionDimensionMetadata[];
   slicerName?: string;
   /**
-   * Set when the detected slicer announces no dimension comments (Cura), so
-   * per-path width and height should be derived from the moves instead
+   * Set to `false` when the detected dialect's E values cannot be read as
+   * filament lengths, so per-path dimensions must not be derived from the
+   * moves. Absent means derive, which is the default for every dialect
    * (see `Job.deriveMoveDimensions`)
    */
   deriveExtrusionDimensions?: boolean;

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -196,6 +196,21 @@ export class Parser {
   private readonly keepLines: boolean;
 
   /**
+   * The first comments of the file, kept across chunks.
+   * @remarks
+   * Slicer identification can land on a later chunk than the header it needs
+   * to read: a streamed parse may see `;FLAVOR:Griffin` in one chunk and the
+   * `;Generated with Cura` that identifies the slicer in the next. Header
+   * questions (slicer name, filament diameter, whether to derive dimensions)
+   * are asked against this sample rather than the identifying chunk alone, so
+   * streamed and one-shot parses answer them identically.
+   */
+  private headerComments: GCodeCommand[] = [];
+
+  /** How many leading comments `headerComments` retains */
+  private static readonly HEADER_COMMENT_SAMPLE = 200;
+
+  /**
    * Creates a new Parser instance
    * @param opts - Parser options
    */
@@ -235,6 +250,9 @@ export class Parser {
     const commands = this.lines2commands(lines);
 
     const comments = commands.filter((cmd) => cmd.comment);
+    if (this.headerComments.length < Parser.HEADER_COMMENT_SAMPLE) {
+      this.headerComments = this.headerComments.concat(comments).slice(0, Parser.HEADER_COMMENT_SAMPLE);
+    }
 
     // Extract thumbnails
     const thumbs = this.parseMetadata(comments).thumbnails;
@@ -246,16 +264,16 @@ export class Parser {
     // (not just comments) so parsers that read Z from G-code moves work.
     if (!this.metadataParser) {
       this.metadataParser = detectSlicer(commands);
-      // The slicer name comes from the chunk that identified the slicer -- a
-      // later chunk may contain layer comments but not the header. The same
-      // goes for the dimension derivation flag and the filament diameter:
-      // both read header comments, which sit in the identifying chunk.
+      // Header questions are asked against the retained header sample, not the
+      // identifying chunk: a streamed parse can identify the slicer on a chunk
+      // that no longer holds the ;FLAVOR: line the diameter and the derivation
+      // flag are read from, which made those answers depend on chunk size.
       if (this.metadataParser) {
-        this.metadata.slicerName = this.metadataParser.detectSlicerName(comments);
-        if (this.metadataParser.derivesExtrusionDimensions(comments)) {
+        this.metadata.slicerName = this.metadataParser.detectSlicerName(this.headerComments);
+        if (this.metadataParser.derivesExtrusionDimensions(this.headerComments)) {
           this.metadata.deriveExtrusionDimensions = true;
         }
-        const filamentDiameter = this.metadataParser.parseFilamentDiameter(comments);
+        const filamentDiameter = this.metadataParser.parseFilamentDiameter(this.headerComments);
         if (filamentDiameter !== undefined) {
           this.metadata.filamentDiameter = filamentDiameter;
         }

--- a/src/parser/gcode-parser.ts
+++ b/src/parser/gcode-parser.ts
@@ -270,8 +270,11 @@ export class Parser {
       // flag are read from, which made those answers depend on chunk size.
       if (this.metadataParser) {
         this.metadata.slicerName = this.metadataParser.detectSlicerName(this.headerComments);
-        if (this.metadataParser.derivesExtrusionDimensions(this.headerComments)) {
-          this.metadata.deriveExtrusionDimensions = true;
+        // Only the opt-out is recorded: deriving is the default, so a job with
+        // no metadata at all still derives, and the flag never flips on
+        // mid-stream when a later chunk finally identifies the slicer.
+        if (!this.metadataParser.derivesExtrusionDimensions(this.headerComments)) {
+          this.metadata.deriveExtrusionDimensions = false;
         }
         const filamentDiameter = this.metadataParser.parseFilamentDiameter(this.headerComments);
         if (filamentDiameter !== undefined) {

--- a/src/parser/metadata-parser-base.ts
+++ b/src/parser/metadata-parser-base.ts
@@ -103,22 +103,24 @@ export abstract class SlicerMetadataParser {
   }
 
   /**
-   * Whether per-path extrusion dimensions should be derived from the moves
-   * themselves for this gcode
+   * Whether the moves of this gcode can be trusted to derive per-path
+   * extrusion dimensions from
    * @param commentCommands - Array of gcode commands with comments
-   * @returns True when the job should derive dimensions volumetrically
+   * @returns True unless the dialect's E values are not filament lengths
    * @remarks
-   * Dialects that announce no dimension comments at all (Cura) opt in here,
-   * so the job can reconstruct per-path width and height from extrusion
-   * amounts and Z changes instead. Dialects with explicit `;WIDTH:` /
-   * `;HEIGHT:` comments keep the default `false`: their announced values are
-   * exact and must not be overridden by derived approximations. Evaluated on
-   * the chunk that identified the slicer (like `detectSlicerName`), so it can
-   * inspect header comments.
+   * Deriving is the default, for every dialect and for gcode no parser
+   * recognised: a file that announces its dimensions simply outranks the
+   * derived values path by path (see `State.resolvedExtrusionWidth`), so
+   * there is nothing to gate on. A dialect only opts out when the arithmetic
+   * itself does not hold -- Cura's UltiGCode flavor, whose E is cubic
+   * millimetres of material rather than millimetres of filament, would
+   * otherwise derive confidently wrong widths. Evaluated on the chunk that
+   * identified the slicer (like `detectSlicerName`), so it can inspect header
+   * comments.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   derivesExtrusionDimensions(commentCommands: GCodeCommand[]): boolean {
-    return false;
+    return true;
   }
 
   /**

--- a/src/parser/metadata-parser-base.ts
+++ b/src/parser/metadata-parser-base.ts
@@ -101,4 +101,40 @@ export abstract class SlicerMetadataParser {
   parseExtrusionDimensions(commands: GCodeCommand[]): ExtrusionDimensionMetadata[] {
     return [];
   }
+
+  /**
+   * Whether per-path extrusion dimensions should be derived from the moves
+   * themselves for this gcode
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns True when the job should derive dimensions volumetrically
+   * @remarks
+   * Dialects that announce no dimension comments at all (Cura) opt in here,
+   * so the job can reconstruct per-path width and height from extrusion
+   * amounts and Z changes instead. Dialects with explicit `;WIDTH:` /
+   * `;HEIGHT:` comments keep the default `false`: their announced values are
+   * exact and must not be overridden by derived approximations. Evaluated on
+   * the chunk that identified the slicer (like `detectSlicerName`), so it can
+   * inspect header comments.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  derivesExtrusionDimensions(commentCommands: GCodeCommand[]): boolean {
+    return false;
+  }
+
+  /**
+   * Reads the filament diameter announced in header comments, when any
+   * @param commentCommands - Array of gcode commands with comments
+   * @returns The filament diameter in millimeters, or undefined when unknown
+   * @remarks
+   * Feeds the volumetric dimension derivation (see
+   * `derivesExtrusionDimensions`), which converts extruded filament lengths
+   * into deposited volume. Only header-borne values may be reported here: a
+   * diameter that appears after moves (like Cura's end-of-file `;SETTING_3`
+   * blob) would reach a one-shot parse before any move executes but a
+   * streamed parse only after every move already ran, making the two disagree.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  parseFilamentDiameter(commentCommands: GCodeCommand[]): number | undefined {
+    return undefined;
+  }
 }

--- a/src/parser/metadata-parser-base.ts
+++ b/src/parser/metadata-parser-base.ts
@@ -110,7 +110,7 @@ export abstract class SlicerMetadataParser {
    * @remarks
    * Deriving is the default, for every dialect and for gcode no parser
    * recognised: a file that announces its dimensions simply outranks the
-   * derived values path by path (see `State.resolvedExtrusionWidth`), so
+   * derived values path by path (the Job resolves that order), so
    * there is nothing to gate on. A dialect only opts out when the arithmetic
    * itself does not hold -- Cura's UltiGCode flavor, whose E is cubic
    * millimetres of material rather than millimetres of filament, would

--- a/src/state.ts
+++ b/src/state.ts
@@ -41,25 +41,52 @@ export class State {
   /** Currently active tool */
   tool = 0;
   /**
-   * Width of extruded material, in millimeters, for paths created from here
-   * on, or `undefined` until slicer metadata announces one.
+   * Width of extruded material, in millimeters, as announced by the slicer,
+   * or `undefined` while no comment has announced one.
    * @remarks
    * Fed by `;WIDTH:` comments (PrusaSlicer family) via the slicer metadata
-   * pipeline (see `Job.beginCommand`). Paths created while this is
-   * `undefined` carry no width of their own and fall back at render time to
-   * the global setting, then to the built-in 0.6.
+   * pipeline (see `Job.beginCommand`). An announced width outranks the one
+   * derived from the moves: the slicer states what it asked the printer for,
+   * while the derivation infers it. See `State.resolvedExtrusionWidth`.
    */
   extrusionWidth: number | undefined = undefined;
   /**
-   * Height of the extruded line, in millimeters, for paths created from here
-   * on, or `undefined` until slicer metadata announces one.
+   * Height of the extruded line, in millimeters, as announced by the slicer,
+   * or `undefined` while no comment has announced one.
    * @remarks
    * Fed by `;HEIGHT:` comments (PrusaSlicer family), which vary throughout a
-   * print when adaptive layer height is enabled. Paths created while this is
-   * `undefined` carry no height of their own and fall back at render time to
-   * the global setting, then to the built-in 0.2.
+   * print when adaptive layer height is enabled. Outranks the derived height
+   * for the same reason as `extrusionWidth`.
    */
   lineHeight: number | undefined = undefined;
+  /**
+   * Width of extruded material derived from the moves themselves, used where
+   * the slicer announced none (see `Job.deriveMoveDimensions`).
+   */
+  derivedExtrusionWidth: number | undefined = undefined;
+  /**
+   * Height of the extruded line derived from the Z steps between extrusion
+   * moves, used where the slicer announced none.
+   */
+  derivedLineHeight: number | undefined = undefined;
+
+  /**
+   * The width paths take right now: announced by the slicer if it said, else
+   * derived from the moves, else `undefined` so the renderer's own fallback
+   * applies.
+   */
+  get resolvedExtrusionWidth(): number | undefined {
+    return this.extrusionWidth ?? this.derivedExtrusionWidth;
+  }
+
+  /**
+   * The line height paths take right now, resolved like
+   * `resolvedExtrusionWidth`.
+   */
+  get resolvedLineHeight(): number | undefined {
+    return this.lineHeight ?? this.derivedLineHeight;
+  }
+
   /** Current units (millimeters or inches) */
   units: Units = 'mm';
   /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -45,9 +45,10 @@ export class State {
    * or `undefined` while no comment has announced one.
    * @remarks
    * Fed by `;WIDTH:` comments (PrusaSlicer family) via the slicer metadata
-   * pipeline (see `Job.beginCommand`). An announced width outranks the one
-   * derived from the moves: the slicer states what it asked the printer for,
-   * while the derivation infers it. See `State.resolvedExtrusionWidth`.
+   * pipeline (see `Job.beginCommand`). An announced width outranks both the
+   * one the caller supplied and the one derived from the moves: the slicer
+   * states what it asked the printer for, while the derivation infers it.
+   * The Job resolves that order when it starts a path.
    */
   extrusionWidth: number | undefined = undefined;
   /**
@@ -55,38 +56,10 @@ export class State {
    * or `undefined` while no comment has announced one.
    * @remarks
    * Fed by `;HEIGHT:` comments (PrusaSlicer family), which vary throughout a
-   * print when adaptive layer height is enabled. Outranks the derived height
-   * for the same reason as `extrusionWidth`.
+   * print when adaptive layer height is enabled. Outranks the supplied and
+   * derived heights for the same reason as `extrusionWidth`.
    */
   lineHeight: number | undefined = undefined;
-  /**
-   * Width of extruded material derived from the moves themselves, used where
-   * the slicer announced none (see `Job.deriveMoveDimensions`).
-   */
-  derivedExtrusionWidth: number | undefined = undefined;
-  /**
-   * Height of the extruded line derived from the Z steps between extrusion
-   * moves, used where the slicer announced none.
-   */
-  derivedLineHeight: number | undefined = undefined;
-
-  /**
-   * The width paths take right now: announced by the slicer if it said, else
-   * derived from the moves, else `undefined` so the renderer's own fallback
-   * applies.
-   */
-  get resolvedExtrusionWidth(): number | undefined {
-    return this.extrusionWidth ?? this.derivedExtrusionWidth;
-  }
-
-  /**
-   * The line height paths take right now, resolved like
-   * `resolvedExtrusionWidth`.
-   */
-  get resolvedLineHeight(): number | undefined {
-    return this.lineHeight ?? this.derivedLineHeight;
-  }
-
   /** Current units (millimeters or inches) */
   units: Units = 'mm';
   /**

--- a/tmp-entry.ts
+++ b/tmp-entry.ts
@@ -1,0 +1,3 @@
+export { Parser } from './src/parser/gcode-parser';
+export { Interpreter } from './src/interpreter';
+export { Job } from './src/job';


### PR DESCRIPTION
## Summary

A file that announces no `;WIDTH:` / `;HEIGHT:` comments gets one global width and height for the whole print, however much its extrusions actually vary. Everything needed to reconstruct them is already in the moves, so this derives them:

- **Height** is the Z step between consecutive *extrusion* moves, which makes z-hop travels invisible to the measurement.
- **Width** comes from conservation of volume — `ΔE × filament cross-section / (length × height)` — using a rectangular deposit, matching the box profile `ExtrusionGeometry` actually extrudes.

Deriving is the **default for every dialect**, not a Cura feature: Cura is the motivating case, but Simplify3D, Slic3r without verbose comments and hand-written gcode all lack dimension comments too. A dialect only opts out when the arithmetic itself does not hold (Cura's UltiGCode flavor, whose E is cubic millimetres of material rather than millimetres of filament).

Precedence per dimension is **announced > supplied > derived > built-in default**. The slicer stating what it asked the printer for outranks everything; a value you pass to the constructor is a decision and outranks the inference, so the derivation simply does not run for it; deriving fills what is left. That keeps `extrusionWidth` and `lineHeight` meaningful options rather than ones the derivation quietly takes over.

That precedence is also what keeps streaming honest. Gating on "this file announced no dimensions" would decide mid-stream: a PrusaSlicer file whose only fingerprint is `;LAYER_CHANGE` is identified *after* its start gcode has extruded a prime line, so a streamed parse would derive for that path while a one-shot parse would not. Nothing flips here, so streamed and one-shot agree by construction.

Stacked on #461, which supplies the true extruded lengths this needs.

## Behavior changes

- Files without dimension comments now render with per-path widths and heights instead of the global fallback.
- Files that announce only *some* dimensions get the rest derived — a PrusaSlicer print's skirt and prime line, emitted before the first `;WIDTH:`, now carry a derived width, unless the caller supplied one.
- Header metadata — the filament diameter and the opt-out — is read from the file's first 200 comments rather than from whichever chunk identified the slicer. Cura writes `;FLAVOR:` before the line that identifies it, so under streaming those could land in different chunks: Griffin silently lost its 2.85 mm diameter, scaling every derived width by (2.85/1.75)² = 2.65×, and UltiGCode wrongly enabled derivation.

Implausible results are discarded rather than rendered: heights outside 0.01–1.0 mm, widths outside 0.1–2.0 mm, and segments under 0.05 mm where E quantization dominates. Derived widths are quantized to 0.01 mm with a 2% tolerance so rounding noise cannot shatter the model into micro-paths.

Deriving costs nothing on files that announce their widths — the volume arithmetic is skipped while an announced width is in force, which is worth about a third of the interpret time on 3DBenchy.

## Public API changes

Two new overridable hooks on `SlicerMetadataParser`: `derivesExtrusionDimensions` (defaults to `true`; a dialect returns `false` to opt out) and `parseFilamentDiameter`. `Metadata` gains optional `deriveExtrusionDimensions` and `filamentDiameter`. `State` is unchanged: the derived dimensions live inside `Job`, since nothing outside it reads them. Its surface is now pinned in the public API test all the same, being reachable as `job.state`. `Job` accepts `extrusionWidth` / `lineHeight`, the dimensions the caller supplied, and `Job.deriveMoveDimensions` is new. No renames or removals.

## Screenshots

Five first-layer lines printed at 1.2 / 0.9 / 0.6 / 0.4 / 0.25 mm, same camera:

| Before | After |
| ------ | ----- |
| ![five parallel first-layer lines, all rendered at an identical 0.6 mm width](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-462-assets/width-fan-before.png) | ![the same five lines with derived widths, tapering from 1.2 mm down to a hairline 0.25 mm](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-462-assets/width-fan-after.png) |

Heights come out of the Z steps, so the tower's three tiers stack visibly differently — 0.3 mm at the bottom, 0.2 mm in the middle, 0.1 mm on top:

![close-up of the tower wall: four fat beads in the bottom tier, eight medium in the middle, about twenty hairline beads on top](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-462-assets/layer-height-tiers.png)

## Checks

- [x] `npm run check` passes (test + typeCheck + lint)
- [x] `npm run test:coverage` — `src/` still at 100%
- [x] Labelled appropriately (`enhancement`)

Assisted by Claude Code - Fable 5
