### PR TITLE
Add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,47 @@
+## Problem
+
+<!--
+What was broken, from the user's point of view. Symptoms, not code.
+Link the issue this fixes ("Fixes #123"), plus any related reports or PRs
+("Ref #123") — duplicates, earlier attempts, the change that regressed it.
+A gcode snippet or screenshot that reproduces it goes a long way.
+-->
+
+## Cause
+
+<!--
+The actual root cause. Why did it only show up in this situation, and why did
+everything else survive? If it's a regression, name the change that introduced it.
+-->
+
+## Fix
+
+<!--
+What changed, and why here rather than somewhere else — especially if the
+obvious-looking fix site was the wrong one.
+-->
+
+## Behavior changes
+
+<!--
+Bug fixes alter output by definition. Spell out what now renders/parses
+differently for files that already worked, so it isn't buried in the diff.
+-->
+
+## Public API changes
+
+<!-- New, changed, removed or deprecated exports, options, methods or types. Usually "None". -->
+
+## Before / After
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+## Checks
+
+- [ ] `npm run check` passes (test + typeCheck + lint)
+- [ ] `npm run test:coverage` — `src/` still at 100%
+- [ ] Labelled `bug` + the relevant area label
+
+Assisted by <tool> - <model>

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,3 +1,5 @@
+<!-- Delete any section that doesn't apply. -->
+
 ## Problem
 
 <!--
@@ -30,7 +32,7 @@ differently for files that already worked, so it isn't buried in the diff.
 
 ## Public API changes
 
-<!-- New, changed, removed or deprecated exports, options, methods or types. Usually "None". -->
+<!-- New, changed, removed or deprecated exports, options, methods or types. Delete if none. -->
 
 ## Before / After
 

--- a/.github/PULL_REQUEST_TEMPLATE/demo-ui.md
+++ b/.github/PULL_REQUEST_TEMPLATE/demo-ui.md
@@ -1,3 +1,5 @@
+<!-- Delete any section that doesn't apply. -->
+
 ## Summary
 
 <!--
@@ -33,11 +35,11 @@ Which presets/files were actually loaded and what you saw. For example:
 
 ## Behavior changes
 
-<!-- Library-side effects, if any. Demo-only changes can say "None (demo only)". -->
+<!-- Library-side effects, if any. Delete this section for demo-only changes. -->
 
 ## Public API changes
 
-<!-- New or changed options/methods the demo relies on. Usually "None". -->
+<!-- New or changed options/methods the demo relies on. Delete if none. -->
 
 ## Checks
 

--- a/.github/PULL_REQUEST_TEMPLATE/demo-ui.md
+++ b/.github/PULL_REQUEST_TEMPLATE/demo-ui.md
@@ -1,0 +1,48 @@
+## Summary
+
+<!--
+What changes in the demo app / UI, and why.
+
+Link the issue this closes ("Fixes #123") and any related issues or PRs ("Ref #123").
+-->
+
+## What changed in the UI
+
+<!-- Controls added, moved or removed; layout, styling and interaction changes. -->
+
+## Screenshots
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+<!--
+Required — this is a visible change.
+Short screen recordings are welcome for interaction changes.
+-->
+
+## Verified in the browser
+
+<!--
+Which presets/files were actually loaded and what you saw. For example:
+
+- **3DBenchy**: renders unchanged ✅
+- **Mach3 (cnc)**: tool path visible, camera centred ✅
+- Console clean (no new warnings or errors) ✅
+-->
+
+## Behavior changes
+
+<!-- Library-side effects, if any. Demo-only changes can say "None (demo only)". -->
+
+## Public API changes
+
+<!-- New or changed options/methods the demo relies on. Usually "None". -->
+
+## Checks
+
+- [ ] `npm run check` passes (test + typeCheck + lint)
+- [ ] `npm run test:coverage` — `src/` still at 100% (if `src/` was touched)
+- [ ] Labelled `demo` and/or `ui`
+
+Assisted by <tool> - <model>

--- a/.github/PULL_REQUEST_TEMPLATE/gcode-support.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gcode-support.md
@@ -1,0 +1,55 @@
+## Command(s)
+
+<!--
+e.g. `G38.2`–`G38.5` (straight probe), `M206` (home offset).
+
+Link the issue this closes ("Closes #123"), and any related ones — sibling
+commands from the same split, the tracking issue, PRs this is stacked on.
+-->
+
+## Dialect & reference
+
+<!--
+Which firmware/slicer flavours this follows — Marlin, RepRapFirmware, LinuxCNC,
+Mach3, Klipper — and a link to the spec or docs page.
+Call out overloads where the same word means different things per firmware
+(e.g. RRF's G10), and say which interpretation this PR implements.
+-->
+
+## What it does
+
+<!-- The semantics being implemented, and any deliberate gaps (parameters ignored, variants left out). -->
+
+## Interpreter state touched
+
+<!--
+Which parts of the state machine this reads or mutates — position, offsets,
+relative/absolute modes, units, tool selection, layer detection.
+Note interactions with existing modes (G90/G91, M82/M83, G20/G21).
+-->
+
+## Behavior changes
+
+<!--
+Does existing gcode parse or render differently now? Previously-unknown commands
+becoming known can shift layer detection or travel/extrusion classification.
+-->
+
+## Public API changes
+
+<!-- New exports, options, command types or state fields. Renames keep a @deprecated alias. -->
+
+## Screenshots
+
+<!-- If the command has a visible effect, before/after from the demo. Otherwise "N/A". -->
+
+## Checks
+
+- [ ] `npm run check` passes (test + typeCheck + lint)
+- [ ] `npm run test:coverage` — `src/` still at 100%
+- [ ] End-to-end coverage exists: a gcode snippet flows through
+      `Parser.parseGCode` → `Interpreter.execute` (or `processGCode` /
+      `processGCodeStream`), not just hand-built `GCodeCommand` objects
+- [ ] Labelled `feature`/`enhancement` + `parser` / `interpreter`
+
+Assisted by <tool> - <model>

--- a/.github/PULL_REQUEST_TEMPLATE/gcode-support.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gcode-support.md
@@ -1,3 +1,5 @@
+<!-- Delete any section that doesn't apply. -->
+
 ## Command(s)
 
 <!--
@@ -41,7 +43,7 @@ becoming known can shift layer detection or travel/extrusion classification.
 
 ## Screenshots
 
-<!-- If the command has a visible effect, before/after from the demo. Otherwise "N/A". -->
+<!-- If the command has a visible effect, before/after from the demo. Delete this section otherwise. -->
 
 ## Checks
 

--- a/.github/PULL_REQUEST_TEMPLATE/performance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance.md
@@ -1,0 +1,57 @@
+## Summary
+
+<!--
+What got faster or lighter, and for which workload.
+
+Link the related issues and PRs ("Ref #123") — the tracking issue, the profiling
+report, and any earlier PR in the same perf stack this builds on.
+-->
+
+## What was slow, and why
+
+<!-- The bottleneck, with evidence — profile, flame graph, allocation counts. -->
+
+## The optimization
+
+<!-- What changed, and why it's safe. Note any accuracy/memory trade-offs taken deliberately. -->
+
+## Numbers
+
+| Metric | Before | After | Δ |
+|---|---|---|---|
+| Parse time |  |  |  |
+| Render/build time |  |  |  |
+| Peak memory |  |  |  |
+
+<!-- Compare against the `develop` baseline, not against an earlier PR in the stack. -->
+
+## How measured
+
+<!--
+File(s) used and their size, machine, browser/node version, number of runs, and
+whether the numbers are medians. Point at the harness so someone else can rerun it.
+-->
+
+## Behavior changes
+
+<!--
+A perf PR should render identically. State that explicitly, and say how you
+confirmed it — pixel comparison, geometry/vertex counts, existing suite.
+If output does change, describe exactly how.
+-->
+
+## Public API changes
+
+<!-- New or changed options/methods. Renames keep a @deprecated alias. Usually "None". -->
+
+## Screenshots
+
+<!-- Before/after render of the same file, to show output is unchanged. -->
+
+## Checks
+
+- [ ] `npm run check` passes (test + typeCheck + lint)
+- [ ] `npm run test:coverage` — `src/` still at 100%
+- [ ] Labelled `performance` + the relevant area label
+
+Assisted by <tool> - <model>

--- a/.github/PULL_REQUEST_TEMPLATE/performance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance.md
@@ -1,3 +1,5 @@
+<!-- Delete any section that doesn't apply. -->
+
 ## Summary
 
 <!--
@@ -42,7 +44,7 @@ If output does change, describe exactly how.
 
 ## Public API changes
 
-<!-- New or changed options/methods. Renames keep a @deprecated alias. Usually "None". -->
+<!-- New or changed options/methods. Renames keep a @deprecated alias. Delete if none. -->
 
 ## Screenshots
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Delete any section that doesn't apply. -->
+
 ## Summary
 
 <!--
@@ -14,21 +16,23 @@ See "Writing a good PR description" in CONTRIBUTING.md.
 
 <!--
 Anything that renders, parses or outputs differently for gcode that already
-worked before — including side effects of a bug fix. "None" is a valid answer,
-but say it explicitly rather than leaving this blank.
+worked before — including side effects of a bug fix. If nothing changes for
+existing files, delete this section.
 -->
 
 ## Public API changes
 
 <!--
 New, changed, removed or deprecated exports, options, methods or types.
-Renames must keep the old name as a @deprecated alias. "None" is fine.
+Renames must keep the old name as a @deprecated alias. Delete this section if
+the public surface is untouched.
 -->
 
 ## Screenshots
 
 <!--
-Required for anything with a visible effect. Before/after side by side helps:
+Required for anything with a visible effect; delete this section otherwise.
+Before/after side by side helps:
 
 | Before | After |
 | ------ | ----- |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!--
+What changes, and why.
+
+Link the issue this closes ("Fixes #123"), and mention any related issues or PRs
+("Ref #123", "stacked on #123", "supersedes #123") so the context is one click away.
+-->
+
+## Behavior changes
+
+<!--
+Anything that renders, parses or outputs differently for gcode that already
+worked before — including side effects of a bug fix. "None" is a valid answer,
+but say it explicitly rather than leaving this blank.
+-->
+
+## Public API changes
+
+<!--
+New, changed, removed or deprecated exports, options, methods or types.
+Renames must keep the old name as a @deprecated alias. "None" is fine.
+-->
+
+## Screenshots
+
+<!--
+Required for anything with a visible effect. Before/after side by side helps:
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+-->
+
+## Checks
+
+- [ ] `npm run check` passes (test + typeCheck + lint)
+- [ ] `npm run test:coverage` — `src/` still at 100%
+- [ ] Labelled appropriately (`bug` / `feature` / `meta` / area labels)
+
+<!-- CONTRIBUTING.md requires disclosing AI tool usage. Keep or edit this line: -->
+Assisted by <tool> - <model>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@ What changes, and why.
 
 Link the issue this closes ("Fixes #123"), and mention any related issues or PRs
 ("Ref #123", "stacked on #123", "supersedes #123") so the context is one click away.
+
+Don't list the changes — the diff shows those. Explain the reasoning instead.
+See "Writing a good PR description" in CONTRIBUTING.md.
 -->
 
 ## Behavior changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,12 @@ considered and history belong in the PR, not in a comment block above the functi
 Code comments should say what the next reader needs *at that line*; the story of how
 the change came about belongs in the PR, which stays reachable from `git blame`.
 
+**Delete what doesn't apply.** The templates are a starting point, not a form to
+fill in. A heading with nothing under it, or a row of "N/A", costs the reviewer a
+scroll and tells them nothing — drop the section entirely. The exception is a
+change whose *absence* is the point: a performance PR that renders identically
+should say so, because that claim is what's being reviewed.
+
 ## Before submitting a PR
 
 Run the full check suite:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,33 @@ If you don't need the demo app, just run `npm run dev:watch`.
 the unit-test CI and the Firebase preview deploy only trigger for PRs targeting it.
 Merges to `develop` auto-deploy the demo to https://gcode-preview.web.app.
 
+## Pull request templates
+
+`.github/pull_request_template.md` is the default and loads automatically for
+every PR. A few specialized templates live in `.github/PULL_REQUEST_TEMPLATE/`,
+but GitHub does **not** offer a picker for them — pick one explicitly.
+
+From the CLI:
+
+```sh
+gh pr create --base develop --template bugfix.md
+```
+
+Or append a query parameter to the compare URL:
+
+```
+https://github.com/xyz-tools/gcode-preview/compare/develop...my-branch?template=bugfix.md
+```
+
+| Template           | Use for                                                          |
+| ------------------ | ---------------------------------------------------------------- |
+| `bugfix.md`        | Fixing broken behavior — Problem / Cause / Fix, before & after   |
+| `gcode-support.md` | New or updated gcode command support                             |
+| `demo-ui.md`       | Demo app and UI changes — screenshots required                   |
+| `performance.md`   | Speed or memory work — before/after numbers, output unchanged    |
+
+Anything else (docs, refactors, dependency bumps) uses the default template.
+
 ## Before submitting a PR
 
 Run the full check suite:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,38 @@ https://github.com/xyz-tools/gcode-preview/compare/develop...my-branch?template=
 
 Anything else (docs, refactors, dependency bumps) uses the default template.
 
+## Writing a good PR description
+
+The diff already shows *what* changed. The description is for everything the diff
+can't show: why this change, why here, and what a reviewer would otherwise have to
+reconstruct on their own.
+
+**Don't list the changes.** A bullet per file or per function is the one thing
+GitHub already renders perfectly. Spend that space on reasoning instead — the root
+cause, the constraint that ruled out the obvious approach, the trade-off you took
+knowingly.
+
+**Draw it when it's structural.** GitHub renders Mermaid in PR descriptions. When a
+change moves data between components, reorders a pipeline or introduces a new
+lifecycle, a small diagram beats three paragraphs:
+
+```mermaid
+flowchart LR
+  gcode[G-code] --> Parser --> Interpreter --> Geometry --> Scene
+```
+
+Diagram only the part you changed; a picture of the whole app helps nobody.
+
+**Explain the math.** New geometry, projections, interpolation, coordinate
+transforms or unit conversions need the reasoning written out — the formula, what
+the variables mean, and why it's correct. A reviewer should be able to check your
+derivation without redoing it from the code.
+
+**Favor the description over verbose code comments.** Background, alternatives
+considered and history belong in the PR, not in a comment block above the function.
+Code comments should say what the next reader needs *at that line*; the story of how
+the change came about belongs in the PR, which stays reachable from `git blame`.
+
 ## Before submitting a PR
 
 Run the full check suite:


### PR DESCRIPTION
## Summary

The repo had no PR templates, so every description was written from scratch and the review standards in `CONTRIBUTING.md` only got applied when someone remembered them. This adds a default template that asks for them by name, four opt-in ones for the PR shapes that recur here (bug fix, gcode command support, demo/UI, performance), and a section on what actually makes a description worth reading.

Two things are deliberate. **Behavior changes and public API changes are separate prompts in every template**, because those are the two `CONTRIBUTING.md` rules most easily satisfied by silence — a bug fix that alters rendering for existing files is exactly the case that gets buried in a diff. And the templates ask for reasoning, not enumeration: the new *Writing a good PR description* section argues against the bullet-list-of-changes habit, points at Mermaid for structural changes, asks that new math be derived in prose, keeps background out of code comments, and tells contributors to delete any section that doesn't apply rather than answer it with "N/A" — a template that gets filled in mechanically produces exactly the padding it was meant to prevent.

The specialized templates need documenting because GitHub gives them no picker — they only load via `gh pr create --template bugfix.md` or `?template=bugfix.md`. Undocumented, they'd be four files nobody ever opens.

This PR's own description uses the default template, so it doubles as a worked example — including dropping the sections that don't apply here.

## Checks

- [x] `npm run check` passes (test + typeCheck + lint)
- [x] `src/` untouched, coverage unaffected
- [x] Labelled `meta` + `docs`

Assisted by Claude Code - Opus 5