### PR TITLE
Expand the options types in the generated API docs

### DIFF
--- a/src/build-volume.ts
+++ b/src/build-volume.ts
@@ -3,7 +3,10 @@ import { AxesHelper, Color, Group, Vector3, Scene } from 'three';
 import { LineBox } from './helpers/line-box';
 import { type Disposable } from './helpers/three-utils';
 
-/** The dimensions a caller supplies to describe a build volume */
+/**
+ * The dimensions a caller supplies to describe a build volume
+ * @interface
+ */
 export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
 
 /**
@@ -44,6 +47,7 @@ export class BuildVolume {
     this._z = Math.max(0, z);
   }
 
+  /** Width of the build volume in mm */
   get x(): number {
     return this._x;
   }
@@ -54,6 +58,7 @@ export class BuildVolume {
     }
     this.update(); // Update the build volume when x changes
   }
+  /** Depth of the build volume in mm */
   get y(): number {
     return this._y;
   }
@@ -64,6 +69,7 @@ export class BuildVolume {
     }
     this.update(); // Update the build volume when y changes
   }
+  /** Height of the build volume in mm */
   get z(): number {
     return this._z;
   }
@@ -74,6 +80,7 @@ export class BuildVolume {
     }
     this.update(); // Update the build volume when z changes
   }
+  /** Whether the finer secondary grid is drawn on the build plate */
   get smallGrid(): boolean | undefined {
     return this._smallGrid;
   }

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -11,7 +11,7 @@ import { splitChunk } from './helpers/split-chunk';
 const LIVE_RENDER_INTERVAL_MS = 250;
 
 /**
- * Options for configuring the G-code preview
+ * Preview-level options, merged into {@link GCodePreviewOptions}.
  */
 type LibOptions = {
   /** Enable developer mode with additional controls */
@@ -43,6 +43,10 @@ type LibOptions = {
   arcChordTolerance?: number;
 };
 
+/**
+ * Options for configuring the G-code preview
+ * @interface
+ */
 export type GCodePreviewOptions = LibOptions & SceneManagerOptions;
 
 /**


### PR DESCRIPTION
## Summary

TypeDoc renders a type alias by printing its right-hand side, so `GCodePreviewOptions` showed up as `LibOptions & SceneManagerOptions` and nothing else — none of its 25 documented options were reachable from the rendered docs. `BuildVolumeDef` had the same problem as a `Pick<>`.

Tagging both aliases with `@interface` makes TypeDoc resolve them to a real interface page that lists every member with its doc comment.

## Screenshots

**`GCodePreviewOptions`**

| Before | After |
| ------ | ----- |
| ![Type Alias GCodePreviewOptions page showing only the text "LibOptions & SceneManagerOptions"](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-467-assets/options-before.png) | ![Interface GCodePreviewOptions page listing all 25 options and their descriptions](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-467-assets/options-after.png) |

**`BuildVolumeDef`**

| Before | After |
| ------ | ----- |
| ![Type Alias BuildVolumeDef page showing only a bare Pick expression](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-467-assets/buildvolume-before.png) | ![Interface BuildVolumeDef page listing x, y, z and smallGrid](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-467-assets/buildvolume-after.png) |

## Public API changes

None. `@interface` is a TypeDoc annotation: the TypeScript types are untouched and the published `.d.ts` still declares the same two aliases. Making them real interfaces would also fix the docs, but interfaces lose the implicit index signature, which can break consumers — the tag avoids that.

The `BuildVolume` accessors now carry the doc comments that previously only sat on the private backing fields.

## Checks

- [x] `npm run check` passes (test + typeCheck + lint)
- [x] Comment-only change; coverage unaffected

Assisted by Claude Code - Opus 5
