### PR TITLE
Test three invariants that were documented but never asserted

### DIFF
--- a/src/__tests__/indexers.ts
+++ b/src/__tests__/indexers.ts
@@ -429,3 +429,38 @@ test('LayersMetadataIndexer.setLayerMetadata tolerates null/undefined', () => {
   indexer.setLayerMetadata(undefined as unknown as LayerMetadata[]);
   expect(indexer.hasMetadata).toBe(false);
 });
+
+// A streaming parse re-sets the *same* (growing) metadata array on every chunk, and the
+// pointer that findLayerIndexForZ scans from must survive that. Setting a different array
+// has to rewind it instead, so positions from the previous metadata cannot leak. Only the
+// same-instance vs swapped-instance contrast catches this: both run the same lines.
+test('LayersMetadataIndexer.setLayerMetadata keeps the layer pointer for the same array, rewinds for a new one', () => {
+  const metadata: LayerMetadata[] = [
+    { layerIndex: 0, z: 0.3, height: 0.3, lineIndex: 0 },
+    { layerIndex: 1, z: 0.6, height: 0.3, lineIndex: 5 },
+    { layerIndex: 2, z: 0.9, height: 0.3, lineIndex: 10 }
+  ];
+  // Walks the pointer up to metadata layer 2.
+  const advancePointer = (indexer: LayersMetadataIndexer): void => {
+    [0.3, 0.6, 0.9].forEach((z) => indexer.sortIn(createPath(z)));
+  };
+
+  // Same instance: the pointer stays at layer 2, so a path low in the stack is filed
+  // into the current layer rather than rediscovering layer 0.
+  const kept = new LayersMetadataIndexer([], metadata);
+  advancePointer(kept);
+  kept.setLayerMetadata(metadata);
+  const afterRestate = createPath(0.3);
+  kept.sortIn(afterRestate);
+
+  expect(afterRestate.layerIndex).toBe(2);
+
+  // Same history, different instance: the pointer rewinds and the scan starts over.
+  const swapped = new LayersMetadataIndexer([], metadata);
+  advancePointer(swapped);
+  swapped.setLayerMetadata([...metadata]);
+  const afterSwap = createPath(0.3);
+  swapped.sortIn(afterSwap);
+
+  expect(afterSwap.layerIndex).toBe(0);
+});

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -5,6 +5,7 @@ import { BoundingBox } from '../bounding-box';
 import { Scene, Color, Group, BatchedMesh, LineBasicMaterial } from 'three';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { createColorMaterial } from '../helpers/colorMaterial';
 
 describe('ObjectsManager', () => {
   let scene: Scene;
@@ -318,6 +319,47 @@ describe('ObjectsManager', () => {
 
       expect(second.materials[0]).not.toBe(firstMaterial);
       second.dispose();
+    });
+
+    // The per-tool isolation above only holds because createColorMaterial builds a new
+    // material every call. Callers write straight into the uniforms (recoloring, clipping),
+    // so a cached/shared instance would make one write show up on every mesh that started
+    // from the same color.
+    test('createColorMaterial returns a fresh material per call, so uniform writes do not bleed', () => {
+      const first = createColorMaterial(0x0000ff, 0.3, 0.6, 1.1);
+      const second = createColorMaterial(0x0000ff, 0.3, 0.6, 1.1);
+
+      expect(second).not.toBe(first);
+      expect(second.uniforms).not.toBe(first.uniforms);
+
+      first.uniforms.uColor.value.setHex(0x00ff00);
+      first.uniforms.clipMinY.value = 5;
+
+      expect(second.uniforms.uColor.value.getHex()).toBe(0x0000ff);
+      expect(second.uniforms.clipMinY.value).toBe(-Infinity);
+
+      first.dispose();
+      second.dispose();
+    });
+
+    // three.js only grew BatchedMesh.addInstance after the oldest version we support, so
+    // createBatchMesh calls it optionally — that `?.` is what lets webgl1 browsers still
+    // get a batched mesh. Simulate the older build by removing the method: nothing may
+    // throw, and the geometry must still land in the mesh.
+    test('batches geometry on a three.js build with no BatchedMesh.addInstance', () => {
+      const addInstance = BatchedMesh.prototype.addInstance;
+      Reflect.deleteProperty(BatchedMesh.prototype, 'addInstance');
+
+      try {
+        expect(BatchedMesh.prototype.addInstance).toBeUndefined();
+        expect(() => objectsManager.renderExtrusionTubes([createTestPath()], new Color(0x0000ff))).not.toThrow();
+
+        const mesh = objectsManager.extrusionsGroup.children[0] as BatchedMesh;
+        expect(mesh).toBeInstanceOf(BatchedMesh);
+        expect(mesh.geometry.attributes.position.count).toBeGreaterThan(0);
+      } finally {
+        BatchedMesh.prototype.addInstance = addInstance;
+      }
     });
   });
 


### PR DESCRIPTION
Three source comments describe an invariant precisely, and nothing asserts it. All three lines are at 100% *line* coverage, so the repo's coverage gate never noticed — the gap is behavioural. A refactor could break any of them and CI would stay green.

| site | invariant |
|---|---|
| `src/indexers.ts:243` | re-setting the **same** growing array keeps the layer pointer; a **different** array rewinds it, so stale positions cannot leak |
| `src/helpers/colorMaterial.ts:59` | every call returns a fresh material, so in-place uniform writes cannot bleed between tools or previews |
| `src/objects-manager.ts:716` | `addInstance?.()` is what lets webgl1 browsers use the batched mesh on older three.js builds |

The indexers one is observed through `path.layerIndex` rather than private state: `findLayerIndexForZ` scans forward from `currentMetadataLayerIndex`, so a path lands in layer 2 if the pointer was kept and layer 0 if it rewound.

Each test was checked to actually fail when its invariant is broken, then the source restored:

- pointer short-circuit removed → `expected +0 to be 2`
- `createColorMaterial` turned into a cached singleton → `expected ShaderMaterial not to be ShaderMaterial`
- `?.` changed to `.` → `TypeError: batchedMesh.addInstance is not a function`

No source files change. Found while auditing the 24 "used to …" comments in `src/` for whether the invariant each one guards is really pinned.

Assisted by Claude Code - Opus 5