### PR TITLE
Sandbox the eval runs so they cannot read the fix they are graded on

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,7 @@ subjective, to support a claim like "the skill is 87% accurate."
 types.ts                 Case schema + loader (validates every case.json)
 run.ts                   runner — one fresh `claude -p` per run
 grade.ts                 grader — tier 1, deterministic
+cases/<id>/pre.patch     optional: applied to the sandbox before the agent looks
 cases/<id>/diff.patch    frozen fixture: a proposed change to this repo
 cases/<id>/case.json     what a correct review must find, and how to grade it
 results/<date-model-mode>/   captured output — gitignored, local to your machine
@@ -23,9 +24,24 @@ patch reads like a change someone might actually propose. Sources are named in
 edit whose correct review is *no findings at all* — it guards against inventing
 problems to look useful.
 
-**Isolation.** Every run is a separate `claude -p` process, so no case can leak into
-another. `run.sh` copies `diff.patch` into a temp directory and points the agent there;
-`case.json` stays behind in the repo so the answers are never in reach.
+Because the fixtures are inverted fixes, the comment explaining an invariant was written
+by the very fix a fixture undoes. Leaving it in hands the run a hint the original reviewer
+never had, and deleting it *inside* `diff.patch` is worse still: a `-` line narrating the
+bug beside the `+` line introducing it is a louder signpost than the defect. So each
+defect case strips those comments in `pre.patch`, applied to the sandbox before the agent
+looks — they appear in neither the diff nor the surrounding source. `loadCases` refuses to
+load a defect case whose `diff.patch` deletes a comment line.
+
+**Isolation.** Every run is a separate `claude -p` process in its own sandbox, so no case
+can leak into another and no run can read the answer. The sandbox is a `git archive`
+export of `HEAD` — tracked files only and **no `.git`**, so neither the working tree nor
+the fix history is reachable — with `evals/` deleted (that is where `case.json` states the
+expected finding) and `pre.patch` applied. `.claude/skills` is a tracked symlink into
+`.agents/`, so the skill under test comes along and resolves normally. `node_modules` does
+not, which is fine: these runs review code, they do not build or test it.
+
+Inspect exactly what a run can see with `npm run evals -- --dry-run`, which builds each
+sandbox, prints its path and stops before spawning the agent.
 
 ## Running
 
@@ -56,16 +72,17 @@ has stopped working.
 must explain NaN persistence, not merely observe that a guard was deleted. Naming the
 right file for the wrong reason is not a hit.
 
-Because the fixtures are inverted fixes, some cases also delete an explanatory comment.
-That is a hint the original author would not have had. The `grading_note` exists to stop
-a run passing on the hint alone.
+`grading_note` predates the sandbox: it was added when fixtures still deleted the
+explanatory comment, to stop a run scoring a hit off that hint alone. The hint is gone
+now, but the bar it set is still the right one.
 
 ## What these cases do and don't measure
 
-A first run (2026-09-07, opus, one run per case) found **skill 5/5 detection, baseline 4/4**.
-On these fixtures the skill shows no detection advantage, and that is a fact about the
-fixtures rather than a verdict on the skill: each one plants a single obvious defect and
-removes the comment that explained it, which a capable model spots unaided.
+A first run (2026-09-07, opus, one run per case) found **skill 5/5 detection, baseline
+4/4** — but that was collected before the sandbox existed, when a run could open the file
+the fixture had un-fixed and read the corrected line straight off disk. Near-perfect scores
+are exactly what that produces, so **those numbers are withdrawn** and no skill-vs-baseline
+claim survives them. Re-baseline before comparing anything.
 
 Where the skill did differ, on real PRs, was in *coverage and discipline* — running every
 relevant class rather than the one that catches the eye, measuring claims against
@@ -93,6 +110,9 @@ count that explodes on real files. Those are harder to build and are the obvious
 1. Pick a bug from `.context/pr-bug-audit.md` with a known fix.
 2. Inject it into current code and generate the patch with
    `diff -u --label a/<path> --label b/<path>`, prefixed by a `diff --git` line.
-3. Verify it applies: `git apply --check cases/<id>/diff.patch`.
-4. Write `case.json` with `must_find`, `expected_classes`, and a `grading_note` that
+3. Move any comment that explains the invariant into `cases/<id>/pre.patch`, so the
+   reviewed diff carries the code change alone. `loadCases` enforces this.
+4. Verify both apply in order, against a sandbox rather than the worktree:
+   `npm run evals -- --dry-run --case <id>`.
+5. Write `case.json` with `must_find`, `expected_classes`, and a `grading_note` that
    names the mechanism a real hit must describe.

--- a/evals/cases/364-boundingbox-nan/diff.patch
+++ b/evals/cases/364-boundingbox-nan/diff.patch
@@ -1,17 +1,10 @@
 diff --git a/src/bounding-box.ts b/src/bounding-box.ts
 --- a/src/bounding-box.ts
 +++ b/src/bounding-box.ts
-@@ -5,17 +5,11 @@
- 
-   /**
-    * Updates the bounding box with the given coordinates.
--   * Points with any non-finite coordinate (NaN or Infinity) are ignored.
-    * @param x - The X coordinate.
-    * @param y - The Y coordinate.
+@@ -10,10 +10,6 @@
     * @param z - The Z coordinate.
     */
    public update(x: number, y: number, z: number): void {
--    // Malformed gcode can yield NaN params; a partial point would corrupt the extremes, so reject the whole point.
 -    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
 -      console.error(`BoundingBox.update: ignoring non-finite point (${x}, ${y}, ${z})`);
 -      return;

--- a/evals/cases/364-boundingbox-nan/pre.patch
+++ b/evals/cases/364-boundingbox-nan/pre.patch
@@ -1,0 +1,17 @@
+diff --git a/src/bounding-box.ts b/src/bounding-box.ts
+--- a/src/bounding-box.ts
++++ b/src/bounding-box.ts
+@@ -5,13 +5,11 @@
+ 
+   /**
+    * Updates the bounding box with the given coordinates.
+-   * Points with any non-finite coordinate (NaN or Infinity) are ignored.
+    * @param x - The X coordinate.
+    * @param y - The Y coordinate.
+    * @param z - The Z coordinate.
+    */
+   public update(x: number, y: number, z: number): void {
+-    // Malformed gcode can yield NaN params; a partial point would corrupt the extremes, so reject the whole point.
+     if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+       console.error(`BoundingBox.update: ignoring non-finite point (${x}, ${y}, ${z})`);
+       return;

--- a/evals/cases/370-nullish-z0/diff.patch
+++ b/evals/cases/370-nullish-z0/diff.patch
@@ -1,14 +1,10 @@
 diff --git a/src/interpreter/commands/arc-move.ts b/src/interpreter/commands/arc-move.ts
 --- a/src/interpreter/commands/arc-move.ts
 +++ b/src/interpreter/commands/arc-move.ts
-@@ -57,13 +57,9 @@
+@@ -57,9 +57,9 @@
        state.units
      );
  
--    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
--    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
--    // rejecting NaN here by accident, which `??` does not do. An axis the command
--    // omits keeps its previous (possibly unknown) value, preserving isHomed semantics.
 -    state.x = x ?? state.x;
 -    state.y = y ?? state.y;
 -    state.z = z ?? state.z;

--- a/evals/cases/370-nullish-z0/pre.patch
+++ b/evals/cases/370-nullish-z0/pre.patch
@@ -1,0 +1,14 @@
+diff --git a/src/interpreter/commands/arc-move.ts b/src/interpreter/commands/arc-move.ts
+--- a/src/interpreter/commands/arc-move.ts
++++ b/src/interpreter/commands/arc-move.ts
+@@ -57,10 +57,6 @@
+       state.units
+     );
+ 
+-    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
+-    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
+-    // rejecting NaN here by accident, which `??` does not do. An axis the command
+-    // omits keeps its previous (possibly unknown) value, preserving isHomed semantics.
+     state.x = x ?? state.x;
+     state.y = y ?? state.y;
+     state.z = z ?? state.z;

--- a/evals/cases/392-truthy-e/diff.patch
+++ b/evals/cases/392-truthy-e/diff.patch
@@ -1,13 +1,10 @@
 diff --git a/src/interpreter/commands/arc-move.ts b/src/interpreter/commands/arc-move.ts
 --- a/src/interpreter/commands/arc-move.ts
 +++ b/src/interpreter/commands/arc-move.ts
-@@ -29,10 +29,7 @@
+@@ -29,7 +29,7 @@
  
      const cw = command.gcode === 'g2';
      let currentPath = job.inprogressPath;
--    // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
--    // material laid down. The looser `e ?` used to misclassify a retracting arc as
--    // Extrusion, so it rendered as deposited filament and stretched the bounding box.
 -    const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
 +    const pathType = e ? PathType.Extrusion : PathType.Travel;
  

--- a/evals/cases/392-truthy-e/pre.patch
+++ b/evals/cases/392-truthy-e/pre.patch
@@ -1,0 +1,13 @@
+diff --git a/src/interpreter/commands/arc-move.ts b/src/interpreter/commands/arc-move.ts
+--- a/src/interpreter/commands/arc-move.ts
++++ b/src/interpreter/commands/arc-move.ts
+@@ -29,9 +29,6 @@
+ 
+     const cw = command.gcode === 'g2';
+     let currentPath = job.inprogressPath;
+-    // `e > 0`, matching g0/g1: a negative E is a retraction, i.e. a travel move with no
+-    // material laid down. The looser `e ?` used to misclassify a retracting arc as
+-    // Extrusion, so it rendered as deposited filament and stretched the bounding box.
+     const pathType = e > 0 ? PathType.Extrusion : PathType.Travel;
+ 
+     if (currentPath === undefined || currentPath.travelType !== pathType) {

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -5,12 +5,11 @@
  *   npm run evals -- --baseline                    all cases, no skill
  *   npm run evals -- --case 392-truthy-e --runs 5
  *
- * Every run is a fresh `claude -p` process, so no case can leak into another.
- * The patch is staged into a temp directory; case.json stays behind in the repo
- * so the expected answers are never within the agent's reach.
+ * Every run is a fresh `claude -p` in its own sandbox, so no case can leak into
+ * another and no run can read the answer. See `sandbox()` for what that means.
  */
-import { spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -18,13 +17,17 @@ import { parseArgs } from 'node:util';
 import { loadCases } from './types.ts';
 
 const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
 
 const { values } = parseArgs({
   options: {
     baseline: { type: 'boolean', default: false },
     case: { type: 'string' },
     runs: { type: 'string' },
-    model: { type: 'string', default: process.env.EVAL_MODEL ?? 'opus' }
+    model: { type: 'string', default: process.env.EVAL_MODEL ?? 'opus' },
+    // Build each sandbox, print where it is, and stop before spawning the agent.
+    // Lets you inspect what a run can actually see without spending tokens.
+    'dry-run': { type: 'boolean', default: false }
   }
 });
 
@@ -36,8 +39,52 @@ const stamp = new Date().toISOString().slice(0, 10);
 const outDir = join(here, 'results', `${stamp}-${values.model}-${mode}`);
 mkdirSync(outDir, { recursive: true });
 
-function promptFor(patch: string, skill: string): string {
-  const target = `the proposed change in ${patch}`;
+/**
+ * Builds the checkout the agent reviews against, and returns its path.
+ *
+ * The agent needs to read surrounding source to review a diff, so it gets a repo —
+ * but not *this* repo. Reviewing against the live worktree let a run open the file
+ * the fixture had un-fixed and read the corrected line straight off disk, which is a
+ * better answer key than case.json ever was. So the sandbox is:
+ *
+ * - a `git archive` export of HEAD, i.e. tracked files only and **no `.git`**, so
+ *   `git log`/`git show` cannot surface the fix either;
+ * - with `evals/` removed, since that is where case.json states the expected finding;
+ * - with `pre.patch` applied, stripping the comment that explains the invariant the
+ *   fixture is about to break. Fixtures are inverted fixes, so that comment was
+ *   written by the very fix being undone — leaving it in hands the run a hint the
+ *   original reviewer never had. Deleting it inside `diff.patch` instead is worse:
+ *   a removed comment narrating the bug is a louder signpost than the bug itself.
+ *
+ * `.claude/skills` is a tracked symlink to `.agents/`, so the skill under test comes
+ * along with the export and resolves normally. node_modules does not, which is fine:
+ * these runs review code, they do not build or test it.
+ */
+function sandbox(caseId: string): string {
+  const work = mkdtempSync(join(tmpdir(), `eval-${caseId}-`));
+  const tar = join(work, 'repo.tar');
+  const root = join(work, 'repo');
+  mkdirSync(root);
+
+  execFileSync('git', ['archive', '--format=tar', '-o', tar, 'HEAD'], { cwd: repoRoot });
+  execFileSync('tar', ['-x', '-f', tar, '-C', root]);
+  rmSync(tar);
+  rmSync(join(root, 'evals'), { recursive: true, force: true });
+
+  const pre = join(here, 'cases', caseId, 'pre.patch');
+  if (existsSync(pre)) {
+    execFileSync('patch', ['-p1', '-s', '--forward', '-d', root], { input: readFileSync(pre) });
+  }
+  copyPatch(caseId, root);
+  return root;
+}
+
+function copyPatch(caseId: string, root: string): void {
+  writeFileSync(join(root, 'proposed.patch'), readFileSync(join(here, 'cases', caseId, 'diff.patch')));
+}
+
+function promptFor(skill: string): string {
+  const target = 'the proposed change in ./proposed.patch';
   const shared =
     `It is a proposed change to this repository; read the surrounding source in the repo for context. ` +
     `Output the review only — do not modify any file and do not post anything anywhere.`;
@@ -50,9 +97,11 @@ let failures = 0;
 for (const c of cases) {
   const runs = values.runs ? Number(values.runs) : c.runs;
   for (let i = 1; i <= runs; i++) {
-    const work = mkdtempSync(join(tmpdir(), `eval-${c.id}-`));
-    const patch = join(work, 'proposed.patch');
-    copyFileSync(join(here, 'cases', c.id, 'diff.patch'), patch);
+    const root = sandbox(c.id);
+    if (values['dry-run']) {
+      console.log(`dry-run ${c.id}: ${root}`);
+      break;
+    }
 
     process.stdout.write(`run ${c.id} [${mode} ${i}/${runs}] `);
     const started = Date.now();
@@ -60,7 +109,7 @@ for (const c of cases) {
       'claude',
       [
         '-p',
-        promptFor(patch, c.skill),
+        promptFor(c.skill),
         '--model',
         String(values.model),
         '--allowedTools',
@@ -70,9 +119,9 @@ for (const c of cases) {
         'Bash',
         'Skill'
       ],
-      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+      { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
     );
-    rmSync(work, { recursive: true, force: true });
+    rmSync(dirname(root), { recursive: true, force: true });
 
     const secs = Math.round((Date.now() - started) / 1000);
     if (res.status !== 0 || !res.stdout?.trim()) {

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -45,13 +45,43 @@ function validate(raw: unknown, id: string): EvalCase {
   return c as EvalCase;
 }
 
+/**
+ * Rejects a defect fixture whose reviewed diff deletes a code comment.
+ *
+ * Fixtures are inverted fixes, so the comment explaining an invariant was written by
+ * the fix the fixture undoes. A `-` line narrating the bug sitting beside the `+` line
+ * introducing it hands the run the answer, and every earlier score was collected that
+ * way. Strip such comments in `pre.patch`, which is applied to the sandbox before the
+ * agent looks, so they appear in neither the diff nor the surrounding source.
+ *
+ * Cases that expect silence are exempt: their whole point is an innocuous edit, and
+ * `clean-docs-only` legitimately rewrites a prose line containing a `//` in a URL.
+ */
+function checkNoAnswerLeak(c: EvalCase, dir: string): void {
+  if (expectsSilence(c)) return;
+  const patch = join(dir, 'diff.patch');
+  if (!existsSync(patch)) throw new Error(`cases/${c.id} has no diff.patch`);
+  const leaked = readFileSync(patch, 'utf8')
+    .split('\n')
+    .filter((l) => /^-\s*(\/\/|\/\*|\*)/.test(l));
+  if (leaked.length) {
+    throw new Error(
+      `cases/${c.id}/diff.patch deletes ${leaked.length} comment line(s), which tells the ` +
+        `review what the defect is. Move them to cases/${c.id}/pre.patch:\n  ${leaked.join('\n  ')}`
+    );
+  }
+}
+
 export function loadCases(casesDir: string, only?: string): EvalCase[] {
   return readdirSync(casesDir, { withFileTypes: true })
     .filter((e) => e.isDirectory() && (!only || e.name === only))
     .map((e) => {
-      const file = join(casesDir, e.name, 'case.json');
+      const dir = join(casesDir, e.name);
+      const file = join(dir, 'case.json');
       if (!existsSync(file)) throw new Error(`cases/${e.name} has no case.json`);
-      return validate(JSON.parse(readFileSync(file, 'utf8')), e.name);
+      const c = validate(JSON.parse(readFileSync(file, 'utf8')), e.name);
+      checkNoAnswerLeak(c, dir);
+      return c;
     })
     .sort((a, b) => a.id.localeCompare(b.id));
 }


### PR DESCRIPTION
## Problem

`evals/run.ts` spawned `claude -p` with **no `cwd`**, so it inherited the repo root, and the prompt tells the agent to "read the surrounding source in the repo for context" with `Read`/`Grep`/`Bash` allowed.

Every fixture is a bug injected into *current* code. So a run reviewing `392-truthy-e` could open `src/interpreter/commands/arc-move.ts` and read the corrected `e > 0` line, comment and all. The README's isolation claim — "`case.json` stays behind in the repo so the answers are never in reach" — covered the wrong file: the fixed source is a better answer key than `case.json`.

A second, smaller leak sat on top: 3 of 4 defect patches deleted the comment explaining the invariant, so the reviewed diff contained a `-` line narrating the very bug the `+` line introduced.

## Fix

Each run now gets a real sandbox: a `git archive` export of `HEAD` — tracked files only and **no `.git`**, so the fix history is unreachable too — with `evals/` deleted and `pre.patch` applied. `.claude/skills` is a tracked symlink into `.agents/`, so the skill under test comes along and resolves normally.

Fixtures are split in two. `pre.patch` strips the explanatory comment and is applied *before* the agent looks; `diff.patch` carries the code change alone. Note that simply *keeping* the comment would also be a hint — a comment reading `e > 0` above code reading `e ?` is glaring — so the two-step is what actually makes it neutral.

`loadCases` now refuses to load a defect case whose `diff.patch` removes a comment line, pointing you at `pre.patch`. Cases that expect silence are exempt, since `clean-docs-only` legitimately rewrites prose containing a `//` in a URL.

## Verification

`npm run evals -- --dry-run` builds each sandbox, prints its path and stops before spending tokens. Confirmed for every case:

- `evals/` (the answer key) removed
- no `.git`
- guarding comment stripped, guarded code still intact for the diff to change
- skill resolves through the symlink
- `pre.patch` + `diff.patch` apply cleanly in order

Also confirmed the new loader guard fires by reintroducing a comment deletion, then reverting.

## Consequence

The recorded **skill 5/5, baseline 4/4** result was collected through the leak, and near-perfect scores are exactly what a leak produces. Those numbers are withdrawn in the README; the suite needs re-baselining before any skill-vs-baseline claim is made from it.

Assisted by Claude Code - Opus 5