### PR TITLE
Let a Z-less layer entry stop swallowing every path after it

### DIFF
--- a/src/__tests__/indexers.ts
+++ b/src/__tests__/indexers.ts
@@ -349,6 +349,30 @@ test('LayersMetadataIndexer handles missing Z values in metadata', () => {
   expect(layers[0].height).toBe(0.3);
 });
 
+test('LayersMetadataIndexer advances past a layer whose metadata has no Z', () => {
+  const layers: Layer[] = [];
+  const metadata: LayerMetadata[] = [
+    { layerIndex: 0, height: 0.2, lineIndex: 0 }, // Missing Z
+    { layerIndex: 1, z: 0.4, height: 0.2, lineIndex: 4 }
+  ];
+
+  const indexer = new LayersMetadataIndexer(layers, metadata);
+
+  // The Z-less entry takes its Z from the first path, so the second path at
+  // that same Z joins it and only the third, higher, path moves on. Matching
+  // on layer order alone kept returning index 0 here and swallowed all three.
+  const first = createPath(0.2);
+  const second = createPath(0.2);
+  const third = createPath(0.4);
+  [first, second, third].forEach((path) => indexer.sortIn(path));
+
+  expect(layers).toHaveLength(2);
+  expect(layers[0].z).toBe(0.2);
+  expect(layers[0].paths).toEqual([first, second]);
+  expect(layers[1].z).toBe(0.4);
+  expect(layers[1].paths).toEqual([third]);
+});
+
 test('LayersMetadataIndexer handles missing height values in metadata', () => {
   const layers: Layer[] = [];
   const metadata: LayerMetadata[] = [

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -307,8 +307,13 @@ export class LayersMetadataIndexer extends Indexer {
    */
   private findLayerIndexForZ(pathZ: number): number {
     for (let i = this.currentMetadataLayerIndex; i < this.layerMetadata.length; i++) {
-      const z = this.layerMetadata[i].z;
-      // Metadata without a Z falls back to plain layer order.
+      // Metadata without a Z is pinned by the first path filed into it, which
+      // `ensureLayersUpTo` records as the layer's own Z. Reading that back is
+      // what lets the search move on: matching purely on layer order would
+      // return this same index for every later path, at any Z, because the
+      // scan restarts from the pointer this entry is holding.
+      const z = this.layerMetadata[i].z ?? this.indexes[i]?.z;
+      // Nothing has landed here yet, so this path is what defines the layer.
       if (z === undefined) return i;
       if (pathZ <= z + LayersMetadataIndexer.Z_MATCH_TOLERANCE) return i;
     }


### PR DESCRIPTION
Independent of #472 and #474 — `src/indexers.ts` is disjoint from both, and this bug stands on its own: any file with a `;LAYER_CHANGE` lacking a `;Z:` collapses into one layer, streamed or not. Mergeable in any order.

## The bug

`findLayerIndexForZ` returns immediately on a metadata entry with no Z, with the stated intent of falling back to plain layer order:

```ts
for (let i = this.currentMetadataLayerIndex; i < this.layerMetadata.length; i++) {
  const z = this.layerMetadata[i].z;
  // Metadata without a Z falls back to plain layer order.
  if (z === undefined) return i;
```

But the scan restarts from `currentMetadataLayerIndex`, and `sortWithMetadata` sets that pointer to the index just returned. So once a Z-less entry is reached it is returned for **every** later path, at any Z. The pointer can never advance, `ensureLayersUpTo` never builds the later layers, and the whole print collapses into a single layer.

This is not streaming-specific. Any file containing a `;LAYER_CHANGE` without a `;Z:` hits it, read in one piece or not. It is also the second half of #445 — the first half (#472) stopped producing spurious Z-less entries, but the absorbing state is a defect on its own merits and outlives that fix.

## The fix

Read the Z back from the layer the entry produced:

```ts
const z = this.layerMetadata[i].z ?? this.indexes[i]?.z;
```

`ensureLayersUpTo` already records the first path's Z as the created layer's own (`metadata.z ?? fallbackZ`), so a Z-less entry is pinned by whatever lands in it first, and paths above that Z move on normally. Still `undefined` means nothing has landed there yet, which is exactly when the path in hand should define the layer — so that branch keeps its old behaviour.

## Why it was not caught

`src/__tests__/indexers.ts` does cover Z-less metadata, but with a single metadata entry and a single path. With one entry the pointer has nowhere to advance to, so the absorbing property cannot show. The new test uses two entries and three paths across two Z levels; it fails on `develop` with `expected [ Layer{ z: 0.2 } ] to have a length of 2 but got 1`.

957 tests pass, coverage stays at 100% with no new pins, typecheck and lint clean.

Assisted by Claude Code - Opus 5

## Before / after

`demo/gcodes/calicat.gcode` (PrusaSlicer, 620 KB) streamed in 1 KB chunks. Same file, same camera, same viewer, view limited to the bottom third of the detected layers.

**Before** — one layer entry ends up without a Z. Because the scan restarts at `currentMetadataLayerIndex`, that entry is returned for every later path at any Z: 29 layers instead of 174, with 2900 paths absorbed into one.

![before](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-473-assets/chunk-split-before.png)

**After** — the pointer advances past it, giving 174 layers and 122 paths in the busiest one.

![after](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-473-assets/chunk-split-after.png)

Note on attribution: in this particular capture the Z-less entry is produced by the chunk-boundary bug that #472 fixes, so either PR alone restores this file — they are two links in one failure chain. This PR is still worth having on its own: it makes the indexer survive a Z-less entry from **any** cause, including a slicer that legitimately emits `;LAYER_CHANGE` with no `;Z:`, which no amount of parser correctness prevents.
