### PR TITLE
Stop counting a line for a chunk that completed none

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -561,12 +561,12 @@ describe('GCodePreview', () => {
 
       await preview.readStream(stream);
 
-      // chunk 1 completes 'G0 X0 Y0', chunk 2 has no newline so it completes
-      // nothing (''), and the leftover tail is flushed after the stream ends
-      expect(preview.parser.parseGCode).toHaveBeenCalledTimes(3);
+      // chunk 2 has no newline, so it completes nothing and is skipped rather
+      // than parsed as an empty line; the tail is flushed after the stream ends
+      expect(preview.parser.parseGCode).toHaveBeenCalledTimes(2);
       expect(preview.parser.parseGCode).toHaveBeenNthCalledWith(1, 'G0 X0 Y0');
       expect(preview.parser.parseGCode).toHaveBeenLastCalledWith('G1 X10 Y10');
-      expect(mockInterpreter.execute).toHaveBeenCalledTimes(3);
+      expect(mockInterpreter.execute).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -311,14 +311,13 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
     await ingest(preview, gcode);
 
     expect(preview.parser.metadata.slicerName).toEqual('PrusaSlicer');
-    // lineIndex is left out: readStream parses an empty string for every chunk
-    // that completes no line, and each of those counts a line the file does not
-    // have. That is a separate defect, fixed on its own branch -- pinning the
-    // inflated numbers here would freeze them.
+    // lineIndex points into the original file, so it only agrees across modes
+    // while every mode counts the same lines.
     expect(preview.parser.metadata.layerMetadata).toEqual([
-      expect.objectContaining({ layerIndex: 0, z: 0.2, height: 0.2 }),
-      expect.objectContaining({ layerIndex: 1, z: 0.4, height: 0.2 })
+      { layerIndex: 0, z: 0.2, height: 0.2, lineIndex: 3 },
+      { layerIndex: 1, z: 0.4, height: 0.2, lineIndex: 8 }
     ]);
+    expect(preview.parser.lineCount).toEqual(13);
     expect(preview.countLayers).toEqual(2);
     expect(preview.job.layers[0].z).toEqual(0.2);
     expect(preview.job.layers[1].z).toEqual(0.4);

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -249,6 +249,11 @@ export class GCodePreview {
       const split = splitChunk(tail, result.value);
       tail = split.tail;
 
+      // Parsing '' would still count a line -- ''.split('\n') is [''] -- and
+      // shift every lineIndex after it. Chunks complete nothing often: bytes
+      // arrive without a newline, or splitChunk holds a comment run back.
+      if (split.complete === '') continue;
+
       const { commands, metadata } = this.parser.parseGCode(split.complete);
 
       // forward metadata before executing: the layer indexer locks its


### PR DESCRIPTION
Stacked on #472. Independent of #476.

## The bug

`splitChunk` returns an empty `complete` for a chunk that finishes no line — one holding no newline, or (since #472) one holding nothing but comments, which it carries on to the next chunk. `readStream` parsed that empty string anyway, and `''.split('\n')` is `['']`, so each of those arrivals counted a line the file does not have and shifted every `lineIndex` reported after it.

That is the common case, not a rare one. A stream delivers a chunk whenever bytes arrive, not whenever a line ends, so with small chunks most arrivals complete nothing. At the harness's one-byte chunk size the parser was called once per byte, almost always with nothing to read, and a layer marker 50 characters into the file reported `lineIndex: 50`.

## The fix

```ts
if (split.complete === '') {
  continue;
}
```

Fixes the accounting, and drops a wasted parse and interpreter dispatch per byte.

The `ingestion-equivalence` fixture added in #472 had to leave `lineIndex` unasserted because of this. It now pins the exact values and `parser.lineCount` across all four ingestion modes.

## Test change worth flagging

`should flush and parse the tail when the last chunk has no trailing newline` asserted `parseGCode` was called **3** times, the middle one being the parse of `''`. Its own comment spelled that out. It was pinning the behaviour this removes, so it now expects 2.

949 tests pass, coverage stays at 100% with no new pins, typecheck and lint clean.

Assisted by Claude Code - Opus 5
