### PR TITLE
Read an omitted arc word as its default instead of unknown

### DIFF
--- a/src/__tests__/arc-tessellator.ts
+++ b/src/__tests__/arc-tessellator.ts
@@ -139,6 +139,30 @@ describe('ArcTessellator', () => {
     expect(points.length).toBeGreaterThanOrEqual(16);
   });
 
+  test('treats an omitted J as a zero offset', () => {
+    const start = { x: 0, y: 0, z: 0.2 };
+    const explicit = tessellate(start, { cw: true, x: 10, y: 0, i: 5, j: 0 });
+    const omitted = tessellate(start, { cw: true, x: 10, y: 0, i: 5 });
+
+    expect(omitted).toEqual(explicit);
+    expect(omitted.length).toBeGreaterThan(1);
+  });
+
+  test('treats an omitted axis word as unchanged rather than unknown', () => {
+    const start = { x: 0, y: 0, z: 0.2 };
+    const explicit = tessellate(start, { cw: true, x: 10, y: 0, i: 5, j: 0 });
+    const omitted = tessellate(start, { cw: true, x: 10, i: 5, j: 0 });
+
+    expect(omitted).toEqual(explicit);
+    expect(omitted.length).toBeGreaterThan(1);
+  });
+
+  test('emits only the endpoint for an arc with no offsets at all', () => {
+    const points = tessellate({ x: 0, y: 0, z: 0 }, { cw: true, x: 10, y: 0 });
+
+    expect(points).toEqual([{ x: 10, y: 0, z: 0 }]);
+  });
+
   test('emits more segments for the same arc in inches', () => {
     const start = { x: 1, y: 0, z: 0 };
     const move = { cw: false, x: 0, y: 1, i: -1, j: 0 };

--- a/src/arc-tessellator.ts
+++ b/src/arc-tessellator.ts
@@ -79,8 +79,18 @@ export class ArcTessellator {
    * least the endpoint, even for degenerate arcs.
    */
   tessellate(start: ArcPoint, move: ArcMove, emit: EmitPoint, units: Units = 'mm'): ArcPoint {
-    const { cw, x, y, z } = move;
+    const { cw } = move;
     let { i, j, r } = move;
+    // Omitted words are defaults, not "unset": G-code reads a missing I/J as a zero
+    // offset and a missing axis word as unchanged. Left undefined they poisoned
+    // centerX/centerY and finalTheta with NaN, so totalSegments came out NaN, the
+    // loop below emitted no intermediate points, and `G2 X10 I5 E1` rendered as a
+    // straight line from the start point to the endpoint instead of an arc.
+    const x = move.x ?? start.x;
+    const y = move.y ?? start.y;
+    const z = move.z ?? start.z;
+    i ??= 0;
+    j ??= 0;
     // Set when the arc cannot be described at all, so only the endpoint is emitted.
     let arcIsDegenerate = false;
 
@@ -155,11 +165,9 @@ export class ArcTessellator {
     // Z1 -> Z3 walked its intermediate points down to Z-0.97 and only landed on Z3 at
     // the endpoint, leaving a visible spike in the rendered path.
     //
-    // `??` not `||`: Z0 is a legitimate target, and `|| start.z` turned a descent to
-    // Z0 into a flat arc at the old height. This matches the endpoint below, and is
-    // only safe because the parser now drops non-finite params -- `||` was rejecting
-    // NaN here by accident, and `??` does not.
-    const zDist = (z ?? start.z) - start.z;
+    // Z defaults to start.z above rather than `|| start.z`: Z0 is a legitimate
+    // target, and `||` turned a descent to Z0 into a flat arc at the old height.
+    const zDist = z - start.z;
     const zStep = zDist / totalSegments;
 
     let pz = start.z;
@@ -171,7 +179,10 @@ export class ArcTessellator {
     // fails the condition), but Infinity ran until the vertex array hit its length
     // limit and threw, aborting the whole job. Emit no intermediate points in either
     // case and fall through to the endpoint below.
-    if (!arcIsDegenerate && Number.isFinite(totalSegments)) {
+    // A zero radius is degenerate too, now that a missing I/J defaults to 0: without
+    // this an arc carrying no offsets at all would stack every intermediate point on
+    // the start position before jumping to the endpoint.
+    if (!arcIsDegenerate && arcRadius > 0 && Number.isFinite(totalSegments)) {
       for (let moveIdx = 0; moveIdx < totalSegments - 1; moveIdx++) {
         currentAngle += arcAngleIncrement;
         pz += zStep;
@@ -179,10 +190,9 @@ export class ArcTessellator {
       }
     }
 
-    // `??` not `||`: an arc ending on X0, Y0 or Z0 used to silently keep the previous
-    // coordinate. Safe now that the parser drops non-finite params -- `||` was also
-    // rejecting NaN here by accident, which `??` does not do.
-    const endPoint = { x: x ?? start.x, y: y ?? start.y, z: z ?? start.z };
+    // An arc ending on X0, Y0 or Z0 used to silently keep the previous coordinate,
+    // back when the defaults above were applied with `||`.
+    const endPoint = { x, y, z };
     emit(endPoint.x, endPoint.y, endPoint.z);
 
     return endPoint;


### PR DESCRIPTION
## Problem

Fixes #447. Arcs that leave out a word render as a straight line. `G2 X10 Y0 I5 J0 E1` draws a semicircle; `G2 X10 Y0 I5 E1` (no `J`) and `G2 X10 I5 J0 E1` (no `Y`, already there) describe the same arc but come out as a single chord from start to end. Slicers omit zero offsets and unchanged axes routinely, so this hits real files.

## Cause

`tessellate()` read `i`, `j`, `x` and `y` straight off the command, so an omitted word stayed `undefined` rather than taking the default G-code assigns it. That reached the geometry as `start.y + undefined` (the center) or `atan2(undefined - ...)` (the final angle), and the resulting `NaN` carried through `totalArc` into `totalSegments`. `moveIdx < NaN - 1` is false on the very first iteration, so the tessellation loop emitted nothing — leaving only the endpoint emitted below it. No throw, no warning, just a chord.

## Fix

Resolve the defaults once at the top of `tessellate()`: a missing `I`/`J` is a zero offset, a missing axis word is that axis unchanged. Doing it there rather than at each use site also repairs two spots that were silently reading `undefined` — `wholeCircle` compared `start.y` against `undefined` and so never fired for an arc that omits its axis words, and R mode derived `deltaX`/`deltaY` from them.

One new case comes with it: an arc carrying *no* offsets at all now has a real radius of `0` instead of `NaN`, which would stack every intermediate point on the start position. The loop is guarded on a positive radius so those still emit the endpoint alone, exactly as before.

## Behavior changes

Arcs with omitted `I`/`J`/axis words now render curved. Files that spelled every word out are byte-identical — the defaults resolve to what those files already passed.

## Public API changes

None.

## Before / After

Three identical rows of semicircles, written three ways: fully spelled out (top), with `J0` omitted (middle), with the unchanged `Y` omitted (bottom).

| Before | After |
| ------ | ----- |
| ![Three rows of arcs; only the fully-spelled-out top row is curved, the two rows with omitted words are flat straight lines](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-479-assets/before.png) | ![The same three rows, all curved identically](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-479-assets/after.png) |

## Checks

- [x] `npm run check` passes (test + typeCheck + lint)
- [x] `npm run test:coverage` — `src/` still at 100%
- [x] Labelled `bug` + the relevant area label

Assisted by Claude Code - Opus 5
