### PR TITLE
Break the in-progress path when the tool changes

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -191,6 +191,36 @@ describe('extrusion dimension metadata (;WIDTH: / ;HEIGHT:)', () => {
   });
 });
 
+describe('tool changes (T0-T7)', () => {
+  const run = (lines: string[]) => new Interpreter().execute(new Parser().parseGCode(lines).commands);
+  const summary = (job: Job) => job.extrusions.map((path) => ({ tool: path.tool, vertices: path.vertices }));
+
+  test('a tool change between two extrusions breaks the path and assigns the new tool', () => {
+    const job = run(['G0 X0 Y0 Z0.2', 'G1 X10 E1', 'T1', 'G1 X20 E2']);
+
+    expect(job.state.tool).toEqual(1);
+    expect(summary(job)).toEqual([
+      { tool: 0, vertices: [0, 0, 0.2, 10, 0, 0.2] },
+      { tool: 1, vertices: [10, 0, 0.2, 20, 0, 0.2] }
+    ]);
+  });
+
+  test('a tool change followed by a travel assigns the next extrusion to the new tool', () => {
+    const job = run(['G0 X0 Y0 Z0.2', 'G1 X10 E1', 'T1', 'G0 X10 Y0 Z0.2', 'G1 X20 E2']);
+
+    expect(summary(job)).toEqual([
+      { tool: 0, vertices: [0, 0, 0.2, 10, 0, 0.2] },
+      { tool: 1, vertices: [10, 0, 0.2, 20, 0, 0.2] }
+    ]);
+  });
+
+  test('re-selecting the current tool does not break the path', () => {
+    const job = run(['G0 X0 Y0 Z0.2', 'G1 X10 E1', 'T0', 'G1 X20 E2']);
+
+    expect(summary(job)).toEqual([{ tool: 0, vertices: [0, 0, 0.2, 10, 0, 0.2, 20, 0, 0.2] }]);
+  });
+});
+
 describe('malformed coordinates through the whole pipeline', () => {
   const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
   const allVertices = (job: Job) => job.paths.flatMap((path) => path.vertices);

--- a/src/__tests__/job.ts
+++ b/src/__tests__/job.ts
@@ -742,6 +742,19 @@ describe('.continuePath', () => {
     expect(next).not.toBe(path);
     expect(next.lineHeight).toEqual(0.3);
   });
+
+  test('breaks when the state tool changed', () => {
+    const job = new Job();
+    const path = job.breakPath(PathType.Extrusion);
+    path.addPoint(1, 1, 0);
+    job.state.tool = 1;
+
+    const next = job.continuePath(PathType.Extrusion);
+
+    expect(next).not.toBe(path);
+    expect(next.tool).toEqual(1);
+    expect(job.paths).toEqual([path]);
+  });
 });
 
 describe('.resumeLastPath', () => {

--- a/src/job.ts
+++ b/src/job.ts
@@ -221,13 +221,14 @@ export class Job {
    * @param pathType - Type of the move about to be added
    * @returns The in-progress path when it can continue, otherwise a fresh one
    * @remarks
-   * The in-progress path continues only while its type and its extrusion
-   * dimensions still match the state; dimension metadata that changed the
-   * state since the path was started (see `beginCommand`) breaks it here, so
-   * every path carries a single width and height. Deciding this lazily at
-   * move time (and not when the metadata is applied) keeps streamed and
-   * one-shot parses identical: the interpreter resumes the last finished path
-   * at every chunk boundary, which would undo an eager break.
+   * The in-progress path continues only while its type, its extrusion
+   * dimensions and its tool still match the state; dimension metadata (see
+   * `beginCommand`) or a tool change that altered the state since the path
+   * was started breaks it here, so every path carries a single width, height
+   * and tool. Deciding this lazily at move time (and not when the metadata or
+   * tool is applied) keeps streamed and one-shot parses identical: the
+   * interpreter resumes the last finished path at every chunk boundary, which
+   * would undo an eager break.
    */
   continuePath(pathType: PathType): Path {
     const currentPath = this.inprogressPath;
@@ -235,7 +236,8 @@ export class Job {
       currentPath !== undefined &&
       currentPath.travelType === pathType &&
       currentPath.extrusionWidth === this.state.extrusionWidth &&
-      currentPath.lineHeight === this.state.lineHeight
+      currentPath.lineHeight === this.state.lineHeight &&
+      currentPath.tool === this.state.tool
     ) {
       return currentPath;
     }


### PR DESCRIPTION
## Problem

Extrude with T0, select T1, then extrude again with no travel in between: both extrusions stay in one path owned by tool 0, so the second one renders in tool 0's colour and shows up under tool 0 in `toolPaths`. With a travel in between it worked, which is why most sliced files hid it.

Fixes #449

## Cause

The `T` handler only updates `job.state.tool`. Nothing broke the in-progress path, so the next extrusion kept extending the path started under the previous tool. `continuePath` already breaks lazily when the state's width or height stops matching the path, but it never compared the tool.

## Fix

Add the tool to the lazy match in `continuePath`, next to width and height. A tool change now ends the running path and the next move starts a fresh one owned by the new tool, seeded from the same point.

Doing it lazily at move time instead of eagerly in the `T` handler keeps streamed and one-shot parses identical: the interpreter resumes the last finished path at every chunk boundary, which would undo an eager break.

## Behavior changes

Files with a tool change between consecutive extrusions now produce one extra path per change, and every path carries a single tool. Files that always travel between tool changes are unaffected.

## Before / After

Six layers of one 60 mm line, tool change mid-line with no travel: `G1 X20 E1` on T0, `T1`, `G1 X40 E2`, `T2`, `G1 X60 E3`. Tool colours red / green / blue, same camera for both. Images live on the throwaway `pr-480-assets` branch.

| Before | After |
| ------ | ----- |
| ![Before: the whole line renders in tool 0's red, the T1 and T2 commands have no visible effect](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-480-assets/before.png) | ![After: the line splits at X20 and X40 into red, green and blue segments on every layer](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-480-assets/after.png) |

## Checks

- [x] `npm run check` passes (test + typeCheck + lint)
- [x] `npm run test:coverage` — `src/` still at 100%
- [x] Labelled `bug` + the relevant area label

Assisted by Claude Code - Fable 5.1

