### PR TITLE
Include the starting point of an extrusion path in the bounding box

### DIFF
--- a/src/__tests__/interpreter.ts
+++ b/src/__tests__/interpreter.ts
@@ -215,7 +215,7 @@ describe('malformed coordinates through the whole pipeline', () => {
   });
 
   test('a malformed coordinate does not poison the bounding box', () => {
-    const job = run(['M83', 'G1 X10 Y10 Z1 E1', 'G1 Xabc Y20 E1', 'G1 X30 Y30 E1'].join('\n'));
+    const job = run(['M83', 'G0 X10 Y10 Z1', 'G1 Xabc Y20 E1', 'G1 X30 Y30 E1'].join('\n'));
 
     expect(job.boundingBox.isValid).toBe(true);
     expect(job.boundingBox.corners).toEqual({
@@ -226,7 +226,7 @@ describe('malformed coordinates through the whole pipeline', () => {
 
   test('an overflowing coordinate does not stretch the bounding box to Infinity', () => {
     const huge = '1' + '0'.repeat(400);
-    const job = run(['M83', 'G1 X10 Y10 Z1 E1', `G1 X${huge} E1`, 'G1 X30 Y30 E1'].join('\n'));
+    const job = run(['M83', 'G0 X10 Y10 Z1', `G1 X${huge} E1`, 'G1 X30 Y30 E1'].join('\n'));
 
     expect(job.boundingBox.size).toEqual(expect.objectContaining({ x: 20, y: 20, z: 0 }));
   });
@@ -353,5 +353,29 @@ describe('malformed coordinates through the whole pipeline', () => {
     expect(points.every((value) => Number.isFinite(value))).toBe(true);
     expect(job.boundingBox.isValid).toBe(true);
     expect(job.boundingBox.corners?.min.x).not.toBeNaN();
+  });
+});
+
+describe('extrusion bounding box', () => {
+  const run = (gcode: string) => new Interpreter().execute(new Parser().parseGCode(gcode).commands);
+
+  test('includes the starting point of an extrusion entered by a travel move', () => {
+    // A path's seed point is never a move destination, so it used to be missing
+    // from the bounds: a travel to X0 followed by a single extrusion to X10
+    // reported a zero-width box pinned at X10 (#451).
+    const job = run(['M83', 'G0 X0 Y0 Z0.2', 'G1 X10 E1'].join('\n'));
+
+    expect(job.boundingBox.corners?.min.x).toEqual(0);
+    expect(job.boundingBox.corners?.max.x).toEqual(10);
+    expect(job.boundingBox.size?.x).toEqual(10);
+    expect(job.boundingBox.center?.x).toEqual(5);
+  });
+
+  test('a travel move does not stretch the bounds', () => {
+    // Only the extrusion's own start counts; the travel lead-up beyond it stays out.
+    const job = run(['M83', 'G0 X-50 Y0 Z0.2', 'G0 X0', 'G1 X10 E1'].join('\n'));
+
+    expect(job.boundingBox.corners?.min.x).toEqual(0);
+    expect(job.boundingBox.corners?.max.x).toEqual(10);
   });
 });

--- a/src/job.ts
+++ b/src/job.ts
@@ -212,6 +212,12 @@ export class Job {
     const currentPath = new Path(newType, this.state.extrusionWidth, this.state.lineHeight, this.state.tool);
     const pos = this.resolvePosition();
     currentPath.addPoint(pos.x, pos.y, pos.z);
+    // The seed point is the extrusion's starting position, which the move
+    // handlers never see as a destination; without it a path entered by a
+    // travel move would be missing its first end from the bounds (see #451).
+    if (newType === PathType.Extrusion) {
+      this.boundingBox.update(pos.x, pos.y, pos.z);
+    }
     this.inprogressPath = currentPath;
     return currentPath;
   }


### PR DESCRIPTION
Fixes #451.

The bounding box only ever received move *destinations* (`linear-move.ts`, `arc-move.ts`), so the seed point of a path entered by a travel move never reached it: a travel to X0 followed by a single extrusion to X10 reported a zero-width box pinned at X10.

The fix feeds the seed point to the bounding box in `Job.breakPath` — the single choke point where every extrusion path gets its start vertex — covering linear moves, arcs, and streamed chunk boundaries in one place. Since `breakPath` only runs for an actual move of the new type, it cannot inflate the box with a phantom point.

Two existing malformed-coordinate fixtures extruded their first move straight from the assumed origin, so the now-included start point legitimately grew their bounds; their lead-in becomes a travel so they keep testing NaN/Infinity handling from a known starting point. The regression tests join the existing interpreter suite, and the reproduction test from #451 (branch `codex/p2-extrusion-bounds-repro`) passes against this fix.

## Before / After

An open "L": travel to X20 Y20 Z1, then `G1 X120 E5`, `G1 Y120 E5`, with `boundingBoxColor` pink. Same camera for both. Images live on the throwaway `pr-481-assets` branch.

| Before | After |
| ------ | ----- |
| ![Before: the bounding box collapses to a flat pink line at X120, the extrusion's starting corner is outside it](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-481-assets/before.png) | ![After: the pink bounding box spans the full L from X20 to X120](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-481-assets/after.png) |

Assisted by Claude Code - Fable 5