### PR TITLE
Stop single-layer mode from showing the layer below

### DIFF
--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -774,7 +774,18 @@ describe('SceneManager properties', () => {
       sceneManager.singleLayerMode = true;
 
       expect(sceneManager.singleLayerMode).toBe(true);
-      expect(sceneManager.startLayer).toBe(1);
+      expect(sceneManager.startLayer).toBe(2);
+    });
+
+    test('singleLayerMode clips away the layer below the end layer', () => {
+      sceneManager.endLayer = 2;
+
+      sceneManager.singleLayerMode = true;
+
+      const layer = sceneManager.job.layers[1];
+      const planes = objectsManager(sceneManager).clippingPlanes;
+      expect(planes).toHaveLength(1);
+      expect(planes[0].constant).toBe(-(layer.z - layer.height));
     });
 
     test('singleLayerMode restores the previous start layer when turned off', () => {
@@ -825,10 +836,14 @@ describe('SceneManager properties', () => {
       fresh.dispose();
     });
 
-    test('endLayer follows the end layer while single layer mode is on', () => {
+    test('startLayer follows the end layer while single layer mode is on', () => {
       sceneManager.singleLayerMode = true;
 
       sceneManager.endLayer = 2;
+
+      expect(sceneManager.startLayer).toBe(2);
+
+      sceneManager.endLayer = 1;
 
       expect(sceneManager.startLayer).toBe(1);
     });

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -519,7 +519,7 @@ export class SceneManager {
     }
 
     if (this._singleLayerMode === true) {
-      this.startLayer = this._endLayer - 1;
+      this.startLayer = this._endLayer;
     }
 
     this.updateClippingPlanes();
@@ -546,7 +546,7 @@ export class SceneManager {
 
     if (this._singleLayerMode) {
       this.prevStartLayer = this._startLayer;
-      this._startLayer = Math.max(this._endLayer - 1, 1);
+      this._startLayer = Math.max(this._endLayer, 1);
     } else {
       this._startLayer = this.prevStartLayer;
     }


### PR DESCRIPTION
Fixes #450

## Problem

`startLayer` is inclusive: the bottom clipping plane sits at the bottom of layer `startLayer`. Single-layer mode collapsed the range to `endLayer - 1`, so the clip band always spanned two layers — the selected one plus the one beneath it. Both entry points had the off-by-one: enabling the mode and changing `endLayer` while the mode is on.

## Fix

Collapse the range onto `endLayer` itself in both setters. Two existing tests encoded the old behavior and were updated; a new one pins the clipping plane to the bottom of the end layer.

## Screenshots

Benchy, single-layer mode at layer 120 of 240:

| Before (layers 119+120 visible) | After (only layer 120) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-482-assets/assets/before.png) | ![after](https://raw.githubusercontent.com/xyz-tools/gcode-preview/pr-482-assets/assets/after.png) |

## Note on the issue's repro branch

The repro branch's fixture repeats `E1` on every extrusion; since #461 a repeated absolute E correctly classifies as travel, so that G-code now parses as one layer and even the control case fails. With cumulative E values (`E1`–`E4`) it reproduces exactly as filed and passes with this fix.

Assisted by Claude Code - Fable 5
