### PR TITLE
Fix stale streams after clearing the preview

### DIFF
--- a/src/__tests__/ingestion-equivalence.ts
+++ b/src/__tests__/ingestion-equivalence.ts
@@ -14,8 +14,8 @@
  * from the fixture line by line) so every mode must independently reproduce
  * them — comparing modes against each other would let a shared bug slip by.
  *
- * Streaming-only behaviors (render throttling, onJobUpdated cadence, …)
- * belong in the gcode-preview.ts tests, not here.
+ * Streaming-only behaviors belong in gcode-preview.ts unless they need this
+ * real-pipeline harness.
  *
  * All helpers live in this file on purpose: the vitest config collects every
  * .ts file under src/__tests__ as a test suite, so a separate helper module
@@ -109,11 +109,11 @@ const MODES: [name: string, ingest: Ingest][] = [
   ['stream chunk=64k', streamIngest(64 * 1024)]
 ];
 
-function createPreview(): GCodePreview {
+function createPreview(keepLines = false): GCodePreview {
   const canvas = document.createElement('canvas');
   Object.defineProperty(canvas, 'offsetWidth', { value: 800, configurable: true });
   Object.defineProperty(canvas, 'offsetHeight', { value: 600, configurable: true });
-  return new GCodePreview({ canvas, buildVolume: { x: 200, y: 200, z: 200 } });
+  return new GCodePreview({ canvas, buildVolume: { x: 200, y: 200, z: 200 }, keepLines });
 }
 
 describe.each(MODES)('ingestion via %s', (_name, ingest) => {
@@ -378,5 +378,59 @@ describe.each(MODES)('ingestion via %s', (_name, ingest) => {
       min: expect.objectContaining({ x: 10, y: 10, z: 1 }),
       max: expect.objectContaining({ x: 30, y: 25, z: 1 })
     });
+  });
+});
+
+describe('stream lifecycle', () => {
+  let preview: GCodePreview;
+
+  beforeEach(() => {
+    preview = createPreview(true);
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    preview.dispose();
+    vi.restoreAllMocks();
+  });
+
+  test('clearing an active stream keeps delayed chunks out of the replacement job', async () => {
+    let controller!: ReadableStreamDefaultController<string>;
+    let cancelled = false;
+    const stream = new ReadableStream<string>({
+      start(value) {
+        controller = value;
+        controller.enqueue('G0 X0 Y0 Z0.2\nG1 X10 E1\n');
+      },
+      cancel() {
+        cancelled = true;
+      }
+    });
+    let firstChunkRead!: () => void;
+    const firstChunk = new Promise<void>((resolve) => {
+      firstChunkRead = resolve;
+    });
+    preview.onJobUpdated = firstChunkRead;
+    const loading = preview.processGCodeStream(stream, { render: false }).catch((error: unknown) => {
+      if (!(error instanceof Error) || error.name !== 'AbortError') throw error;
+    });
+
+    await firstChunk;
+    preview.clear();
+    await preview.processGCodeStream('G0 X0 Y0 Z0.2\nG1 X100 E1', { render: false });
+    const replacement = preview.job;
+    const expectedLines = [...preview.parser.lines];
+    const expectedPaths = replacement.paths.map((path) => [...path.vertices]);
+
+    if (!cancelled) {
+      controller.enqueue('G1 X999 E1\n');
+      controller.close();
+    }
+    await loading;
+
+    expect(preview.job).toBe(replacement);
+    expect(preview.job.state.x).toBe(100);
+    expect(preview.parser.lines).toEqual(expectedLines);
+    expect(preview.job.paths.map((path) => path.vertices)).toEqual(expectedPaths);
   });
 });

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -92,6 +92,7 @@ export class GCodePreview {
   private opts: GCodePreviewOptions | null;
 
   private interpreter: Interpreter;
+  private activeStreamReader?: ReadableStreamDefaultReader;
 
   // dev mode
   /** Developer mode configuration */
@@ -173,6 +174,7 @@ export class GCodePreview {
    * Clears the preview and resets the parser, sceneManager, gui and job
    */
   clear(): void {
+    this.cancelActiveStream();
     this._parser = this.createParser();
     this.job = new Job({ minLayerThreshold: this.opts.minLayerThreshold });
     this.sceneManager.clear();
@@ -229,7 +231,9 @@ export class GCodePreview {
   }
 
   async readStream(stream: ReadableStream, options: { render?: boolean } = {}): Promise<void> {
+    this.cancelActiveStream();
     const reader = stream.getReader();
+    this.activeStreamReader = reader;
     let result;
     let tail = '';
     let size = 0;
@@ -237,6 +241,9 @@ export class GCodePreview {
 
     do {
       result = await reader.read();
+      if (this.activeStreamReader !== reader) {
+        throw new DOMException('Stream cancelled', 'AbortError');
+      }
       const length = result.value?.length ?? 0;
       if (length === 0) {
         // TextDecoderStream can legitimately emit an empty chunk (e.g. one
@@ -284,7 +291,14 @@ export class GCodePreview {
     }
 
     console.debug('total read from stream', Math.floor(size / 1024), 'kB');
+    this.activeStreamReader = undefined;
     this.onStreamEnd?.();
+  }
+
+  private cancelActiveStream(): void {
+    const reader = this.activeStreamReader;
+    this.activeStreamReader = undefined;
+    if (reader) void reader.cancel().catch(console.debug);
   }
 
   /**
@@ -300,6 +314,7 @@ export class GCodePreview {
    * Disposes of all resources and cleans up
    */
   dispose(): void {
+    this.cancelActiveStream();
     this.devGui?.destroy();
     this.devGui = undefined;
 


### PR DESCRIPTION
## Problem

Fixes #448.

Clearing a preview while a `ReadableStream` was paused did not stop that stream. A delayed chunk could therefore be parsed into the replacement job, changing its source lines, state, and geometry.

## Cause

`clear()` replaced the parser and job, while `readStream()` retained only a local reader and accessed the mutable `this.parser` and `this.job` after every await. Nothing connected the reader's lifetime to the preview's lifetime.

## Fix

The preview now owns its active reader. Clearing, disposing, or starting another stream cancels that reader, and a resumed read verifies that it is still current before touching preview state. An invalidated read rejects with `AbortError`, preventing the abandoned operation from reaching its completion/render path.

The regression test uses the real parser, interpreter, job, scene manager, and geometry pipeline. It gates chunk delivery deterministically, loads a replacement job, and verifies that a delayed old chunk cannot change the replacement object's identity, state, source lines, or vertices.

## Behavior changes

| Before | After |
| ------ | ----- |
| An old stream could resume after `clear()` and append to the replacement job. | The active reader is cancelled and stale reads abort before parsing. |
| Disposing or starting a second stream left the previous reader active. | The previous reader is cancelled at the shared lifecycle boundary. |

## Checks

- [x] `npm run check` — 967 tests, typecheck, and lint pass
- [x] `npm run test:coverage` — 100% statements, branches, functions, and lines
- [x] `npm run build`
- [ ] Labelled `bug` + `3.0` (maintainer permission required)

Assisted by OpenAI Codex - GPT-5
