### PR TITLE
Cancel an in-flight stream when clear() replaces the job

### DIFF
--- a/src/__tests__/gcode-preview.ts
+++ b/src/__tests__/gcode-preview.ts
@@ -568,6 +568,54 @@ describe('GCodePreview', () => {
       expect(preview.parser.parseGCode).toHaveBeenLastCalledWith('G1 X10 Y10');
       expect(mockInterpreter.execute).toHaveBeenCalledTimes(2);
     });
+
+    it('cancels the stream when clear() replaces the job mid-stream', async () => {
+      preview = new GCodePreview({ canvas: mockCanvas });
+      const onStreamEnd = vi.fn();
+      preview.onStreamEnd = onStreamEnd;
+
+      let controller!: ReadableStreamDefaultController<string>;
+      let cancelled = false;
+      const stream = new ReadableStream<string>({
+        start(streamController) {
+          controller = streamController;
+          controller.enqueue('G0 X0 Y0\n');
+        },
+        cancel() {
+          cancelled = true;
+        }
+      });
+
+      let firstChunkProcessed!: () => void;
+      const firstChunk = new Promise<void>((resolve) => (firstChunkProcessed = resolve));
+      preview.onJobUpdated = () => firstChunkProcessed();
+
+      const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const reading = preview.readStream(stream);
+      await firstChunk;
+      const oldParseGCode = preview.parser.parseGCode;
+
+      // clear() builds a fresh Job; the shared mock would hand back the same
+      // object, which would hide the identity change the fix relies on
+      vi.mocked(Job).mockImplementationOnce(function () {
+        return { ...mockJob };
+      } as never);
+      preview.clear();
+
+      // simulate a delayed chunk from the old stream arriving after clear()
+      controller.enqueue('G1 X999 E1\n');
+      await reading;
+
+      // only the pre-clear chunk was parsed and executed; the delayed chunk
+      // was dropped and the old reader cancelled without signalling stream end
+      expect(oldParseGCode).toHaveBeenCalledTimes(1);
+      expect(preview.parser.parseGCode).not.toHaveBeenCalled();
+      expect(mockInterpreter.execute).toHaveBeenCalledTimes(1);
+      expect(cancelled).toBe(true);
+      expect(onStreamEnd).not.toHaveBeenCalled();
+
+      consoleDebugSpy.mockRestore();
+    });
   });
 
   describe('initStats method', () => {

--- a/src/gcode-preview.ts
+++ b/src/gcode-preview.ts
@@ -230,6 +230,8 @@ export class GCodePreview {
 
   async readStream(stream: ReadableStream, options: { render?: boolean } = {}): Promise<void> {
     const reader = stream.getReader();
+    // the job this stream feeds; clear() swaps in a replacement
+    const job = this.job;
     let result;
     let tail = '';
     let size = 0;
@@ -237,6 +239,12 @@ export class GCodePreview {
 
     do {
       result = await reader.read();
+      // clear() ran while this chunk was in flight: the stream belongs to the
+      // discarded job, so cancel it rather than corrupt the replacement
+      if (this.job !== job) {
+        await reader.cancel();
+        return;
+      }
       const length = result.value?.length ?? 0;
       if (length === 0) {
         // TextDecoderStream can legitimately emit an empty chunk (e.g. one


### PR DESCRIPTION
Fixes #448.

`readStream()` kept reading after `clear()`: it reaches the parser and job through `this`, so once `clear()` swapped in a replacement job, delayed chunks from the old stream were parsed and folded into the new job — corrupting its state, source lines, and geometry.

The fix captures the job the stream was started for and, after each read, bails out and cancels the reader if `clear()` has replaced it. The delayed chunk is dropped, `onStreamEnd` is not fired for the abandoned stream, and the replacement job is untouched.

Verified against the reproduction test on `codex/p1-stream-clear-repro` (now passing); the regression test joins the existing `readStream` suite.

Assisted by Claude Code - Fable 5