### PR TITLE
Cancel the incremental render loop on dispose

### DIFF
--- a/src/__tests__/scene-manager.ts
+++ b/src/__tests__/scene-manager.ts
@@ -67,6 +67,48 @@ test('cancelAnimation should cancel the render loop', async () => {
   expect(callCountAfterDestroy).toBe(callCountAfterDestroy2);
 });
 
+test('disposing cancels pending incremental render frames', () => {
+  let nextId = 0;
+  const frames = new Map<number, FrameRequestCallback>();
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.set(++nextId, callback);
+    return nextId;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id));
+  try {
+    const proto = SceneManager.prototype as unknown as Record<string, (...args: unknown[]) => unknown>;
+    const mock = createMockSceneManager() as ReturnType<typeof createMockSceneManager> & {
+      job?: { paths: number[] };
+      renderPaths: ReturnType<typeof vi.fn>;
+      renderBoundingBox: ReturnType<typeof vi.fn>;
+      renderFrameLoop: unknown;
+      renderFrame: unknown;
+    };
+    mock.job = { paths: [1, 2, 3, 4] };
+    mock.renderPaths = vi.fn();
+    mock.renderBoundingBox = vi.fn();
+    // the loop under test is private, so borrow it from the prototype like cancelAnimation above
+    mock.renderFrameLoop = proto.renderFrameLoop;
+    mock.renderFrame = proto.renderFrame;
+
+    // the promise never settles once disposal cancels the loop, so don't await it
+    void SceneManager.prototype.renderAnimated.call(mock, 1);
+    expect(frames.size).toBeGreaterThan(0);
+
+    SceneManager.prototype.dispose.call(mock);
+    const callsAtDisposal = mock.renderer.render.mock.calls.length;
+
+    // deliver the frames still queued after disposal, as the browser would
+    for (const [id, callback] of [...frames.entries()]) {
+      frames.delete(id);
+      callback(16);
+    }
+    expect(mock.renderer.render.mock.calls.length).toBe(callsAtDisposal);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});
+
 test('renderProgressive draws the paths parsed so far, holding back the still-growing last one', () => {
   const mock = createMockSceneManager() as ReturnType<typeof createMockSceneManager> & {
     job?: { paths: number[] };

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -123,6 +123,8 @@ export class SceneManager {
   static readonly defaultExtrusionColor = ObjectsManager.defaultExtrusionColor;
   /** Animation frame ID */
   private animationFrameId?: number;
+  /** Frame ID of the incremental render loop, distinct from the continuous one */
+  private frameLoopId?: number;
   /** Previous start layer before single layer mode */
   private prevStartLayer = 0;
   // colors
@@ -718,6 +720,7 @@ export class SceneManager {
    * @remarks
    * The cursor walks the job's combined path list; the ObjectsManager routes
    * each prefix by category and skips what it has already drawn.
+   * dispose() cancels the queued frame, leaving the promise unsettled.
    */
   private renderFrameLoop(pathCount: number): Promise<void> {
     return new Promise((resolve) => {
@@ -729,7 +732,7 @@ export class SceneManager {
         } else {
           drawnUpTo = Math.min(drawnUpTo + pathCount, this.job.paths.length);
           this.renderFrame(drawnUpTo);
-          requestAnimationFrame(loop);
+          this.frameLoopId = requestAnimationFrame(loop);
         }
       };
       loop();
@@ -823,6 +826,8 @@ export class SceneManager {
   private cancelAnimation(): void {
     if (this.animationFrameId !== undefined) cancelAnimationFrame(this.animationFrameId);
     this.animationFrameId = undefined;
+    if (this.frameLoopId !== undefined) cancelAnimationFrame(this.frameLoopId);
+    this.frameLoopId = undefined;
   }
 
   /**


### PR DESCRIPTION
Fixes #452.

`renderFrameLoop()` discarded the id returned by `requestAnimationFrame`, so `dispose()` could only cancel the continuous `animate()` loop — a queued incremental frame survived disposal and kept calling the renderer.

The fix stores the incremental loop's frame id in its own field (`frameLoopId`, separate from `animationFrameId` since both loops run concurrently) and cancels it in `cancelAnimation()`. After disposal the queued frame never fires; the `renderAnimated()` promise is left unsettled, as the reproduction test anticipated.

Verified against the issue's reproduction test on `codex/p2-animated-dispose-repro` (passes with the fix), and the regression test added to the existing scene-manager suite fails without the fix.

Assisted by Claude Code - Fable 5