### PR TITLE
Document the invalid-gcode failure model in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,55 @@ AI-assisted contributions are welcome, but usage of AI tools (Copilot, Claude,
 ChatGPT, etc.) must be disclosed in the PR description. You remain responsible
 for understanding and verifying everything you submit.
 
+## Handling invalid gcode
+
+The closest analogy is a web browser: render as much as possible, keep going when
+something doesn't make sense, and never punish the whole file for one bad line.
+This is a _viewer_, so a partial picture always beats an error message.
+([#361](https://github.com/xyz-tools/gcode-preview/issues/361) is where this was
+settled.)
+
+**Don't crash, don't throw, don't bail.** No input — malformed, truncated,
+corrupted, or not gcode at all — should throw out of the library or leave the
+scene in a broken state. Skip the line you can't make sense of and move on to the
+next one. Real files are almost always slicer output, so a problem is typically a
+handful of lines out of hundreds of thousands; dropping the rest of the model over
+them is the wrong trade.
+
+**Validating gcode is not this library's job.** Don't add checks that exist only to
+tell the user their file is wrong: bounds checks on values the printer would
+happily accept, arity checks on commands we don't implement, rejecting vendor or
+non-standard syntax. Being zealous here breaks legitimate files — Klipper extended
+gcode, vendor macros, slicer directives — for no rendering benefit.
+
+**Unsupported is not invalid.** A command we don't implement is a no-op, not an
+error, and needs no diagnostic. "Invalid" means the shape is wrong where we _do_
+parse: a required argument missing, an extra argument, a value that can't be read
+as a number.
+
+**Set invariants at the parser instead of guarding downstream.** The parser should
+gate garbage at the boundary so the rest of the code doesn't need ad hoc defenses.
+The standing rule: **a parameter is either a finite number or absent** — no `NaN`
+ever leaves the parser. A letter with no number of its own isn't a word; it's glued
+to the value before it and is dropped with the rest of that token.
+
+```js
+new Parser().parseCommand('G1 X123abc Y20').params; // { x: 123, y: 20 }
+new Parser().parseCommand('M117 Hi').params; // {}
+```
+
+`X123abc` still yields `x: 123` — the same prefix Marlin's `strtod` reads — so
+nothing the firmware would act on is thrown away. An `isNaN` or null guard
+appearing in `state`, `Path` or `BoundingBox` is a sign the invariant is leaking
+and the fix belongs upstream.
+
+**Dropping junk is silent, for now.** There is no diagnostics channel on the parse
+result today, and adding one is a separate design decision — don't introduce a
+one-off warning, callback or `console.log` alongside a fix.
+
+Changes in this area want a test that feeds the malformed snippet through the
+pipeline and asserts what _did_ render, not just that nothing threw.
+
 ## Review standards
 
 Every change, **intended or not**, must be:


### PR DESCRIPTION
Closes #361.

We reached consensus in #361 on how the library should behave on invalid gcode, but the outcome only lived in the issue thread. That leaves every future parser/interpreter PR to re-derive the policy from scratch, or worse, to guess — which is exactly how a well-meaning "let's validate this" change ends up breaking Klipper macros for someone. Writing it into CONTRIBUTING gives reviewers a rule to point at instead of an opinion to argue.

The section states the browser analogy (render what you can, skip what you can't), the rule that validation isn't this library's responsibility, the distinction between *unsupported* (a no-op) and *invalid* (wrong shape where we do parse), and the parser invariant — a parameter is either a finite number or absent, so no `NaN` escapes into `state`, `Path` or `BoundingBox`.

The invariant is documented as it actually behaves today, not aspirationally: `src/parser/gcode-parser.ts:360` already drops non-finite params, and the single-pass word walker splits `X123abc` such that `G1 X123abc Y20` yields `{ x: 123, y: 20 }`. Both examples in the code block were checked against the current implementation.

Left deliberately open: whether the parse result should carry diagnostics (question 2 in the issue). The section says dropping junk is silent *for now* and asks contributors not to sneak in a one-off warning or `console.log` ahead of that decision.

Docs only — no source or test changes.

---

*Assisted by Claude Code - Opus 5*
