### PR TITLE
Declare three.js as a peer dependency

### DIFF
--- a/.agents/bump-three-version/SKILL.md
+++ b/.agents/bump-three-version/SKILL.md
@@ -63,18 +63,24 @@ grep -rn "0\.1[0-9][0-9]" --include="*.json" --include="*.yml" --include="*.ts" 
 
 Files that need updating (as of this writing):
 
-1. **`package.json`** — the supported range in `dependencies`:
+1. **`package.json`** — the supported range in `peerDependencies`:
    ```json
    "three": ">=0.166.0 <0.186.0"
    ```
    Raise the upper bound so the new version is included. The bound is
    **exclusive**, so for new version `0.186.x` set it to `<0.187.0`.
 
-2. **`package.json`** — the `@types/three` devDependency:
+   `three` is a **peer** dependency, not a regular one, so that consumers keep a
+   single copy of it. Don't move it back into `dependencies`; the guard tests in
+   `src/__tests__/three-version.ts` will fail if you do.
+
+2. **`package.json`** — the `three` and `@types/three` devDependencies:
    ```json
+   "three": "^0.185.1",
    "@types/three": "^0.185.4"
    ```
-   Bump to the `@types/three` release that matches the new `three` version.
+   A peer dependency is not installed for local development, so `three` is also
+   a devDependency; bump both to the new release.
 
 3. **`.github/workflows/run-tests.yml`** — the test matrix under
    `strategy.matrix.include`. Add a new entry pairing the new `three-version`

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Click to see the [full-fledged demo](https://gcode-preview.web.app/):
 
 ## Installation
 
-`npm install gcode-preview`
+`npm install gcode-preview three`
 
-GCode Preview depends on [three.js](https://threejs.org/) and supports `three` `>=0.166.0 <0.186.0`.
+[three.js](https://threejs.org/) is a peer dependency; GCode Preview supports `three` `>=0.166.0 <0.186.0`. npm 7 and later install it for you, but naming it in your own `package.json` keeps your app and the library on the same copy of three. That matters: two copies of three in one bundle are two different sets of classes, so `instanceof` checks fail across the boundary and helpers like `STLExporter` reject objects from the other copy.
 
 ### Quick start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
-        "lil-gui": "^0.20.0",
-        "three": ">=0.166.0 <0.186.0"
+        "lil-gui": "^0.20.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",
@@ -29,8 +28,12 @@
         "rollup": "^4.44.2",
         "rollup-plugin-dts": "^6.2.1",
         "rollup-plugin-esbuild": "^6.2.1",
+        "three": "^0.185.1",
         "typedoc": "^0.28.7",
         "vitest": "^4.1.0"
+      },
+      "peerDependencies": {
+        "three": ">=0.166.0 <0.186.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6778,6 +6781,7 @@
       "version": "0.185.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rollup": "^4.44.2",
     "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-esbuild": "^6.2.1",
+    "three": "^0.185.1",
     "typedoc": "^0.28.7",
     "vitest": "^4.1.0"
   },
@@ -65,7 +66,9 @@
     "evals:grade": "node --no-warnings --experimental-strip-types evals/grade.ts"
   },
   "dependencies": {
-    "lil-gui": "^0.20.0",
+    "lil-gui": "^0.20.0"
+  },
+  "peerDependencies": {
     "three": ">=0.166.0 <0.186.0"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,7 +22,9 @@ const config = [
         }
       }
     ],
-    external: [...Object.keys(pkg.dependencies || {})],
+    // peer dependencies are externals too: bundling three would ship a second
+    // copy of it to every consumer that already has its own
+    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
     plugins: [
       nodeResolve(),
       esbuild({

--- a/src/__tests__/three-version.ts
+++ b/src/__tests__/three-version.ts
@@ -18,8 +18,28 @@ function parseVersion(version: string): number {
 const minMinor = Number(MIN_VERSION.split('.')[1]);
 const maxMinorExclusive = Number(MAX_EXCLUSIVE_VERSION.split('.')[1]);
 
-test('three.js dependency is declared as the supported range', () => {
-  expect(pkg.dependencies.three).toBe(SUPPORTED_RANGE);
+test('three.js is declared as a peer dependency with the supported range', () => {
+  expect(pkg.peerDependencies.three).toBe(SUPPORTED_RANGE);
+});
+
+test('three.js is not also a regular dependency', () => {
+  // shipping three as a regular dependency lets a consumer end up with a
+  // second copy of it, and two copies are two different sets of classes:
+  // instanceof fails across the boundary and helpers like STLExporter reject
+  // objects built by the other copy
+  expect((pkg.dependencies as Record<string, string>).three).toBeUndefined();
+});
+
+test('rollup treats every peer dependency as external', async () => {
+  // the bundle must import three rather than inline it -- otherwise moving it
+  // to peerDependencies achieves nothing, because every consumer still gets
+  // the library's own copy baked into the dist
+  const { default: config } = await import('../../rollup.config.mjs');
+  const external = (config as { external?: string[] }[])[0].external ?? [];
+
+  for (const name of Object.keys(pkg.peerDependencies)) {
+    expect(external).toContain(name);
+  }
 });
 
 test('installed three.js version is within the supported range', () => {


### PR DESCRIPTION
`three` was a regular dependency, so a consumer that also depends on `three` could end up with two copies of it. Two copies are two different sets of classes: `instanceof` fails across the boundary and helpers like `STLExporter` reject objects built by the other copy. `gcode-preview-examples` hit exactly this and needed a version bump to force npm to dedupe.

### The part that isn't just moving a line

`rollup.config.mjs` derived its externals from `pkg.dependencies`. Moving `three` out without touching that would have made rollup **inline three into the bundle** — `dist/gcode-preview.es.js` goes 162,651 → 698,608 bytes and the `from"three"` import disappears — so every consumer would get the library's own copy anyway, which is worse than before. Externals now cover `peerDependencies` too, and with that in place the built dist is byte-identical to before this PR.

Because that failure is silent at build time, `src/__tests__/three-version.ts` now guards it: `three` must be a peer dep, must not also be a regular dep, and every peer dep must appear in rollup's externals.

### Verified

Packed the tarball and installed it into a scratch consumer:

- consumer with `three@0.171.0` → one copy, `three@0.171.0 deduped`, consumer's version wins
- consumer with out-of-range `three@0.160.0` → install fails with `ERESOLVE ... peer three@">=0.166.0 <0.186.0"`, instead of silently adding a second copy

`build`, `test:coverage` (976 tests, 100% gate), `typeCheck` and `lint` all pass. `README.md` install instructions and the `bump-three-version` skill are updated to match.

Assisted by Claude Code - Opus 5