### PR TITLE
Make smallGrid optional again, defaulting to false

### DIFF
--- a/src/__tests__/build-volume.ts
+++ b/src/__tests__/build-volume.ts
@@ -1,5 +1,5 @@
 import { test, describe, expect, vi } from 'vitest';
-import { BuildVolume } from '../build-volume';
+import { BuildVolume, type BuildVolumeDef } from '../build-volume';
 import { AxesHelper, Color, Object3D, Scene } from 'three';
 import { Grid } from '../helpers/grid';
 import { LineBox } from '../helpers/line-box';
@@ -306,6 +306,43 @@ describe('BuildVolume', () => {
       const scene = new Scene();
       const sceneAddSpy = vi.spyOn(scene, 'add');
       const buildVolume = new BuildVolume(10, 20, 30, false, scene);
+
+      buildVolume.smallGrid = false;
+
+      expect(sceneAddSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test('an omitted value defaults to false rather than undefined', () => {
+      const buildVolume = new BuildVolume(10, 20, 30, undefined, mockScene);
+
+      expect(buildVolume.smallGrid).toBe(false);
+    });
+
+    // BuildVolumeDef is spelled out by hand rather than derived from this class,
+    // so this pins the two against drifting apart: a def has to remain something
+    // the constructor accepts.
+    test('a BuildVolumeDef without smallGrid can construct a BuildVolume', () => {
+      const def: BuildVolumeDef = { x: 10, y: 20, z: 30 };
+
+      const buildVolume = new BuildVolume(def.x, def.y, def.z, def.smallGrid, mockScene);
+
+      expect([buildVolume.x, buildVolume.y, buildVolume.z]).toEqual([10, 20, 30]);
+      expect(buildVolume.smallGrid).toBe(false);
+    });
+
+    test('setting it back to undefined reads as false', () => {
+      const scene = new Scene();
+      const buildVolume = new BuildVolume(10, 20, 30, true, scene);
+
+      buildVolume.smallGrid = undefined;
+
+      expect(buildVolume.smallGrid).toBe(false);
+    });
+
+    test('going from undefined to false does not trigger an update', () => {
+      const scene = new Scene();
+      const sceneAddSpy = vi.spyOn(scene, 'add');
+      const buildVolume = new BuildVolume(10, 20, 30, undefined, scene);
 
       buildVolume.smallGrid = false;
 

--- a/src/build-volume.ts
+++ b/src/build-volume.ts
@@ -7,7 +7,16 @@ import { type Disposable } from './helpers/three-utils';
  * The dimensions a caller supplies to describe a build volume
  * @interface
  */
-export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
+export type BuildVolumeDef = {
+  /** Width of the build volume in mm */
+  x: number;
+  /** Depth of the build volume in mm */
+  y: number;
+  /** Height of the build volume in mm */
+  z: number;
+  /** Whether the finer secondary grid is drawn on the build plate. Defaults to `false`. */
+  smallGrid?: boolean;
+};
 
 /**
  * Represents the build volume of a 3D printer.
@@ -20,7 +29,7 @@ export class BuildVolume {
   /** Height of the build volume in mm */
   private _z: number;
   /** Whether the finer secondary grid is drawn */
-  private _smallGrid: boolean | undefined;
+  private _smallGrid = false;
   /** Color used for the grid */
   private gridColor: Color = new Color(0x888888); // Default grid color
   private smallGridColor: Color = new Color(0x444444); // Default small grid color
@@ -33,7 +42,7 @@ export class BuildVolume {
    * @param x - Width in mm
    * @param y - Depth in mm
    * @param z - Height in mm
-   * @param smallGrid - Whether to show a small grid
+   * @param smallGrid - Whether to show a small grid; `undefined` keeps the default
    * @param scene - The Three.js scene to add the build volume to
    */
   constructor(
@@ -47,7 +56,9 @@ export class BuildVolume {
     this._x = Math.max(0, x);
     this._y = Math.max(0, y);
     this._z = Math.max(0, z);
-    this._smallGrid = smallGrid;
+    if (smallGrid !== undefined) {
+      this._smallGrid = smallGrid;
+    }
   }
 
   /** Width of the build volume in mm */
@@ -84,12 +95,13 @@ export class BuildVolume {
     this.update(); // Update the build volume when z changes
   }
   /** Whether the finer secondary grid is drawn on the build plate */
-  get smallGrid(): boolean | undefined {
+  get smallGrid(): boolean {
     return this._smallGrid;
   }
   set smallGrid(value: boolean | undefined) {
-    if (this._smallGrid !== value) {
-      this._smallGrid = value;
+    const next = value ?? false;
+    if (this._smallGrid !== next) {
+      this._smallGrid = next;
       this.update(); // Update the build volume when smallGrid changes
     }
   }


### PR DESCRIPTION
`buildVolume` could not be given without `smallGrid` in TypeScript:

```ts
new GCodePreview({ canvas, buildVolume: { x: 250, y: 220, z: 150 } });
// TS2741: Property 'smallGrid' is missing in type '{ x: number; y: number; z: number; }'
```

That's the exact shape the [README](https://github.com/xyz-tools/gcode-preview/blob/develop/README.md) and the `GCodePreview` JSDoc example use, so the documented call didn't compile for TS consumers. It surfaced while migrating the React demo, which passes a build volume.

### Where it came from

Not intentional. [#297](https://github.com/xyz-tools/gcode-preview/pull/297) ("Scene/build volume refactor", commit `6a3ac93`) replaced `buildVolume?: BuildVolume` with:

```ts
export type BuildVolumeDef = Pick<BuildVolume, 'x' | 'y' | 'z' | 'smallGrid'>;
```

`Pick` preserves a key's required-ness, and does so even when the value type is `boolean | undefined` — so `smallGrid` silently became mandatory. The intent was clearly the opposite: the setter's own JSDoc in that same PR calls the argument "Partial build volume properties", and the runtime has always accepted `undefined` and treated it as falsy. Only the type was wrong.

### This change

The `Pick` is dropped rather than worked around. `BuildVolumeDef` is now a plain object literal:

```ts
export type BuildVolumeDef = {
  /** Width of the build volume in mm */
  x: number;
  /** Depth of the build volume in mm */
  y: number;
  /** Height of the build volume in mm */
  z: number;
  /** Whether the finer secondary grid is drawn on the build plate. Defaults to `false`. */
  smallGrid?: boolean;
};
```

Three reasons this beats a cleverer type expression:

- It was the only `Pick<>`-derived type in `src/`. `SceneManagerOptions` and `DevModeOptions` are both plain object literals, so this now matches the house style.
- **It restores the docs.** TypeDoc can't see through a `Pick` expansion (noted in #467), so these properties rendered with no descriptions at all. The emitted `.d.ts` now carries a comment per field, which is what shows up on hover in a consumer's editor.
- Deriving four primitive fields from the class bought very little, and cost exactly the bug this PR is fixing.

The default now lives on the field declaration (`private _smallGrid = false`), so `false` is written once and the constructor only assigns when a value was actually passed. The getter narrows to `boolean`; the setter still accepts `undefined` and normalizes it. JavaScript callers are unaffected — this was only ever a type-level error.

Three runtime tests cover the default, reset-to-`undefined`, and that `undefined → false` doesn't fire a redundant scene update, plus one that constructs a `BuildVolume` from a `BuildVolumeDef` with no `smallGrid`.

No new type pin was needed: the existing assertions in `public-api.test-d.ts` (lines 104 and 202) already fail if the `Pick` comes back — verified by reintroducing it.

`build`, `test:coverage` (978 tests, 100% gate), `typeCheck` and `lint` all pass.

Assisted by Claude Code - Opus 5