### PR TITLE
Fix thumbnail data URL MIME type detection

### DIFF
--- a/src/__tests__/parse-thumbnail.ts
+++ b/src/__tests__/parse-thumbnail.ts
@@ -41,10 +41,23 @@ test('not matching size should be invalid', () => {
   expect(thumb.isValid).toBeFalsy();
 });
 
-test('src should be a jpeg data URL of the base64 chars', () => {
+test('src should be a PNG data URL of the base64 chars', () => {
   const thumb = new Thumbnail('16x16', 16, 16, encodedImg.length);
   thumb.chars = encodedImg;
-  expect(thumb.src).toEqual('data:image/jpeg;base64,' + encodedImg);
+  expect(thumb.src).toEqual('data:image/png;base64,' + encodedImg);
+});
+
+test.each([
+  ['JPEG', '/9j/4AAQ', 'image/jpeg'],
+  ['QOI', 'cW9pZgAAAAEAAAABBAAA/wAA/wAAAAAAAAAB', 'image/qoi'],
+  ['unknown format', 'R0lGODlh', 'image/jpeg'],
+  ['empty payload', '', 'image/jpeg'],
+  ['short payload', 'iVA=', 'image/jpeg'],
+  ['malformed base64', '!!!!!!!!', 'image/jpeg']
+])('src should use the expected MIME type for %s', (_, chars, mimeType) => {
+  const thumb = new Thumbnail('1x1', 1, 1, chars.length);
+  thumb.chars = chars;
+  expect(thumb.src).toEqual(`data:${mimeType};base64,${chars}`);
 });
 
 test('well-formatted thumbnail should be parsed', () => {
@@ -55,6 +68,7 @@ test('well-formatted thumbnail should be parsed', () => {
   expect(parsed.metadata).not.toBeNull();
   expect(parsed.metadata.thumbnails).not.toBeNull();
   expect(Object.keys(parsed.metadata.thumbnails).length).toEqual(1);
+  expect(parsed.metadata.thumbnails['16x16'].src).toEqual('data:image/png;base64,' + encodedImg);
 });
 
 test('no thumbnail should be parsed if none present', () => {

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -1,5 +1,3 @@
-const prefix = 'data:image/jpeg;base64,';
-
 /**
  * Represents a thumbnail image extracted from G-code
  */
@@ -38,7 +36,21 @@ export class Thumbnail {
    * @returns Data URL for the thumbnail image
    */
   get src(): string {
-    return prefix + this.chars;
+    let mimeType = 'image/jpeg';
+    try {
+      // Decode only the header needed to identify the image format.
+      const header = atob(this.chars.slice(0, 8));
+      if (header.startsWith('\x89PNG')) {
+        mimeType = 'image/png';
+      } else if (header.startsWith('\xff\xd8\xff')) {
+        mimeType = 'image/jpeg';
+      } else if (header.startsWith('qoif')) {
+        mimeType = 'image/qoi';
+      }
+    } catch {
+      // Preserve the legacy JPEG fallback for malformed base64.
+    }
+    return `data:${mimeType};base64,${this.chars}`;
   }
 
   /**


### PR DESCRIPTION
## Problem

PNG thumbnails such as those embedded in `demo/gcodes/screw.gcode` declare `image/jpeg` in their data URLs, giving consumers the wrong content type. Fixes #504.

## Cause

`Thumbnail.src` hardcodes the JPEG prefix regardless of the embedded image format. Browsers can sniff the payload, masking the mismatch.

## Fix

Decode only the leading base64 characters and identify PNG, JPEG, or QOI from their magic bytes. Keep the existing JPEG fallback for unknown or malformed data so accessing `src` remains tolerant of incomplete input.

## Behavior changes

PNG and QOI payloads now declare `image/png` and `image/qoi`; JPEG retains `image/jpeg`. The payload and getter signature remain unchanged.

## Checks

- [x] `npm run test:coverage`: 984 tests pass; 100% statement, branch, function, and line coverage.
- [x] `npm run typeCheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Regression coverage for PNG parsing, JPEG, QOI, unknown, empty, short, and malformed payloads.
- [x] Labelled `bug` and `parser`.

Assisted by Codex - GPT-6
