### PR TITLE
Enable tube rendering by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Supported systems include:
  - and possibly more
 
 ### Render extrusion as tubes
-Extrusions are rendered as flat lines by default; pass the `renderTubes`
-constructor option to get true tube geometry (it can also be toggled at runtime
+Extrusions are rendered as tubes by default; pass `renderTubes: false` as a
+constructor option to render flat lines (it can also be toggled at runtime
 via `preview.sceneManager.renderTubes`):
 ```js
-new GCodePreview({ canvas, renderTubes: true });
+new GCodePreview({ canvas, renderTubes: false });
 ```
 
 ### G2/G3 arc support

--- a/src/__tests__/objects-manager.ts
+++ b/src/__tests__/objects-manager.ts
@@ -14,6 +14,7 @@ describe('ObjectsManager', () => {
   beforeEach(() => {
     scene = new Scene();
     objectsManager = new ObjectsManager(scene, 0.4, 0.2, 0.6);
+    objectsManager.renderTubes = false;
   });
 
   describe('constructor', () => {
@@ -899,7 +900,7 @@ describe('ObjectsManager', () => {
       ['setLineHeight', () => manager.setLineHeight(0.5)],
       ['setLineHeight back to per-path', () => manager.setLineHeight(undefined)],
       ['setExtrusionWidth', () => manager.setExtrusionWidth(1.2)],
-      ['setRenderTubes', () => manager.setRenderTubes(true)]
+      ['setRenderTubes', () => manager.setRenderTubes(false)]
     ])('%s asks for a rebuild', (_name, change) => {
       change();
       vi.advanceTimersByTime(ObjectsManager.rebuildDebounce);
@@ -920,7 +921,7 @@ describe('ObjectsManager', () => {
       ['setLineWidth', () => manager.setLineWidth(0.4)],
       ['setLineHeight', () => manager.setLineHeight(0.2)],
       ['setExtrusionWidth', () => manager.setExtrusionWidth(0.6)],
-      ['setRenderTubes', () => manager.setRenderTubes(false)]
+      ['setRenderTubes', () => manager.setRenderTubes(true)]
     ])('%s does not rebuild when the value is unchanged', (_name, change) => {
       change();
       vi.advanceTimersByTime(ObjectsManager.rebuildDebounce);

--- a/src/__tests__/renderer-smoke.ts
+++ b/src/__tests__/renderer-smoke.ts
@@ -69,7 +69,7 @@ describe('SceneManager runtime smoke test', () => {
   });
 
   it('constructs real three.js objects when rendering lines', async () => {
-    const preview = createPreview({ renderExtrusion: true, renderTravel: true });
+    const preview = createPreview({ renderExtrusion: true, renderTravel: true, renderTubes: false });
     preview.processGCode(SAMPLE_GCODE);
     await nextFrame();
 
@@ -90,8 +90,8 @@ describe('SceneManager runtime smoke test', () => {
     expect(mockRenderers[0].dispose).toHaveBeenCalled();
   });
 
-  it('constructs a real BatchedMesh when rendering tubes', async () => {
-    const preview = createPreview({ renderExtrusion: true, renderTravel: false, renderTubes: true });
+  it('constructs a real BatchedMesh by default', async () => {
+    const preview = createPreview({ renderExtrusion: true, renderTravel: false });
     preview.processGCode(SAMPLE_GCODE);
     await nextFrame();
 

--- a/src/__tests__/scene-manager-properties.ts
+++ b/src/__tests__/scene-manager-properties.ts
@@ -1464,6 +1464,7 @@ function createSceneManager(opts: Partial<SceneManagerOptions> & { job?: Job } =
       buildVolume: { x: 200, y: 200, z: 200, smallGrid: true },
       renderExtrusion: true,
       renderTravel: false,
+      renderTubes: false,
       ...sceneOptions
     },
     job ?? createJob()

--- a/src/objects-manager.ts
+++ b/src/objects-manager.ts
@@ -67,7 +67,7 @@ export class ObjectsManager {
    * is unset too.
    */
   extrusionWidth?: number;
-  renderTubes = false;
+  renderTubes = true;
 
   /**
    * Whether extrusion lines get a per-layer brightness gradient baked into their vertex colors.


### PR DESCRIPTION
Extrusions now render as tubes when `renderTubes` is omitted. Callers can still select flat lines with `renderTubes: false`.

Updated the README and existing tests to cover the new default and explicit line mode.

Validation: 978 tests pass with 100% coverage, build, type checking, and lint pass. Tests ran with `NODE_OPTIONS=--no-experimental-webstorage` for the local Node 26 environment.
