### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,8 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - develop
+permissions:
+  contents: read
 jobs:
   build_and_deploy:
 


### PR DESCRIPTION
Potential fix for [https://github.com/xyz-tools/gcode-preview/security/code-scanning/1](https://github.com/xyz-tools/gcode-preview/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best single fix (without changing functionality): set workflow-level permissions to the minimal baseline CodeQL recommends:

- `contents: read`

This addresses the finding directly and preserves existing job logic.  
Edit only `.github/workflows/firebase-hosting-merge.yml`, inserting the `permissions` block at the root level (after the trigger section and before `jobs:` is a clean location).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
